### PR TITLE
Update release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,12 +126,16 @@ jobs:
           path: _packages/${{ matrix.artifact_name }}
 
   publish:
+    if: github.repository_owner == 'Effect-Ts'
+    name: Release
     runs-on: ubuntu-latest
     needs: [build]
     timeout-minutes: 30
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
       id-token: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- restrict the publish job to the Effect-Ts org so forks do not attempt release publishing
- grant the publish job the write permissions it needs for release contents, pull requests, and packages
- rename the publish job to `Release` for clearer workflow output