### PR TITLE
Centralize setup constants

### DIFF
--- a/_packages/tsgo/src/setup/assessment.ts
+++ b/_packages/tsgo/src/setup/assessment.ts
@@ -6,10 +6,7 @@ import type * as PlatformError from "effect/PlatformError"
 import * as ts from "typescript"
 import { FileReadError, PackageJsonNotFoundError } from "./errors.js"
 import type { Assessment, FileInput } from "./types.js"
-
-const LSP_PACKAGE_NAME = "@effect/tsgo"
-const LSP_PLUGIN_NAME = "@effect/language-service"
-const PATCH_COMMAND = "effect-tsgo"
+import { LSP_PACKAGE_NAME, LSP_PLUGIN_NAME, PATCH_COMMAND } from "./consts.js"
 
 /**
  * Read files from file system and create assessment input

--- a/_packages/tsgo/src/setup/changes.ts
+++ b/_packages/tsgo/src/setup/changes.ts
@@ -1,10 +1,7 @@
 import * as Option from "effect/Option"
 import * as ts from "typescript"
 import type { Assessment, Target } from "./types.js"
-
-const LSP_PACKAGE_NAME = "@effect/tsgo"
-const LSP_PLUGIN_NAME = "@effect/language-service"
-const PATCH_COMMAND = "effect-tsgo patch"
+import { LSP_PACKAGE_NAME, LSP_PLUGIN_NAME, PATCH_COMMAND } from "./consts.js"
 
 interface ComputeFileChangesResult {
   readonly codeActions: ReadonlyArray<ts.CodeAction>

--- a/_packages/tsgo/src/setup/consts.ts
+++ b/_packages/tsgo/src/setup/consts.ts
@@ -1,0 +1,6 @@
+import * as pkgJson from "../../package.json"
+
+export const LSP_PACKAGE_NAME = pkgJson.name
+export const LSP_PLUGIN_NAME = "@effect/language-service"
+export const PATCH_COMMAND = "effect-tsgo patch"
+export const DEFAULT_LSP_VERSION = pkgJson.version

--- a/_packages/tsgo/src/setup/index.ts
+++ b/_packages/tsgo/src/setup/index.ts
@@ -10,8 +10,7 @@ import { computeChanges } from "./changes.js"
 import { renderCodeActions } from "./diff-renderer.js"
 import { gatherTargetState } from "./target-prompt.js"
 import { selectTsConfigFile } from "./tsconfig-prompt.js"
-
-const DEFAULT_LSP_VERSION = "^0.0.0"
+import { DEFAULT_LSP_VERSION } from "./consts.js"
 
 export const setupCommand = Command.make("setup").pipe(
   Command.withDescription("Setup @effect/tsgo for the given project using an interactive CLI."),


### PR DESCRIPTION
## Summary
- move setup package, plugin, and patch command literals into a shared constants module
- derive the default LSP version from package metadata so setup stays aligned with the published package version
- update setup assessment and change generation to reuse the centralized constants