### PR TITLE
Invalidate stale tsbuildinfo on Effect plugin version change

### DIFF
--- a/_patches/021-core-version-suffix.patch
+++ b/_patches/021-core-version-suffix.patch
@@ -1,0 +1,25 @@
+diff --git a/internal/core/version.go b/internal/core/version.go
+index 9e04cb52c..e3c0ab7b3 100644
+--- a/internal/core/version.go
++++ b/internal/core/version.go
+@@ -8,9 +8,20 @@ import (
+ var version = "7.0.0-dev"
+
+ func Version() string {
++	if versionSuffix != "" {
++		return version + "+" + versionSuffix
++	}
+ 	return version
+ }
+
++var versionSuffix string
++
++// SetVersionSuffix appends a suffix to the version string (e.g. "effect.2").
++// This invalidates tsbuildinfo files produced by builds with a different suffix.
++func SetVersionSuffix(suffix string) {
++	versionSuffix = suffix
++}
++
+ var versionMajorMinor = func() string {
+ 	seenMajor := false
+ 	i := strings.IndexFunc(version, func(r rune) bool {

--- a/etscheckerhooks/init.go
+++ b/etscheckerhooks/init.go
@@ -17,6 +17,8 @@ import (
 
 // init registers the Effect diagnostics callbacks with TypeScript-Go.
 func init() {
+	// Set version suffix to invalidate tsbuildinfo when plugin diagnostics change
+	core.SetVersionSuffix(etscore.EffectPluginVersion)
 	// Register the after check source file callback
 	checker.RegisterAfterCheckSourceFileCallback(afterCheckSourceFile)
 }

--- a/etscore/consts.go
+++ b/etscore/consts.go
@@ -3,3 +3,7 @@ package etscore
 // EffectPluginName is the name of the Effect language service plugin.
 // This is used to identify the plugin in the tsconfig.json plugins array.
 const EffectPluginName = "@effect/language-service"
+
+// EffectPluginVersion is appended to the TypeScript version in tsbuildinfo files.
+// Bump this whenever diagnostic behavior changes to invalidate stale incremental state.
+const EffectPluginVersion = "effect.1"

--- a/shim/core/shim.go
+++ b/shim/core/shim.go
@@ -135,6 +135,8 @@ const ScriptTargetJSON = core.ScriptTargetJSON
 const ScriptTargetLatest = core.ScriptTargetLatest
 const ScriptTargetLatestStandard = core.ScriptTargetLatestStandard
 const ScriptTargetNone = core.ScriptTargetNone
+//go:linkname SetVersionSuffix github.com/microsoft/typescript-go/internal/core.SetVersionSuffix
+func SetVersionSuffix(suffix string)
 //go:linkname ShouldRewriteModuleSpecifier github.com/microsoft/typescript-go/internal/core.ShouldRewriteModuleSpecifier
 func ShouldRewriteModuleSpecifier(specifier string, compilerOptions *core.CompilerOptions) bool
 type Stack[T any] = core.Stack[T]


### PR DESCRIPTION
## Summary

- Append an Effect plugin version suffix (`+effect.1`) to the TypeScript version stored in tsbuildinfo files
- When the suffix changes (after diagnostic behavior fixes), old incremental state is automatically discarded
- Users no longer need `--force` to clear stale diagnostics after upgrading

## How it works

TypeScript-Go validates tsbuildinfo files by comparing `buildInfo.Version == core.Version()`. By appending an Effect-specific suffix to the version string, any change to the Effect plugin's diagnostic behavior (tracked by bumping `EffectPluginVersion` in `etscore/consts.go`) causes the version check to fail, forcing a clean rebuild.

**Before:** `Version 7.0.0-dev`
**After:** `Version 7.0.0-dev+effect.1`

## Changes

- `_patches/021-core-version-suffix.patch` — adds `SetVersionSuffix()` to `core/version.go`
- `etscore/consts.go` — defines `EffectPluginVersion` constant (bump when diagnostics change)
- `etscheckerhooks/init.go` — calls `SetVersionSuffix` during init
- `shim/core/shim.go` — regenerated to expose `SetVersionSuffix`

Closes #14

## Test plan

- [x] `go build ./...` passes
- [x] `tsgo --version` outputs `Version 7.0.0-dev+effect.1`
- [ ] Verify with reproduction repo that stale diagnostics are cleared without `--force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)