### PR TITLE
Fix Nix vendor hash drift and nil pointer dereference

### DIFF
--- a/_tools/update-flake-vendor-hash.sh
+++ b/_tools/update-flake-vendor-hash.sh
@@ -42,19 +42,24 @@ update_input_commit() {
   local suffix="${4:-}"
 
   local current
-  current="$(perl -ne "
-    if (/\"github:${repo_url}\\/([a-f0-9]+)${suffix}\"/) {
-      print \"\$1\\n\";
+  current="$(REPO_URL="$repo_url" SUFFIX="$suffix" perl -ne '
+    my $pat = quotemeta("github:$ENV{REPO_URL}/");
+    my $suf = quotemeta($ENV{SUFFIX});
+    if (m{${pat}([a-f0-9]+)${suf}}) {
+      print "$1\n";
       exit 0;
     }
-  " "$flake_file")"
+  ' "$flake_file")"
 
   if [[ "$current" == "$new_commit" ]]; then
     echo "$input_name: already at $new_commit"
   else
-    local escaped_suffix
-    escaped_suffix="$(printf '%s' "$suffix" | sed 's/[?]/\\?/g')"
-    perl -pi -e "s|github:${repo_url}/[a-f0-9]+${escaped_suffix}|github:${repo_url}/${new_commit}${suffix}|" "$flake_file"
+    REPO_URL="$repo_url" OLD_COMMIT="$current" NEW_COMMIT="$new_commit" SUFFIX="$suffix" \
+      perl -pi -e '
+        my $old = quotemeta("github:$ENV{REPO_URL}/$ENV{OLD_COMMIT}$ENV{SUFFIX}");
+        my $new = "github:$ENV{REPO_URL}/$ENV{NEW_COMMIT}$ENV{SUFFIX}";
+        s/$old/$new/;
+      ' "$flake_file"
     echo "$input_name: updated ${current:-unknown} -> $new_commit"
   fi
 }

--- a/flake.nix
+++ b/flake.nix
@@ -36,19 +36,15 @@
       ];
       /*
        Go module vendor hash for buildGoModule (proxyVendor mode).
-       Uses `go mod download` under the hood — the download cache uses `!`
-       escaping for uppercase letters in module paths, making it deterministic
-       across case-sensitive (Linux) and case-insensitive (macOS APFS)
-       filesystems.
+       proxyVendor is required because this project has deps with
+       mixed-case module paths (Microsoft/go-winio vs microsoft/
+       typescript-go) — `go work vendor` produces different directory
+       layouts on case-sensitive (Linux) vs case-insensitive (macOS)
+       filesystems. The download cache uses `!` escaping for uppercase
+       letters, making it deterministic across both.
 
-       Refresh workflow:
-       1. Run `./_tools/update-flake-vendor-hash.sh`.
-       2. Commit the resulting `flake.nix` update if the script changed it.
-
-       Manual fallback:
-       1. Temporarily set this value to `lib.fakeHash`.
-       2. Run `nix build .#effect-tsgo --no-write-lock-file`.
-       3. Copy the reported `got: sha256-...` value back here.
+       Refresh: ./_tools/update-flake-vendor-hash.sh
+       Manual:  set to lib.fakeHash, build, copy the reported hash.
       */
       vendorHash = "sha256-15dQYcuOPxrnIXWV8UVVSqDqMyRJJmQqVEF7o3wgxz4=";
       forAllSystems =

--- a/internal/typeparser/effect_type.go
+++ b/internal/typeparser/effect_type.go
@@ -13,6 +13,9 @@ import (
 // The detection strategy is chosen based on the detected Effect version:
 // v4 uses direct symbol lookup, v3/unknown uses property iteration.
 func EffectType(c *checker.Checker, t *checker.Type, atLocation *ast.Node) *Effect {
+	if c == nil || t == nil {
+		return nil
+	}
 	version := DetectEffectVersion(c)
 	if version == EffectMajorV4 {
 		// Direct property access using the known Effect v4 type ID
@@ -128,6 +131,9 @@ func StrictIsEffectType(c *checker.Checker, t *checker.Type, atLocation *ast.Nod
 // For v4, this is a quick check for the "~effect/Effect" property.
 // For v3/unknown, this defers to IsEffectType since there is no single property shortcut.
 func HasEffectTypeId(c *checker.Checker, t *checker.Type, atLocation *ast.Node) bool {
+	if c == nil || t == nil {
+		return false
+	}
 	version := DetectEffectVersion(c)
 	if version == EffectMajorV4 {
 		return GetPropertyOfTypeByName(c, t, EffectTypeId) != nil

--- a/internal/typeparser/expected_and_real_type_test.go
+++ b/internal/typeparser/expected_and_real_type_test.go
@@ -287,6 +287,57 @@ func TestExpectedAndRealTypes_NilInputs(t *testing.T) {
 	}
 }
 
+func TestEffectType_NilInputs(t *testing.T) {
+	t.Parallel()
+
+	source := `const x: number = 42`
+	c, sf, done := compileAndGetCheckerAndSourceFile(t, source)
+	defer done()
+
+	// nil type must not panic
+	if result := typeparser.EffectType(c, nil, sf.AsNode()); result != nil {
+		t.Error("expected nil for nil type")
+	}
+	// nil checker must not panic
+	if result := typeparser.EffectType(nil, nil, sf.AsNode()); result != nil {
+		t.Error("expected nil for nil checker")
+	}
+	// HasEffectTypeId with nil type must not panic
+	if typeparser.HasEffectTypeId(c, nil, sf.AsNode()) {
+		t.Error("expected false for nil type")
+	}
+}
+
+func TestLayerType_NilInputs(t *testing.T) {
+	t.Parallel()
+
+	source := `const x: number = 42`
+	c, sf, done := compileAndGetCheckerAndSourceFile(t, source)
+	defer done()
+
+	if result := typeparser.LayerType(c, nil, sf.AsNode()); result != nil {
+		t.Error("expected nil for nil type")
+	}
+	if result := typeparser.LayerType(nil, nil, sf.AsNode()); result != nil {
+		t.Error("expected nil for nil checker")
+	}
+}
+
+func TestContextTag_NilInputs(t *testing.T) {
+	t.Parallel()
+
+	source := `const x: number = 42`
+	c, sf, done := compileAndGetCheckerAndSourceFile(t, source)
+	defer done()
+
+	if result := typeparser.ContextTag(c, nil, sf.AsNode()); result != nil {
+		t.Error("expected nil for nil type")
+	}
+	if result := typeparser.ContextTag(nil, nil, sf.AsNode()); result != nil {
+		t.Error("expected nil for nil checker")
+	}
+}
+
 func TestExpectedAndRealTypes_EmptyFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/typeparser/layer_type.go
+++ b/internal/typeparser/layer_type.go
@@ -33,6 +33,9 @@ func parseLayerVarianceStruct(c *checker.Checker, t *checker.Type, atLocation *a
 // The detection strategy is chosen based on the detected Effect version:
 // v4 uses direct symbol lookup, v3/unknown uses property iteration.
 func LayerType(c *checker.Checker, t *checker.Type, atLocation *ast.Node) *Layer {
+	if c == nil || t == nil {
+		return nil
+	}
 	version := DetectEffectVersion(c)
 	if version == EffectMajorV4 {
 		// Direct property access using the known Layer v4 type ID

--- a/internal/typeparser/service_type.go
+++ b/internal/typeparser/service_type.go
@@ -47,6 +47,9 @@ func IsServiceType(c *checker.Checker, t *checker.Type, atLocation *ast.Node) bo
 // For V3/unknown, this iterates properties looking for a service variance struct,
 // following the same pattern as LayerType() and EffectType().
 func ContextTag(c *checker.Checker, t *checker.Type, atLocation *ast.Node) *Service {
+	if c == nil || t == nil {
+		return nil
+	}
 	version := DetectEffectVersion(c)
 	if version == EffectMajorV4 {
 		return ServiceType(c, t, atLocation)


### PR DESCRIPTION
Closes #23

## Summary

- **Nil pointer crash fix**: Add nil guards to `EffectType`, `LayerType`, `ContextTag`, and `HasEffectTypeId` — the V3/unknown code path called `GetPropertiesOfType(t)` without checking `t != nil`
- **Document why `proxyVendor = true` is required**: mixed-case module paths (`Microsoft/go-winio` vs `microsoft/typescript-go`) cause `go work vendor` to produce different directory layouts on case-sensitive (Linux) vs case-insensitive (macOS) filesystems. The `proxyVendor` download cache uses `!` escaping for uppercase letters, making it deterministic across both
- **Fix Perl regex in `update-flake-vendor-hash.sh`**: the `/` in repo URLs like `microsoft/typescript-go` was interpreted as a Perl regex delimiter, breaking the Refresh Flake Hash CI workflow. Use `quotemeta()` with env vars instead

## Rationale

The original issue reported hash drift from a custom `gomodcache` derivation (pre-831fca0). The `buildGoModule` + `proxyVendor = true` migration already fixed that. Switching to `go work vendor` would reintroduce cross-platform issues due to case sensitivity, so we keep `proxyVendor = true` and document why.

## Test plan

- [x] `nix build .#effect-tsgo` succeeds locally
- [x] `go test ./internal/typeparser/` passes with new nil-input tests
- [x] `_tools/update-flake-vendor-hash.sh` runs correctly
- [ ] CI: flake builds on Linux + macOS
- [ ] CI: Refresh Flake Hash workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)