### PR TITLE
ETSGO-19 Ship schema.json in distribution of @effect/tsgo CLI as well

### DIFF
--- a/.changeset/wise-rats-travel.md
+++ b/.changeset/wise-rats-travel.md
@@ -1,0 +1,12 @@
+---
+"@effect/tsgo": patch
+"@effect/tsgo-darwin-arm64": patch
+"@effect/tsgo-darwin-x64": patch
+"@effect/tsgo-linux-arm": patch
+"@effect/tsgo-linux-arm64": patch
+"@effect/tsgo-linux-x64": patch
+"@effect/tsgo-win32-arm64": patch
+"@effect/tsgo-win32-x64": patch
+---
+
+Ship `schema.json` with `@effect/tsgo` so local `tsconfig.json` `$schema` references stay aligned with the installed CLI version.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ Each release of `effect-tsgo` is built against a specific upstream `tsgo` commit
 
 ## Plugin Options
 
+When you want schema validation for the plugin config, point `tsconfig.json` at the schema shipped in your local install:
+
+```jsonc
+{
+  "$schema": "./node_modules/@effect/tsgo/schema.json"
+}
+```
+
+The GitHub-hosted `schema.json` is still available, but the local file stays aligned with the installed CLI version.
+
 These options are configured in `tsconfig.json` under `compilerOptions.plugins` for the `@effect/language-service` plugin entry.
 
 | Option | Type | Default | Description |

--- a/_packages/tsgo/.gitignore
+++ b/_packages/tsgo/.gitignore
@@ -1,2 +1,3 @@
 bin/
 node_modules/
+schema.json

--- a/_packages/tsgo/package.json
+++ b/_packages/tsgo/package.json
@@ -12,10 +12,7 @@
   "homepage": "https://github.com/Effect-TS/tsgo#readme",
   "publishConfig": {
     "access": "public",
-    "provenance": true,
-    "bin": {
-      "effect-tsgo": "./bin/effect-tsgo.js"
-    }
+    "provenance": true
   },
   "scripts": {
     "build": "tsdown --config tsdown.config.mjs",
@@ -23,7 +20,7 @@
     "test": "vitest run"
   },
   "bin": {
-    "effect-tsgo": "./src/cli.ts"
+    "effect-tsgo": "./bin/effect-tsgo.js"
   },
   "files": [
     "bin/",

--- a/_packages/tsgo/package.json
+++ b/_packages/tsgo/package.json
@@ -18,7 +18,7 @@
     }
   },
   "scripts": {
-    "build": "tsdown --config tsdown.config.mjs",
+    "build": "tsdown --config tsdown.config.mjs && node ./scripts/postbuild.mjs",
     "check": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run"
   },
@@ -26,7 +26,8 @@
     "effect-tsgo": "./src/cli.ts"
   },
   "files": [
-    "bin/"
+    "bin/",
+    "schema.json"
   ],
   "optionalDependencies": {
     "@effect/tsgo-win32-x64": "workspace:*",

--- a/_packages/tsgo/package.json
+++ b/_packages/tsgo/package.json
@@ -18,7 +18,7 @@
     }
   },
   "scripts": {
-    "build": "tsdown --config tsdown.config.mjs && node ./scripts/postbuild.mjs",
+    "build": "tsdown --config tsdown.config.mjs",
     "check": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run"
   },

--- a/_packages/tsgo/scripts/postbuild.mjs
+++ b/_packages/tsgo/scripts/postbuild.mjs
@@ -1,0 +1,9 @@
+import { copyFile } from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const packageDir = path.dirname(fileURLToPath(import.meta.url))
+const schemaSourcePath = path.resolve(packageDir, "..", "..", "..", "schema.json")
+const schemaTargetPath = path.resolve(packageDir, "..", "schema.json")
+
+await copyFile(schemaSourcePath, schemaTargetPath)

--- a/_packages/tsgo/tsdown.config.mjs
+++ b/_packages/tsgo/tsdown.config.mjs
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: {
     "effect-tsgo": "./src/cli.ts",
   },
+  onSuccess: "node ./scripts/postbuild.mjs",
   inlineOnly: false,
   outDir: "./bin",
   format: ["cjs"],


### PR DESCRIPTION
## Summary
- copy the repository root `schema.json` into `_packages/tsgo/` after a successful CLI build and publish it with the `@effect/tsgo` package
- ignore the copied package-local `schema.json` in git while keeping the packaged artifact available for npm publishes
- document the local `$schema` path in `README.md` and add a patch changeset for the fixed package group

## Validation
- `pnpm setup-repo && pnpm check && pnpm build && pnpm test && pnpm --filter @effect/tsgo exec npm pack --dry-run`