### PR TITLE
Raise effect test program concurrency for CI validation

### DIFF
--- a/internal/effecttest/vfs.go
+++ b/internal/effecttest/vfs.go
@@ -70,12 +70,9 @@ func EnsurePackageInstalled(version EffectVersion, packageName string) error {
 var programSemaphore = make(chan struct{}, maxConcurrentPrograms())
 
 func maxConcurrentPrograms() int {
-	n := runtime.GOMAXPROCS(0) / 3
+	n := runtime.GOMAXPROCS(0)
 	if n < 1 {
 		n = 1
-	}
-	if n > 3 {
-		n = 3
 	}
 	return n
 }


### PR DESCRIPTION
## Summary
- raise the Effect test program semaphore from a hard cap of 3 to `GOMAXPROCS(0)`
- keep the change minimal so CI can show whether higher concurrency improves runtime or triggers memory pressure
- local validation passed with `pnpm test` on a 12-core Linux machine