### PR TITLE
fix: port effect context tracking from reference

### DIFF
--- a/.changeset/port-effect-context-tracking-14d57985.md
+++ b/.changeset/port-effect-context-tracking-14d57985.md
@@ -1,0 +1,7 @@
+---
+"@effect/tsgo": patch
+---
+
+Port the Effect context tracking refactor from the TypeScript reference implementation so diagnostics also recognize Effect constructor thunks such as `Effect.sync`, `Effect.promise`, `Effect.try`, and `Effect.tryPromise`.
+
+This updates related metadata and baselines and adds thunk-focused test coverage for both Effect v3 and v4 fixtures.

--- a/_packages/tsgo/src/metadata.json
+++ b/_packages/tsgo/src/metadata.json
@@ -1064,7 +1064,13 @@
       ],
       "preview": {
         "sourceText": "import { Effect } from \"effect\"\n\nexport const preview = Effect.gen(function*() {\n  return yield* Effect.promise(() =\u003e fetch(\"https://example.com\"))\n})\n",
-        "diagnostics": []
+        "diagnostics": [
+          {
+            "start": 118,
+            "end": 123,
+            "text": "This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)"
+          }
+        ]
       }
     },
     {

--- a/internal/rules/crypto_random_uuid.go
+++ b/internal/rules/crypto_random_uuid.go
@@ -52,7 +52,7 @@ func runCryptoRandomUUID(ctx *rule.Context, checkInEffect bool) []*ast.Diagnosti
 		}
 		if node.Kind == ast.KindCallExpression {
 			call := node.AsCallExpression()
-			inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagCanYieldEffect != 0
+			inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagInEffect != 0
 			if inEffect == checkInEffect {
 				if receiver := cryptoRandomUUIDReceiver(call); receiver != nil {
 					if ctx.TypeParser.ResolveToGlobalSymbol(ctx.Checker.GetSymbolAtLocation(receiver)) == cryptoSymbol {

--- a/internal/rules/global_console.go
+++ b/internal/rules/global_console.go
@@ -60,7 +60,7 @@ func runGlobalConsole(ctx *rule.Context, checkInEffect bool) []*ast.Diagnostic {
 			return false
 		}
 		if node.Kind == ast.KindCallExpression && node.AsCallExpression().Expression.Kind == ast.KindPropertyAccessExpression {
-			inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagCanYieldEffect != 0
+			inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagInEffect != 0
 			if inEffect == checkInEffect {
 				prop := node.AsCallExpression().Expression.AsPropertyAccessExpression()
 				method := prop.Name().Text()

--- a/internal/rules/global_date.go
+++ b/internal/rules/global_date.go
@@ -51,7 +51,7 @@ func runGlobalDate(ctx *rule.Context, checkInEffect bool) []*ast.Diagnostic {
 		if node == nil {
 			return false
 		}
-		inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagCanYieldEffect != 0
+		inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagInEffect != 0
 		if inEffect == checkInEffect {
 			var objectNode *ast.Node
 			message := tsdiag.This_code_uses_Date_now_time_access_is_represented_through_Clock_from_Effect_effect_globalDate

--- a/internal/rules/global_fetch.go
+++ b/internal/rules/global_fetch.go
@@ -56,7 +56,7 @@ func runGlobalFetch(ctx *rule.Context, checkInEffect bool) []*ast.Diagnostic {
 			return false
 		}
 		if node.Kind == ast.KindCallExpression {
-			inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagCanYieldEffect != 0
+			inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagInEffect != 0
 			if inEffect == checkInEffect {
 				call := node.AsCallExpression()
 				if ctx.TypeParser.ResolveToGlobalSymbol(ctx.Checker.GetSymbolAtLocation(call.Expression)) == fetchSymbol {

--- a/internal/rules/global_random.go
+++ b/internal/rules/global_random.go
@@ -51,7 +51,7 @@ func runGlobalRandom(ctx *rule.Context, checkInEffect bool) []*ast.Diagnostic {
 			return false
 		}
 		if node.Kind == ast.KindCallExpression && node.AsCallExpression().Expression.Kind == ast.KindPropertyAccessExpression {
-			inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagCanYieldEffect != 0
+			inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagInEffect != 0
 			if inEffect == checkInEffect {
 				prop := node.AsCallExpression().Expression.AsPropertyAccessExpression()
 				if prop.Name().Text() == "random" && ctx.TypeParser.ResolveToGlobalSymbol(ctx.Checker.GetSymbolAtLocation(prop.Expression)) == mathSymbol {

--- a/internal/rules/global_timers.go
+++ b/internal/rules/global_timers.go
@@ -72,7 +72,7 @@ func runGlobalTimers(ctx *rule.Context, checkInEffect bool) []*ast.Diagnostic {
 			return false
 		}
 		if node.Kind == ast.KindCallExpression {
-			inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagCanYieldEffect != 0
+			inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagInEffect != 0
 			if inEffect == checkInEffect {
 				resolved := ctx.TypeParser.ResolveToGlobalSymbol(ctx.Checker.GetSymbolAtLocation(node.AsCallExpression().Expression))
 				if resolved != nil {

--- a/internal/rules/prefer_schema_over_json.go
+++ b/internal/rules/prefer_schema_over_json.go
@@ -199,21 +199,7 @@ func checkJsonMethodInEffectGen(tp *typeparser.TypeParser, _ *checker.Checker, n
 		return nil
 	}
 
-	if tp.GetEffectContextFlags(node)&typeparser.EffectContextFlagCanYieldEffect == 0 {
-		return nil
-	}
-
-	genFn := tp.GetEffectYieldGeneratorFunction(node)
-	if genFn == nil {
-		return nil
-	}
-
-	// Check that the generator body has at least one statement
-	if genFn.Body == nil || genFn.Body.Kind != ast.KindBlock {
-		return nil
-	}
-	block := genFn.Body.AsBlock()
-	if block.Statements == nil || len(block.Statements.Nodes) == 0 {
+	if tp.GetEffectContextFlags(node)&typeparser.EffectContextFlagInEffect == 0 {
 		return nil
 	}
 

--- a/internal/rules/process_env.go
+++ b/internal/rules/process_env.go
@@ -51,7 +51,7 @@ func runProcessEnv(ctx *rule.Context, checkInEffect bool) []*ast.Diagnostic {
 			return false
 		}
 
-		inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagCanYieldEffect != 0
+		inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagInEffect != 0
 		if inEffect == checkInEffect {
 			if processNode := processEnvRoot(node); processNode != nil {
 				if ctx.TypeParser.ResolveToGlobalSymbol(ctx.Checker.GetSymbolAtLocation(processNode)) == processSymbol {

--- a/internal/rules/schema_sync_in_effect.go
+++ b/internal/rules/schema_sync_in_effect.go
@@ -82,21 +82,7 @@ func checkSchemaSyncInEffect(ctx *rule.Context, node *ast.Node, syncToEffectMeth
 		return nil
 	}
 
-	if ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagCanYieldEffect == 0 {
-		return nil
-	}
-
-	genFn := ctx.TypeParser.GetEffectYieldGeneratorFunction(node)
-	if genFn == nil {
-		return nil
-	}
-
-	// Check that the generator body has at least one statement
-	if genFn.Body == nil || genFn.Body.Kind != ast.KindBlock {
-		return nil
-	}
-	block := genFn.Body.AsBlock()
-	if block.Statements == nil || len(block.Statements.Nodes) == 0 {
+	if ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagInEffect == 0 {
 		return nil
 	}
 

--- a/internal/typeparser/effect_context.go
+++ b/internal/typeparser/effect_context.go
@@ -10,6 +10,10 @@ type EffectContextFlags uint8
 const (
 	EffectContextFlagNone           EffectContextFlags = 0
 	EffectContextFlagCanYieldEffect EffectContextFlags = 1 << iota
+	EffectContextFlagInEffectConstructorThunk
+	EffectContextFlagPendingNextFunctionIsEffectThunk
+	EffectContextFlagPendingNextObjectTryPropertyIsEffectThunk
+	EffectContextFlagInEffect = EffectContextFlagCanYieldEffect | EffectContextFlagInEffectConstructorThunk
 )
 
 func (tp *TypeParser) GetEffectContextFlags(node *ast.Node) EffectContextFlags {
@@ -22,7 +26,7 @@ func (tp *TypeParser) GetEffectContextFlags(node *ast.Node) EffectContextFlags {
 	}
 
 	if closest, ok := getClosestNodeWithLinks(&links.EffectContextFlags, node); ok {
-		return *links.EffectContextFlags.TryGet(closest)
+		return *links.EffectContextFlags.TryGet(closest) & EffectContextFlagInEffect
 	}
 	return EffectContextFlagNone
 }
@@ -87,9 +91,42 @@ func (tp *TypeParser) analyzeEffectContextForSourceFile(sf *ast.SourceFile) {
 	var walk ast.Visitor
 	var pendingEnableFlags core.LinkStore[*ast.Node, EffectContextFlags]
 	var pendingDisableFlags core.LinkStore[*ast.Node, EffectContextFlags]
+	pendingFlagsMask := EffectContextFlagPendingNextFunctionIsEffectThunk | EffectContextFlagPendingNextObjectTryPropertyIsEffectThunk
+	functionScopeResetFlags := EffectContextFlagCanYieldEffect | EffectContextFlagInEffectConstructorThunk | pendingFlagsMask
 
-	resetChildCanYieldEffect := func(node *ast.Node) bool {
-		*pendingDisableFlags.Get(node) |= EffectContextFlagCanYieldEffect
+	setPendingEnableFlags := func(node *ast.Node, flags EffectContextFlags) {
+		if node == nil || flags == EffectContextFlagNone {
+			return
+		}
+		*pendingEnableFlags.Get(node) |= flags
+	}
+
+	setPendingDisableFlags := func(node *ast.Node, flags EffectContextFlags) {
+		if node == nil || flags == EffectContextFlagNone {
+			return
+		}
+		*pendingDisableFlags.Get(node) |= flags
+	}
+
+	transparentPendingExpression := func(node *ast.Node) *ast.Node {
+		if node == nil {
+			return nil
+		}
+		switch node.Kind {
+		case ast.KindParenthesizedExpression, ast.KindSatisfiesExpression, ast.KindAsExpression, ast.KindNonNullExpression, ast.KindTypeAssertionExpression:
+			return node.Expression()
+		default:
+			return nil
+		}
+	}
+
+	resetChildFunctionScopeFlags := func(node *ast.Node) bool {
+		setPendingDisableFlags(node, functionScopeResetFlags)
+		return false
+	}
+
+	resetPendingFlags := func(child *ast.Node) bool {
+		setPendingDisableFlags(child, pendingFlagsMask)
 		return false
 	}
 
@@ -119,18 +156,65 @@ func (tp *TypeParser) analyzeEffectContextForSourceFile(sf *ast.SourceFile) {
 			*links.EffectContextFlags.Get(node) |= *pendingEnableFlags.TryGet(node)
 		}
 
+		if *links.EffectContextFlags.Get(node)&EffectContextFlagPendingNextFunctionIsEffectThunk != 0 && (node.Kind == ast.KindArrowFunction || node.Kind == ast.KindFunctionExpression) {
+			if body := node.Body(); body != nil {
+				setPendingEnableFlags(body.AsNode(), EffectContextFlagInEffectConstructorThunk)
+				setPendingDisableFlags(body.AsNode(), pendingFlagsMask)
+			}
+		} else if *links.EffectContextFlags.Get(node)&EffectContextFlagPendingNextObjectTryPropertyIsEffectThunk != 0 && node.Kind == ast.KindObjectLiteralExpression {
+			node.ForEachChild(resetPendingFlags)
+
+			obj := node.AsObjectLiteralExpression()
+			if obj != nil && obj.Properties != nil {
+				for _, prop := range obj.Properties.Nodes {
+					if prop == nil || prop.Kind != ast.KindPropertyAssignment {
+						continue
+					}
+					assignment := prop.AsPropertyAssignment()
+					if assignment == nil || assignment.Name() == nil || assignment.Initializer == nil {
+						continue
+					}
+					if assignment.Name().Text() != "try" {
+						continue
+					}
+					setPendingEnableFlags(assignment.Initializer, EffectContextFlagPendingNextFunctionIsEffectThunk)
+				}
+			}
+		} else if expr := transparentPendingExpression(node); expr != nil {
+			setPendingEnableFlags(expr, *links.EffectContextFlags.Get(node)&pendingFlagsMask)
+		} else if *links.EffectContextFlags.Get(node)&pendingFlagsMask != 0 {
+			node.ForEachChild(resetPendingFlags)
+		}
+
 		// logic for this node
 		if effectGen := tp.EffectGenCall(node); effectGen != nil {
 			bodyNode := effectGen.Body.AsNode()
-			*pendingEnableFlags.Get(bodyNode) |= EffectContextFlagCanYieldEffect
+			setPendingEnableFlags(bodyNode, EffectContextFlagCanYieldEffect)
 			*links.EffectYieldGeneratorFunction.Get(bodyNode) = effectGen.GeneratorFunction
 		} else if effectFn := tp.EffectFnCall(node); effectFn != nil && effectFn.IsGenerator() {
 			body := effectFn.Body()
 			genFn := effectFn.GeneratorFunction()
 			if body != nil && genFn != nil {
 				bodyNode := body.AsNode()
-				*pendingEnableFlags.Get(bodyNode) |= EffectContextFlagCanYieldEffect
+				setPendingEnableFlags(bodyNode, EffectContextFlagCanYieldEffect)
 				*links.EffectYieldGeneratorFunction.Get(bodyNode) = genFn
+			}
+		}
+
+		if node.Kind == ast.KindCallExpression {
+			call := node.AsCallExpression()
+			if call != nil && call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+				effectThunkArg := call.Arguments.Nodes[0]
+				switch {
+				case tp.IsNodeReferenceToEffectModuleApi(call.Expression, "sync"),
+					tp.IsNodeReferenceToEffectModuleApi(call.Expression, "promise"),
+					tp.IsNodeReferenceToEffectModuleApi(call.Expression, "callback"),
+					tp.IsNodeReferenceToEffectModuleApi(call.Expression, "suspend"):
+					setPendingEnableFlags(effectThunkArg, EffectContextFlagPendingNextFunctionIsEffectThunk)
+				case tp.IsNodeReferenceToEffectModuleApi(call.Expression, "try"),
+					tp.IsNodeReferenceToEffectModuleApi(call.Expression, "tryPromise"):
+					setPendingEnableFlags(effectThunkArg, EffectContextFlagPendingNextFunctionIsEffectThunk|EffectContextFlagPendingNextObjectTryPropertyIsEffectThunk)
+				}
 			}
 		}
 
@@ -138,7 +222,7 @@ func (tp *TypeParser) analyzeEffectContextForSourceFile(sf *ast.SourceFile) {
 		// yieldability from an outer Effect scope. Matching Effect helpers re-enable the
 		// flag on the specific body node below.
 		if ast.IsFunctionLike(node) {
-			node.ForEachChild(resetChildCanYieldEffect)
+			node.ForEachChild(resetChildFunctionScopeFlags)
 		}
 
 		// reset stores correlated to a flag set here.

--- a/testdata/baselines/reference/effect-v3/globalConsoleInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v3/globalConsoleInEffect_thunks.errors.txt
@@ -1,0 +1,39 @@
+=== Metadata ===
+Effect version: 3.19.19
+
+/.src/globalConsoleInEffect_thunks.ts(6,48): warning TS377065: This Effect code uses `console.log`, logging in Effect code is represented through `Effect.log or Logger`. effect(globalConsoleInEffect)
+/.src/globalConsoleInEffect_thunks.ts(9,14): warning TS377065: This Effect code uses `console.warn`, logging in Effect code is represented through `Effect.logWarning or Logger`. effect(globalConsoleInEffect)
+/.src/globalConsoleInEffect_thunks.ts(13,66): warning TS377065: This Effect code uses `console.log`, logging in Effect code is represented through `Effect.log or Logger`. effect(globalConsoleInEffect)
+/.src/globalConsoleInEffect_thunks.ts(16,20): warning TS377065: This Effect code uses `console.warn`, logging in Effect code is represented through `Effect.logWarning or Logger`. effect(globalConsoleInEffect)
+
+
+==== /.src/globalConsoleInEffect_thunks.ts (4 errors) ====
+    // @effect-diagnostics globalConsoleInEffect:warning
+    import { Data, Effect } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    export const consoleInSync = Effect.sync(() => console.log("sync"))
+                                                   ~~~~~~~~~~~~~~~~~~~
+!!! warning TS377065: This Effect code uses `console.log`, logging in Effect code is represented through `Effect.log or Logger`. effect(globalConsoleInEffect)
+    
+    export const consoleInTryObject = Effect.try({
+      try: () => console.warn("try"),
+                 ~~~~~~~~~~~~~~~~~~~
+!!! warning TS377065: This Effect code uses `console.warn`, logging in Effect code is represented through `Effect.logWarning or Logger`. effect(globalConsoleInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const consoleInTryPromise = Effect.tryPromise(async () => console.log("try-promise"))
+                                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377065: This Effect code uses `console.log`, logging in Effect code is represented through `Effect.log or Logger`. effect(globalConsoleInEffect)
+    
+    export const consoleInTryPromiseObject = Effect.tryPromise({
+      try: async () => console.warn("try-promise-object"),
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377065: This Effect code uses `console.warn`, logging in Effect code is represented through `Effect.logWarning or Logger`. effect(globalConsoleInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => console.log("nested"))
+    

--- a/testdata/baselines/reference/effect-v3/globalConsoleInEffect_thunks.flows.globalConsoleInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v3/globalConsoleInEffect_thunks.flows.globalConsoleInEffect_thunks.mermaid
@@ -1,0 +1,73 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: Equals#lt;A, #123;#125;#gt; extends true ? void : #123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: Equals#lt;A, #123;#125;#gt; extends true ? void : #123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3((("type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; console.log#40;#quot;sync#quot;#41;")))
+  4["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  5[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  6[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; console.log#40;#quot;sync#quot;#41;"]]
+  7((("type: void<br/>node: console.log#40;#quot;sync#quot;#41;")))
+  8[/"type: #quot;sync#quot;<br/>node: #quot;sync#quot;"/]
+  9["type: void<br/>callee: console.log<br/>args: #91;#93;"]
+  10[/"type: #40;...data: any#91;#93;#41; =#gt; void<br/>node: console.log"/]
+  11[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; console.warn#40;#quot;try#quot;#41;"]]
+  12((("type: void<br/>node: console.warn#40;#quot;try#quot;#41;")))
+  13[/"type: #quot;try#quot;<br/>node: #quot;try#quot;"/]
+  14["type: void<br/>callee: console.warn<br/>args: #91;#93;"]
+  15[/"type: #40;...data: any#91;#93;#41; =#gt; void<br/>node: console.warn"/]
+  16[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  17[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  18[["type: #40;#41; =#gt; Promise#lt;void#gt;<br/>node: async #40;#41; =#gt; console.log#40;#quot;try-promise#quot;#41;"]]
+  19((("type: void<br/>node: console.log#40;#quot;try-promise#quot;#41;")))
+  20[/"type: #quot;try-promise#quot;<br/>node: #quot;try-promise#quot;"/]
+  21["type: void<br/>callee: console.log<br/>args: #91;#93;"]
+  22[/"type: #40;...data: any#91;#93;#41; =#gt; void<br/>node: console.log"/]
+  23[["type: #40;#41; =#gt; Promise#lt;void#gt;<br/>node: async #40;#41; =#gt; console.warn#40;#quot;try-promise-object#quot;#41;"]]
+  24((("type: void<br/>node: console.warn#40;#quot;try-promise-object#quot;#41;")))
+  25[/"type: #quot;try-promise-object#quot;<br/>node: #quot;try-promise-object#quot;"/]
+  26["type: void<br/>callee: console.warn<br/>args: #91;#93;"]
+  27[/"type: #40;...data: any#91;#93;#41; =#gt; void<br/>node: console.warn"/]
+  28[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  29[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  30((("type: #40;#41; =#gt; #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #40;#41; =#gt; console.log#40;#quot;nested#quot;#41;")))
+  31["type: Effect#lt;#40;#41; =#gt; void, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  32[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  33[["type: #40;#41; =#gt; #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #40;#41; =#gt; console.log#40;#quot;nested#quot;#41;"]]
+  34((("type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; console.log#40;#quot;nested#quot;#41;")))
+  35[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; console.log#40;#quot;nested#quot;#41;"]]
+  36((("type: void<br/>node: console.log#40;#quot;nested#quot;#41;")))
+  37[/"type: #quot;nested#quot;<br/>node: #quot;nested#quot;"/]
+  38["type: void<br/>callee: console.log<br/>args: #91;#93;"]
+  39[/"type: #40;...data: any#91;#93;#41; =#gt; void<br/>node: console.log"/]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  7 -->|"kind: potentialReturn"| 6
+  6 -->|"kind: connect"| 3
+  8 -->|"kind: pipe"| 9
+  9 -->|"kind: connect"| 7
+  10 -->|"kind: transformCallee"| 9
+  12 -->|"kind: potentialReturn"| 11
+  13 -->|"kind: pipe"| 14
+  14 -->|"kind: connect"| 12
+  15 -->|"kind: transformCallee"| 14
+  17 -->|"kind: potentialReturn"| 16
+  19 -->|"kind: potentialReturn"| 18
+  20 -->|"kind: pipe"| 21
+  21 -->|"kind: connect"| 19
+  22 -->|"kind: transformCallee"| 21
+  24 -->|"kind: potentialReturn"| 23
+  25 -->|"kind: pipe"| 26
+  26 -->|"kind: connect"| 24
+  27 -->|"kind: transformCallee"| 26
+  29 -->|"kind: potentialReturn"| 28
+  30 -->|"kind: pipe"| 31
+  32 -->|"kind: transformCallee"| 31
+  34 -->|"kind: potentialReturn"| 33
+  33 -->|"kind: connect"| 30
+  36 -->|"kind: potentialReturn"| 35
+  35 -->|"kind: connect"| 34
+  37 -->|"kind: pipe"| 38
+  38 -->|"kind: connect"| 36
+  39 -->|"kind: transformCallee"| 38

--- a/testdata/baselines/reference/effect-v3/globalConsoleInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v3/globalConsoleInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/globalConsoleInEffect_thunks.ts -> globalConsoleInEffect_thunks.flows.globalConsoleInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v3/globalConsoleInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v3/globalConsoleInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/globalConsoleInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v3/globalConsoleInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v3/globalConsoleInEffect_thunks.pipings.txt
@@ -1,0 +1,155 @@
+==== /.src/globalConsoleInEffect_thunks.ts (11 flows) ====
+
+=== Piping Flow ===
+Location: 4:27 - 4:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: Equals<A, {}> extends true ? void : { readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 6:29 - 6:68
+Node: Effect.sync(() => console.log("sync"))
+Node Kind: KindCallExpression
+
+Subject: () => console.log("sync")
+Subject Type: () => void
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 6:47 - 6:67
+Node: console.log("sync")
+Node Kind: KindCallExpression
+
+Subject: "sync"
+Subject Type: "sync"
+
+Transformations (1):
+  [0] kind: call
+      callee: console.log
+      args: (constant)
+      outType: void
+
+=== Piping Flow ===
+Location: 8:34 - 11:3
+Node: Effect.try({\n  try: () => console.warn("try"),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => console.warn("try"),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => void; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<void, ExampleError, never>
+
+=== Piping Flow ===
+Location: 9:13 - 9:33
+Node: console.warn("try")
+Node Kind: KindCallExpression
+
+Subject: "try"
+Subject Type: "try"
+
+Transformations (1):
+  [0] kind: call
+      callee: console.warn
+      args: (constant)
+      outType: void
+
+=== Piping Flow ===
+Location: 13:35 - 13:93
+Node: Effect.tryPromise(async () => console.log("try-promise"))
+Node Kind: KindCallExpression
+
+Subject: async () => console.log("try-promise")
+Subject Type: () => Promise<void>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<void, UnknownException, never>
+
+=== Piping Flow ===
+Location: 13:65 - 13:92
+Node: console.log("try-promise")
+Node Kind: KindCallExpression
+
+Subject: "try-promise"
+Subject Type: "try-promise"
+
+Transformations (1):
+  [0] kind: call
+      callee: console.log
+      args: (constant)
+      outType: void
+
+=== Piping Flow ===
+Location: 15:41 - 18:3
+Node: Effect.tryPromise({\n  try: async () => console.warn("try-promise-object"),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => console.warn("try-promise-object"),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<void>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<void, ExampleError, never>
+
+=== Piping Flow ===
+Location: 16:19 - 16:54
+Node: console.warn("try-promise-object")
+Node Kind: KindCallExpression
+
+Subject: "try-promise-object"
+Subject Type: "try-promise-object"
+
+Transformations (1):
+  [0] kind: call
+      callee: console.warn
+      args: (constant)
+      outType: void
+
+=== Piping Flow ===
+Location: 20:48 - 20:95
+Node: Effect.sync(() => () => console.log("nested"))
+Node Kind: KindCallExpression
+
+Subject: () => () => console.log("nested")
+Subject Type: () => () => void
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => void, never, never>
+
+=== Piping Flow ===
+Location: 20:72 - 20:94
+Node: console.log("nested")
+Node Kind: KindCallExpression
+
+Subject: "nested"
+Subject Type: "nested"
+
+Transformations (1):
+  [0] kind: call
+      callee: console.log
+      args: (constant)
+      outType: void

--- a/testdata/baselines/reference/effect-v3/globalConsoleInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/globalConsoleInEffect_thunks.quickfixes.txt
@@ -1,0 +1,43 @@
+=== Quick Fix Inventory ===
+
+[D1] (6:48-6:67) TS377065: This Effect code uses `console.log`, logging in Effect code is represented through `Effect.log or Logger`. effect(globalConsoleInEffect)
+  Fix 0: "Disable globalConsoleInEffect for this line"
+  Fix 1: "Disable globalConsoleInEffect for entire file"
+
+[D2] (9:14-9:33) TS377065: This Effect code uses `console.warn`, logging in Effect code is represented through `Effect.logWarning or Logger`. effect(globalConsoleInEffect)
+  Fix 0: "Disable globalConsoleInEffect for this line"
+  Fix 1: "Disable globalConsoleInEffect for entire file"
+
+[D3] (13:66-13:92) TS377065: This Effect code uses `console.log`, logging in Effect code is represented through `Effect.log or Logger`. effect(globalConsoleInEffect)
+  Fix 0: "Disable globalConsoleInEffect for this line"
+  Fix 1: "Disable globalConsoleInEffect for entire file"
+
+[D4] (16:20-16:54) TS377065: This Effect code uses `console.warn`, logging in Effect code is represented through `Effect.logWarning or Logger`. effect(globalConsoleInEffect)
+  Fix 0: "Disable globalConsoleInEffect for this line"
+  Fix 1: "Disable globalConsoleInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable globalConsoleInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable globalConsoleInEffect for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable globalConsoleInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable globalConsoleInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable globalConsoleInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable globalConsoleInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable globalConsoleInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable globalConsoleInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v3/globalDateInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v3/globalDateInEffect_thunks.errors.txt
@@ -1,0 +1,39 @@
+=== Metadata ===
+Effect version: 3.19.19
+
+/.src/globalDateInEffect_thunks.ts(6,45): warning TS377067: This Effect code uses `Date.now()`, time access in Effect code is represented through `Clock` from Effect. effect(globalDateInEffect)
+/.src/globalDateInEffect_thunks.ts(9,14): warning TS377069: This Effect code constructs `new Date()`, date values in Effect code are represented through `DateTime` from Effect. effect(globalDateInEffect)
+/.src/globalDateInEffect_thunks.ts(13,63): warning TS377067: This Effect code uses `Date.now()`, time access in Effect code is represented through `Clock` from Effect. effect(globalDateInEffect)
+/.src/globalDateInEffect_thunks.ts(16,20): warning TS377069: This Effect code constructs `new Date()`, date values in Effect code are represented through `DateTime` from Effect. effect(globalDateInEffect)
+
+
+==== /.src/globalDateInEffect_thunks.ts (4 errors) ====
+    // @effect-diagnostics globalDateInEffect:warning
+    import { Data, Effect } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    export const dateInSync = Effect.sync(() => Date.now())
+                                                ~~~~~~~~~~
+!!! warning TS377067: This Effect code uses `Date.now()`, time access in Effect code is represented through `Clock` from Effect. effect(globalDateInEffect)
+    
+    export const newDateInTryObject = Effect.try({
+      try: () => new Date(),
+                 ~~~~~~~~~~
+!!! warning TS377069: This Effect code constructs `new Date()`, date values in Effect code are represented through `DateTime` from Effect. effect(globalDateInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const dateInTryPromise = Effect.tryPromise(async () => Date.now())
+                                                                  ~~~~~~~~~~
+!!! warning TS377067: This Effect code uses `Date.now()`, time access in Effect code is represented through `Clock` from Effect. effect(globalDateInEffect)
+    
+    export const newDateInTryPromiseObject = Effect.tryPromise({
+      try: async () => new Date(),
+                       ~~~~~~~~~~
+!!! warning TS377069: This Effect code constructs `new Date()`, date values in Effect code are represented through `DateTime` from Effect. effect(globalDateInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => Date.now())
+    

--- a/testdata/baselines/reference/effect-v3/globalDateInEffect_thunks.flows.globalDateInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v3/globalDateInEffect_thunks.flows.globalDateInEffect_thunks.mermaid
@@ -1,0 +1,43 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: Equals#lt;A, #123;#125;#gt; extends true ? void : #123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: Equals#lt;A, #123;#125;#gt; extends true ? void : #123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3((("type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Date.now#40;#41;")))
+  4["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  5[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  6[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Date.now#40;#41;"]]
+  7[/"type: number<br/>node: Date.now#40;#41;"/]
+  8[["type: #40;#41; =#gt; Date<br/>node: #40;#41; =#gt; new Date#40;#41;"]]
+  9[/"type: Date<br/>node: new Date#40;#41;"/]
+  10[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  11[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  12[["type: #40;#41; =#gt; Promise#lt;number#gt;<br/>node: async #40;#41; =#gt; Date.now#40;#41;"]]
+  13[/"type: number<br/>node: Date.now#40;#41;"/]
+  14[["type: #40;#41; =#gt; Promise#lt;Date#gt;<br/>node: async #40;#41; =#gt; new Date#40;#41;"]]
+  15[/"type: Date<br/>node: new Date#40;#41;"/]
+  16[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  17[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  18((("type: #40;#41; =#gt; #40;#41; =#gt; number<br/>node: #40;#41; =#gt; #40;#41; =#gt; Date.now#40;#41;")))
+  19["type: Effect#lt;#40;#41; =#gt; number, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  20[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  21[["type: #40;#41; =#gt; #40;#41; =#gt; number<br/>node: #40;#41; =#gt; #40;#41; =#gt; Date.now#40;#41;"]]
+  22((("type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Date.now#40;#41;")))
+  23[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Date.now#40;#41;"]]
+  24[/"type: number<br/>node: Date.now#40;#41;"/]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  7 -->|"kind: potentialReturn"| 6
+  6 -->|"kind: connect"| 3
+  9 -->|"kind: potentialReturn"| 8
+  11 -->|"kind: potentialReturn"| 10
+  13 -->|"kind: potentialReturn"| 12
+  15 -->|"kind: potentialReturn"| 14
+  17 -->|"kind: potentialReturn"| 16
+  18 -->|"kind: pipe"| 19
+  20 -->|"kind: transformCallee"| 19
+  22 -->|"kind: potentialReturn"| 21
+  21 -->|"kind: connect"| 18
+  24 -->|"kind: potentialReturn"| 23
+  23 -->|"kind: connect"| 22

--- a/testdata/baselines/reference/effect-v3/globalDateInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v3/globalDateInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/globalDateInEffect_thunks.ts -> globalDateInEffect_thunks.flows.globalDateInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v3/globalDateInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v3/globalDateInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/globalDateInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v3/globalDateInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v3/globalDateInEffect_thunks.pipings.txt
@@ -1,0 +1,85 @@
+==== /.src/globalDateInEffect_thunks.ts (6 flows) ====
+
+=== Piping Flow ===
+Location: 4:27 - 4:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: Equals<A, {}> extends true ? void : { readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 6:26 - 6:56
+Node: Effect.sync(() => Date.now())
+Node Kind: KindCallExpression
+
+Subject: () => Date.now()
+Subject Type: () => number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 8:34 - 11:3
+Node: Effect.try({\n  try: () => new Date(),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => new Date(),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Date; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<Date, ExampleError, never>
+
+=== Piping Flow ===
+Location: 13:32 - 13:74
+Node: Effect.tryPromise(async () => Date.now())
+Node Kind: KindCallExpression
+
+Subject: async () => Date.now()
+Subject Type: () => Promise<number>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<number, UnknownException, never>
+
+=== Piping Flow ===
+Location: 15:41 - 18:3
+Node: Effect.tryPromise({\n  try: async () => new Date(),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => new Date(),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<Date>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<Date, ExampleError, never>
+
+=== Piping Flow ===
+Location: 20:48 - 20:84
+Node: Effect.sync(() => () => Date.now())
+Node Kind: KindCallExpression
+
+Subject: () => () => Date.now()
+Subject Type: () => () => number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => number, never, never>

--- a/testdata/baselines/reference/effect-v3/globalDateInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/globalDateInEffect_thunks.quickfixes.txt
@@ -1,0 +1,43 @@
+=== Quick Fix Inventory ===
+
+[D1] (6:45-6:55) TS377067: This Effect code uses `Date.now()`, time access in Effect code is represented through `Clock` from Effect. effect(globalDateInEffect)
+  Fix 0: "Disable globalDateInEffect for this line"
+  Fix 1: "Disable globalDateInEffect for entire file"
+
+[D2] (9:14-9:24) TS377069: This Effect code constructs `new Date()`, date values in Effect code are represented through `DateTime` from Effect. effect(globalDateInEffect)
+  Fix 0: "Disable globalDateInEffect for this line"
+  Fix 1: "Disable globalDateInEffect for entire file"
+
+[D3] (13:63-13:73) TS377067: This Effect code uses `Date.now()`, time access in Effect code is represented through `Clock` from Effect. effect(globalDateInEffect)
+  Fix 0: "Disable globalDateInEffect for this line"
+  Fix 1: "Disable globalDateInEffect for entire file"
+
+[D4] (16:20-16:30) TS377069: This Effect code constructs `new Date()`, date values in Effect code are represented through `DateTime` from Effect. effect(globalDateInEffect)
+  Fix 0: "Disable globalDateInEffect for this line"
+  Fix 1: "Disable globalDateInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable globalDateInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable globalDateInEffect for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable globalDateInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable globalDateInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable globalDateInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable globalDateInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable globalDateInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable globalDateInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v3/globalFetchInEffect_preview.errors.txt
+++ b/testdata/baselines/reference/effect-v3/globalFetchInEffect_preview.errors.txt
@@ -1,14 +1,17 @@
 === Metadata ===
 Effect version: 3.19.19
 
+/.src/globalFetchInEffect_preview.ts(6,38): warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `@effect/platform`. effect(globalFetchInEffect)
 
 
-==== /.src/globalFetchInEffect_preview.ts (0 errors) ====
+==== /.src/globalFetchInEffect_preview.ts (1 errors) ====
     // @effect-diagnostics *:off
     // @effect-diagnostics globalFetchInEffect:warning
     import { Effect } from "effect"
     
     export const preview = Effect.gen(function*() {
       return yield* Effect.promise(() => fetch("https://example.com"))
+                                         ~~~~~
+!!! warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `@effect/platform`. effect(globalFetchInEffect)
     })
     

--- a/testdata/baselines/reference/effect-v3/globalFetchInEffect_preview.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/globalFetchInEffect_preview.quickfixes.txt
@@ -1,5 +1,13 @@
 === Quick Fix Inventory ===
-(no diagnostics)
+
+[D1] (6:38-6:43) TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+  Fix 0: "Disable globalFetchInEffect for this line"
+  Fix 1: "Disable globalFetchInEffect for entire file"
 
 === Quick Fix Application Results ===
-(no quick fixes to apply)
+
+=== [D1] Fix 0: "Disable globalFetchInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable globalFetchInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v3/globalFetchInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v3/globalFetchInEffect_thunks.errors.txt
@@ -1,0 +1,42 @@
+=== Metadata ===
+Effect version: 3.19.19
+
+/.src/globalFetchInEffect_thunks.ts(6,40): warning TS377082: This `Effect.sync` thunk returns a Promise. Use `Effect.promise` or `Effect.tryPromise` to represent async work. effect(lazyPromiseInEffectSync)
+/.src/globalFetchInEffect_thunks.ts(6,46): warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `@effect/platform`. effect(globalFetchInEffect)
+/.src/globalFetchInEffect_thunks.ts(9,14): warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `@effect/platform`. effect(globalFetchInEffect)
+/.src/globalFetchInEffect_thunks.ts(13,64): warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `@effect/platform`. effect(globalFetchInEffect)
+/.src/globalFetchInEffect_thunks.ts(16,20): warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `@effect/platform`. effect(globalFetchInEffect)
+
+
+==== /.src/globalFetchInEffect_thunks.ts (5 errors) ====
+    // @effect-diagnostics globalFetchInEffect:warning
+    import { Data, Effect } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    export const fetchInSync = Effect.sync(() => fetch("https://example.com/sync"))
+                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377082: This `Effect.sync` thunk returns a Promise. Use `Effect.promise` or `Effect.tryPromise` to represent async work. effect(lazyPromiseInEffectSync)
+                                                 ~~~~~
+!!! warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `@effect/platform`. effect(globalFetchInEffect)
+    
+    export const fetchInTryObject = Effect.try({
+      try: () => fetch("https://example.com/try"),
+                 ~~~~~
+!!! warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `@effect/platform`. effect(globalFetchInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const fetchInTryPromise = Effect.tryPromise(async () => fetch("https://example.com/try-promise"))
+                                                                   ~~~~~
+!!! warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `@effect/platform`. effect(globalFetchInEffect)
+    
+    export const fetchInTryPromiseObject = Effect.tryPromise({
+      try: async () => fetch("https://example.com/try-promise-object"),
+                       ~~~~~
+!!! warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `@effect/platform`. effect(globalFetchInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => fetch("https://example.com/nested"))
+    

--- a/testdata/baselines/reference/effect-v3/globalFetchInEffect_thunks.flows.globalFetchInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v3/globalFetchInEffect_thunks.flows.globalFetchInEffect_thunks.mermaid
@@ -1,0 +1,43 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: Equals#lt;A, #123;#125;#gt; extends true ? void : #123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: Equals#lt;A, #123;#125;#gt; extends true ? void : #123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3((("type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: #40;#41; =#gt; fetch#40;#quot;https://example.com/sync#quot;#41;")))
+  4["type: Effect#lt;Promise#lt;Response#gt;, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  5[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  6[["type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: #40;#41; =#gt; fetch#40;#quot;https://example.com/sync#quot;#41;"]]
+  7[/"type: Promise#lt;Response#gt;<br/>node: fetch#40;#quot;https://example.com/sync#quot;#41;"/]
+  8[["type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: #40;#41; =#gt; fetch#40;#quot;https://example.com/try#quot;#41;"]]
+  9[/"type: Promise#lt;Response#gt;<br/>node: fetch#40;#quot;https://example.com/try#quot;#41;"/]
+  10[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  11[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  12[["type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: async #40;#41; =#gt; fetch#40;#quot;https://example.com/try-promise#quot;#41;"]]
+  13[/"type: Promise#lt;Response#gt;<br/>node: fetch#40;#quot;https://example.com/try-promise#quot;#41;"/]
+  14[["type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: async #40;#41; =#gt; fetch#40;#quot;https://example.com/try-promise-object#quot;#41;"]]
+  15[/"type: Promise#lt;Response#gt;<br/>node: fetch#40;#quot;https://example.com/try-promise-object#quot;#41;"/]
+  16[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  17[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  18((("type: #40;#41; =#gt; #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: #40;#41; =#gt; #40;#41; =#gt; fetch#40;#quot;https://example.com/nested#quot;#41;")))
+  19["type: Effect#lt;#40;#41; =#gt; Promise#lt;Response#gt;, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  20[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  21[["type: #40;#41; =#gt; #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: #40;#41; =#gt; #40;#41; =#gt; fetch#40;#quot;https://example.com/nested#quot;#41;"]]
+  22((("type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: #40;#41; =#gt; fetch#40;#quot;https://example.com/nested#quot;#41;")))
+  23[["type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: #40;#41; =#gt; fetch#40;#quot;https://example.com/nested#quot;#41;"]]
+  24[/"type: Promise#lt;Response#gt;<br/>node: fetch#40;#quot;https://example.com/nested#quot;#41;"/]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  7 -->|"kind: potentialReturn"| 6
+  6 -->|"kind: connect"| 3
+  9 -->|"kind: potentialReturn"| 8
+  11 -->|"kind: potentialReturn"| 10
+  13 -->|"kind: potentialReturn"| 12
+  15 -->|"kind: potentialReturn"| 14
+  17 -->|"kind: potentialReturn"| 16
+  18 -->|"kind: pipe"| 19
+  20 -->|"kind: transformCallee"| 19
+  22 -->|"kind: potentialReturn"| 21
+  21 -->|"kind: connect"| 18
+  24 -->|"kind: potentialReturn"| 23
+  23 -->|"kind: connect"| 22

--- a/testdata/baselines/reference/effect-v3/globalFetchInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v3/globalFetchInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/globalFetchInEffect_thunks.ts -> globalFetchInEffect_thunks.flows.globalFetchInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v3/globalFetchInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v3/globalFetchInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/globalFetchInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v3/globalFetchInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v3/globalFetchInEffect_thunks.pipings.txt
@@ -1,0 +1,155 @@
+==== /.src/globalFetchInEffect_thunks.ts (11 flows) ====
+
+=== Piping Flow ===
+Location: 4:27 - 4:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: Equals<A, {}> extends true ? void : { readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 6:27 - 6:80
+Node: Effect.sync(() => fetch("https://example.com/sync"))
+Node Kind: KindCallExpression
+
+Subject: () => fetch("https://example.com/sync")
+Subject Type: () => Promise<Response>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<Promise<Response>, never, never>
+
+=== Piping Flow ===
+Location: 6:45 - 6:79
+Node: fetch("https://example.com/sync")
+Node Kind: KindCallExpression
+
+Subject: "https://example.com/sync"
+Subject Type: "https://example.com/sync"
+
+Transformations (1):
+  [0] kind: call
+      callee: fetch
+      args: (constant)
+      outType: Promise<Response>
+
+=== Piping Flow ===
+Location: 8:32 - 11:3
+Node: Effect.try({\n  try: () => fetch("https://example.com/try"),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => fetch("https://example.com/try"),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<Response>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<Promise<Response>, ExampleError, never>
+
+=== Piping Flow ===
+Location: 9:13 - 9:46
+Node: fetch("https://example.com/try")
+Node Kind: KindCallExpression
+
+Subject: "https://example.com/try"
+Subject Type: "https://example.com/try"
+
+Transformations (1):
+  [0] kind: call
+      callee: fetch
+      args: (constant)
+      outType: Promise<Response>
+
+=== Piping Flow ===
+Location: 13:33 - 13:105
+Node: Effect.tryPromise(async () => fetch("https://example.com/try-promise"))
+Node Kind: KindCallExpression
+
+Subject: async () => fetch("https://example.com/try-promise")
+Subject Type: () => Promise<Response>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<Response, UnknownException, never>
+
+=== Piping Flow ===
+Location: 13:63 - 13:104
+Node: fetch("https://example.com/try-promise")
+Node Kind: KindCallExpression
+
+Subject: "https://example.com/try-promise"
+Subject Type: "https://example.com/try-promise"
+
+Transformations (1):
+  [0] kind: call
+      callee: fetch
+      args: (constant)
+      outType: Promise<Response>
+
+=== Piping Flow ===
+Location: 15:39 - 18:3
+Node: Effect.tryPromise({\n  try: async () => fetch("https://example.com/try-promise-object"),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => fetch("https://example.com/try-promise-object"),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<Response>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<Response, ExampleError, never>
+
+=== Piping Flow ===
+Location: 16:19 - 16:67
+Node: fetch("https://example.com/try-promise-object")
+Node Kind: KindCallExpression
+
+Subject: "https://example.com/try-promise-object"
+Subject Type: "https://example.com/try-promise-object"
+
+Transformations (1):
+  [0] kind: call
+      callee: fetch
+      args: (constant)
+      outType: Promise<Response>
+
+=== Piping Flow ===
+Location: 20:48 - 20:109
+Node: Effect.sync(() => () => fetch("https://example.com/nested"))
+Node Kind: KindCallExpression
+
+Subject: () => () => fetch("https://example.com/nested")
+Subject Type: () => () => Promise<Response>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => Promise<Response>, never, never>
+
+=== Piping Flow ===
+Location: 20:72 - 20:108
+Node: fetch("https://example.com/nested")
+Node Kind: KindCallExpression
+
+Subject: "https://example.com/nested"
+Subject Type: "https://example.com/nested"
+
+Transformations (1):
+  [0] kind: call
+      callee: fetch
+      args: (constant)
+      outType: Promise<Response>

--- a/testdata/baselines/reference/effect-v3/globalFetchInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/globalFetchInEffect_thunks.quickfixes.txt
@@ -1,0 +1,53 @@
+=== Quick Fix Inventory ===
+
+[D1] (6:40-6:79) TS377082: This `Effect.sync` thunk returns a Promise. Use `Effect.promise` or `Effect.tryPromise` to represent async work. effect(lazyPromiseInEffectSync)
+  Fix 0: "Disable lazyPromiseInEffectSync for this line"
+  Fix 1: "Disable lazyPromiseInEffectSync for entire file"
+
+[D2] (6:46-6:51) TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+  Fix 0: "Disable globalFetchInEffect for this line"
+  Fix 1: "Disable globalFetchInEffect for entire file"
+
+[D3] (9:14-9:19) TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+  Fix 0: "Disable globalFetchInEffect for this line"
+  Fix 1: "Disable globalFetchInEffect for entire file"
+
+[D4] (13:64-13:69) TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+  Fix 0: "Disable globalFetchInEffect for this line"
+  Fix 1: "Disable globalFetchInEffect for entire file"
+
+[D5] (16:20-16:25) TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+  Fix 0: "Disable globalFetchInEffect for this line"
+  Fix 1: "Disable globalFetchInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable lazyPromiseInEffectSync for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable lazyPromiseInEffectSync for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable globalFetchInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable globalFetchInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable globalFetchInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable globalFetchInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable globalFetchInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable globalFetchInEffect for entire file" ===
+skipped by default
+
+=== [D5] Fix 0: "Disable globalFetchInEffect for this line" ===
+skipped by default
+
+=== [D5] Fix 1: "Disable globalFetchInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v3/globalRandomInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v3/globalRandomInEffect_thunks.errors.txt
@@ -1,0 +1,39 @@
+=== Metadata ===
+Effect version: 3.19.19
+
+/.src/globalRandomInEffect_thunks.ts(6,47): warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+/.src/globalRandomInEffect_thunks.ts(9,14): warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+/.src/globalRandomInEffect_thunks.ts(13,65): warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+/.src/globalRandomInEffect_thunks.ts(16,20): warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+
+
+==== /.src/globalRandomInEffect_thunks.ts (4 errors) ====
+    // @effect-diagnostics globalRandomInEffect:warning
+    import { Data, Effect } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    export const randomInSync = Effect.sync(() => Math.random())
+                                                  ~~~~~~~~~~~~~
+!!! warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+    
+    export const randomInTryObject = Effect.try({
+      try: () => Math.random(),
+                 ~~~~~~~~~~~~~
+!!! warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const randomInTryPromise = Effect.tryPromise(async () => Math.random())
+                                                                    ~~~~~~~~~~~~~
+!!! warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+    
+    export const randomInTryPromiseObject = Effect.tryPromise({
+      try: async () => Math.random(),
+                       ~~~~~~~~~~~~~
+!!! warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => Math.random())
+    

--- a/testdata/baselines/reference/effect-v3/globalRandomInEffect_thunks.flows.globalRandomInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v3/globalRandomInEffect_thunks.flows.globalRandomInEffect_thunks.mermaid
@@ -1,0 +1,43 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: Equals#lt;A, #123;#125;#gt; extends true ? void : #123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: Equals#lt;A, #123;#125;#gt; extends true ? void : #123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3((("type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Math.random#40;#41;")))
+  4["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  5[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  6[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Math.random#40;#41;"]]
+  7[/"type: number<br/>node: Math.random#40;#41;"/]
+  8[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Math.random#40;#41;"]]
+  9[/"type: number<br/>node: Math.random#40;#41;"/]
+  10[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  11[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  12[["type: #40;#41; =#gt; Promise#lt;number#gt;<br/>node: async #40;#41; =#gt; Math.random#40;#41;"]]
+  13[/"type: number<br/>node: Math.random#40;#41;"/]
+  14[["type: #40;#41; =#gt; Promise#lt;number#gt;<br/>node: async #40;#41; =#gt; Math.random#40;#41;"]]
+  15[/"type: number<br/>node: Math.random#40;#41;"/]
+  16[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  17[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  18((("type: #40;#41; =#gt; #40;#41; =#gt; number<br/>node: #40;#41; =#gt; #40;#41; =#gt; Math.random#40;#41;")))
+  19["type: Effect#lt;#40;#41; =#gt; number, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  20[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  21[["type: #40;#41; =#gt; #40;#41; =#gt; number<br/>node: #40;#41; =#gt; #40;#41; =#gt; Math.random#40;#41;"]]
+  22((("type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Math.random#40;#41;")))
+  23[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Math.random#40;#41;"]]
+  24[/"type: number<br/>node: Math.random#40;#41;"/]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  7 -->|"kind: potentialReturn"| 6
+  6 -->|"kind: connect"| 3
+  9 -->|"kind: potentialReturn"| 8
+  11 -->|"kind: potentialReturn"| 10
+  13 -->|"kind: potentialReturn"| 12
+  15 -->|"kind: potentialReturn"| 14
+  17 -->|"kind: potentialReturn"| 16
+  18 -->|"kind: pipe"| 19
+  20 -->|"kind: transformCallee"| 19
+  22 -->|"kind: potentialReturn"| 21
+  21 -->|"kind: connect"| 18
+  24 -->|"kind: potentialReturn"| 23
+  23 -->|"kind: connect"| 22

--- a/testdata/baselines/reference/effect-v3/globalRandomInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v3/globalRandomInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/globalRandomInEffect_thunks.ts -> globalRandomInEffect_thunks.flows.globalRandomInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v3/globalRandomInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v3/globalRandomInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/globalRandomInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v3/globalRandomInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v3/globalRandomInEffect_thunks.pipings.txt
@@ -1,0 +1,85 @@
+==== /.src/globalRandomInEffect_thunks.ts (6 flows) ====
+
+=== Piping Flow ===
+Location: 4:27 - 4:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: Equals<A, {}> extends true ? void : { readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 6:28 - 6:61
+Node: Effect.sync(() => Math.random())
+Node Kind: KindCallExpression
+
+Subject: () => Math.random()
+Subject Type: () => number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 8:33 - 11:3
+Node: Effect.try({\n  try: () => Math.random(),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => Math.random(),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => number; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<number, ExampleError, never>
+
+=== Piping Flow ===
+Location: 13:34 - 13:79
+Node: Effect.tryPromise(async () => Math.random())
+Node Kind: KindCallExpression
+
+Subject: async () => Math.random()
+Subject Type: () => Promise<number>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<number, UnknownException, never>
+
+=== Piping Flow ===
+Location: 15:40 - 18:3
+Node: Effect.tryPromise({\n  try: async () => Math.random(),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => Math.random(),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<number>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<number, ExampleError, never>
+
+=== Piping Flow ===
+Location: 20:48 - 20:87
+Node: Effect.sync(() => () => Math.random())
+Node Kind: KindCallExpression
+
+Subject: () => () => Math.random()
+Subject Type: () => () => number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => number, never, never>

--- a/testdata/baselines/reference/effect-v3/globalRandomInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/globalRandomInEffect_thunks.quickfixes.txt
@@ -1,0 +1,43 @@
+=== Quick Fix Inventory ===
+
+[D1] (6:47-6:60) TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+  Fix 0: "Disable globalRandomInEffect for this line"
+  Fix 1: "Disable globalRandomInEffect for entire file"
+
+[D2] (9:14-9:27) TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+  Fix 0: "Disable globalRandomInEffect for this line"
+  Fix 1: "Disable globalRandomInEffect for entire file"
+
+[D3] (13:65-13:78) TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+  Fix 0: "Disable globalRandomInEffect for this line"
+  Fix 1: "Disable globalRandomInEffect for entire file"
+
+[D4] (16:20-16:33) TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+  Fix 0: "Disable globalRandomInEffect for this line"
+  Fix 1: "Disable globalRandomInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable globalRandomInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable globalRandomInEffect for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable globalRandomInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable globalRandomInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable globalRandomInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable globalRandomInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable globalRandomInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable globalRandomInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v3/globalTimersInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v3/globalTimersInEffect_thunks.errors.txt
@@ -1,0 +1,39 @@
+=== Metadata ===
+Effect version: 3.19.19
+
+/.src/globalTimersInEffect_thunks.ts(6,48): warning TS377073: This Effect code uses `setTimeout`, the corresponding timer API in this context is `Effect.sleep or Schedule` from Effect. effect(globalTimersInEffect)
+/.src/globalTimersInEffect_thunks.ts(9,14): warning TS377073: This Effect code uses `setInterval`, the corresponding timer API in this context is `Schedule or Effect.repeat` from Effect. effect(globalTimersInEffect)
+/.src/globalTimersInEffect_thunks.ts(13,66): warning TS377073: This Effect code uses `setTimeout`, the corresponding timer API in this context is `Effect.sleep or Schedule` from Effect. effect(globalTimersInEffect)
+/.src/globalTimersInEffect_thunks.ts(16,20): warning TS377073: This Effect code uses `setInterval`, the corresponding timer API in this context is `Schedule or Effect.repeat` from Effect. effect(globalTimersInEffect)
+
+
+==== /.src/globalTimersInEffect_thunks.ts (4 errors) ====
+    // @effect-diagnostics globalTimersInEffect:warning
+    import { Data, Effect } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    export const timeoutInSync = Effect.sync(() => setTimeout(() => {}, 100))
+                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377073: This Effect code uses `setTimeout`, the corresponding timer API in this context is `Effect.sleep or Schedule` from Effect. effect(globalTimersInEffect)
+    
+    export const intervalInTryObject = Effect.try({
+      try: () => setInterval(() => {}, 100),
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377073: This Effect code uses `setInterval`, the corresponding timer API in this context is `Schedule or Effect.repeat` from Effect. effect(globalTimersInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const timeoutInTryPromise = Effect.tryPromise(async () => setTimeout(() => {}, 100))
+                                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377073: This Effect code uses `setTimeout`, the corresponding timer API in this context is `Effect.sleep or Schedule` from Effect. effect(globalTimersInEffect)
+    
+    export const intervalInTryPromiseObject = Effect.tryPromise({
+      try: async () => setInterval(() => {}, 100),
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377073: This Effect code uses `setInterval`, the corresponding timer API in this context is `Schedule or Effect.repeat` from Effect. effect(globalTimersInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => setTimeout(() => {}, 100))
+    

--- a/testdata/baselines/reference/effect-v3/globalTimersInEffect_thunks.flows.globalTimersInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v3/globalTimersInEffect_thunks.flows.globalTimersInEffect_thunks.mermaid
@@ -1,0 +1,48 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: Equals#lt;A, #123;#125;#gt; extends true ? void : #123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: Equals#lt;A, #123;#125;#gt; extends true ? void : #123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3((("type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;")))
+  4["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  5[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  6[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;"]]
+  7[/"type: number<br/>node: setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;"/]
+  8[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #123;#125;"]]
+  9[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; setInterval#40;#40;#41; =#gt; #123;#125;, 100#41;"]]
+  10[/"type: number<br/>node: setInterval#40;#40;#41; =#gt; #123;#125;, 100#41;"/]
+  11[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #123;#125;"]]
+  12[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  13[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  14[["type: #40;#41; =#gt; Promise#lt;number#gt;<br/>node: async #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;"]]
+  15[/"type: number<br/>node: setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;"/]
+  16[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #123;#125;"]]
+  17[["type: #40;#41; =#gt; Promise#lt;number#gt;<br/>node: async #40;#41; =#gt; setInterval#40;#40;#41; =#gt; #123;#125;, 100#41;"]]
+  18[/"type: number<br/>node: setInterval#40;#40;#41; =#gt; #123;#125;, 100#41;"/]
+  19[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #123;#125;"]]
+  20[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  21[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  22((("type: #40;#41; =#gt; #40;#41; =#gt; number<br/>node: #40;#41; =#gt; #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;")))
+  23["type: Effect#lt;#40;#41; =#gt; number, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  24[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  25[["type: #40;#41; =#gt; #40;#41; =#gt; number<br/>node: #40;#41; =#gt; #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;"]]
+  26((("type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;")))
+  27[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;"]]
+  28[/"type: number<br/>node: setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;"/]
+  29[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #123;#125;"]]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  7 -->|"kind: potentialReturn"| 6
+  6 -->|"kind: connect"| 3
+  10 -->|"kind: potentialReturn"| 9
+  13 -->|"kind: potentialReturn"| 12
+  15 -->|"kind: potentialReturn"| 14
+  18 -->|"kind: potentialReturn"| 17
+  21 -->|"kind: potentialReturn"| 20
+  22 -->|"kind: pipe"| 23
+  24 -->|"kind: transformCallee"| 23
+  26 -->|"kind: potentialReturn"| 25
+  25 -->|"kind: connect"| 22
+  28 -->|"kind: potentialReturn"| 27
+  27 -->|"kind: connect"| 26

--- a/testdata/baselines/reference/effect-v3/globalTimersInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v3/globalTimersInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/globalTimersInEffect_thunks.ts -> globalTimersInEffect_thunks.flows.globalTimersInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v3/globalTimersInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v3/globalTimersInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/globalTimersInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v3/globalTimersInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v3/globalTimersInEffect_thunks.pipings.txt
@@ -1,0 +1,85 @@
+==== /.src/globalTimersInEffect_thunks.ts (6 flows) ====
+
+=== Piping Flow ===
+Location: 4:27 - 4:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: Equals<A, {}> extends true ? void : { readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 6:29 - 6:74
+Node: Effect.sync(() => setTimeout(() => {}, 100))
+Node Kind: KindCallExpression
+
+Subject: () => setTimeout(() => {}, 100)
+Subject Type: () => number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 8:35 - 11:3
+Node: Effect.try({\n  try: () => setInterval(() => {}, 100),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => setInterval(() => {}, 100),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => number; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<number, ExampleError, never>
+
+=== Piping Flow ===
+Location: 13:35 - 13:92
+Node: Effect.tryPromise(async () => setTimeout(() => {}, 100))
+Node Kind: KindCallExpression
+
+Subject: async () => setTimeout(() => {}, 100)
+Subject Type: () => Promise<number>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<number, UnknownException, never>
+
+=== Piping Flow ===
+Location: 15:42 - 18:3
+Node: Effect.tryPromise({\n  try: async () => setInterval(() => {}, 100),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => setInterval(() => {}, 100),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<number>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<number, ExampleError, never>
+
+=== Piping Flow ===
+Location: 20:48 - 20:99
+Node: Effect.sync(() => () => setTimeout(() => {}, 100))
+Node Kind: KindCallExpression
+
+Subject: () => () => setTimeout(() => {}, 100)
+Subject Type: () => () => number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => number, never, never>

--- a/testdata/baselines/reference/effect-v3/globalTimersInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/globalTimersInEffect_thunks.quickfixes.txt
@@ -1,0 +1,43 @@
+=== Quick Fix Inventory ===
+
+[D1] (6:48-6:73) TS377073: This Effect code uses `setTimeout`, the corresponding timer API in this context is `Effect.sleep or Schedule` from Effect. effect(globalTimersInEffect)
+  Fix 0: "Disable globalTimersInEffect for this line"
+  Fix 1: "Disable globalTimersInEffect for entire file"
+
+[D2] (9:14-9:40) TS377073: This Effect code uses `setInterval`, the corresponding timer API in this context is `Schedule or Effect.repeat` from Effect. effect(globalTimersInEffect)
+  Fix 0: "Disable globalTimersInEffect for this line"
+  Fix 1: "Disable globalTimersInEffect for entire file"
+
+[D3] (13:66-13:91) TS377073: This Effect code uses `setTimeout`, the corresponding timer API in this context is `Effect.sleep or Schedule` from Effect. effect(globalTimersInEffect)
+  Fix 0: "Disable globalTimersInEffect for this line"
+  Fix 1: "Disable globalTimersInEffect for entire file"
+
+[D4] (16:20-16:46) TS377073: This Effect code uses `setInterval`, the corresponding timer API in this context is `Schedule or Effect.repeat` from Effect. effect(globalTimersInEffect)
+  Fix 0: "Disable globalTimersInEffect for this line"
+  Fix 1: "Disable globalTimersInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable globalTimersInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable globalTimersInEffect for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable globalTimersInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable globalTimersInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable globalTimersInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable globalTimersInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable globalTimersInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable globalTimersInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v3/preferSchemaOverJson.errors.txt
+++ b/testdata/baselines/reference/effect-v3/preferSchemaOverJson.errors.txt
@@ -12,9 +12,10 @@ Effect version: 3.19.19
 /.src/preferSchemaOverJson.ts(25,18): suggestion TS377026: This code uses `JSON.parse` or `JSON.stringify`. Effect Schema provides Effect-aware APIs for JSON parsing and stringifying. effect(preferSchemaOverJson)
 /.src/preferSchemaOverJson.ts(33,16): suggestion TS377026: This code uses `JSON.parse` or `JSON.stringify`. Effect Schema provides Effect-aware APIs for JSON parsing and stringifying. effect(preferSchemaOverJson)
 /.src/preferSchemaOverJson.ts(41,18): suggestion TS377026: This code uses `JSON.parse` or `JSON.stringify`. Effect Schema provides Effect-aware APIs for JSON parsing and stringifying. effect(preferSchemaOverJson)
+/.src/preferSchemaOverJson.ts(61,18): suggestion TS377026: This code uses `JSON.parse` or `JSON.stringify`. Effect Schema provides Effect-aware APIs for JSON parsing and stringifying. effect(preferSchemaOverJson)
 
 
-==== /.src/preferSchemaOverJson.ts (11 errors) ====
+==== /.src/preferSchemaOverJson.ts (12 errors) ====
     // @effect-v3
     import { Effect } from "effect"
     
@@ -98,6 +99,8 @@ Effect version: 3.19.19
     // Should NOT trigger - JSON.parse not as direct expression in Effect.try
     export const notDirectExpression = Effect.try(() => {
       const parsed = JSON.parse("{\"indirect\":true}")
+                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! suggestion TS377026: This code uses `JSON.parse` or `JSON.stringify`. Effect Schema provides Effect-aware APIs for JSON parsing and stringifying. effect(preferSchemaOverJson)
       return parsed.indirect
     })
     

--- a/testdata/baselines/reference/effect-v3/preferSchemaOverJson.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/preferSchemaOverJson.quickfixes.txt
@@ -47,6 +47,10 @@
 [D12] (47:7-47:20) TS6133: '_regularParse' is declared but its value is never read.
   (no quick fixes)
 
+[D13] (61:18-61:51) TS377026: This code uses `JSON.parse` or `JSON.stringify`. Effect Schema provides Effect-aware APIs for JSON parsing and stringifying. effect(preferSchemaOverJson)
+  Fix 0: "Disable preferSchemaOverJson for this line"
+  Fix 1: "Disable preferSchemaOverJson for entire file"
+
 === Quick Fix Application Results ===
 
 === [D1] Fix 0: "Disable preferSchemaOverJson for this line" ===
@@ -113,4 +117,10 @@ skipped by default
 skipped by default
 
 === [D11] Fix 1: "Disable preferSchemaOverJson for entire file" ===
+skipped by default
+
+=== [D13] Fix 0: "Disable preferSchemaOverJson for this line" ===
+skipped by default
+
+=== [D13] Fix 1: "Disable preferSchemaOverJson for entire file" ===
 skipped by default

--- a/testdata/baselines/reference/effect-v3/processEnvInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v3/processEnvInEffect_thunks.errors.txt
@@ -1,0 +1,40 @@
+=== Metadata ===
+Effect version: 3.19.19
+
+/.src/processEnvInEffect_thunks.ts(7,44): warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+/.src/processEnvInEffect_thunks.ts(10,14): warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+/.src/processEnvInEffect_thunks.ts(14,62): warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+/.src/processEnvInEffect_thunks.ts(17,20): warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+
+
+==== /.src/processEnvInEffect_thunks.ts (4 errors) ====
+    // @effect-diagnostics processEnvInEffect:warning
+    /// <reference types="node" />
+    import { Data, Effect } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    export const envInSync = Effect.sync(() => process.env.SYNC_SECRET)
+                                               ~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+    
+    export const envInTryObject = Effect.try({
+      try: () => process.env.TRY_SECRET,
+                 ~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const envInTryPromise = Effect.tryPromise(async () => process.env.TRY_PROMISE_SECRET)
+                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+    
+    export const envInTryPromiseObject = Effect.tryPromise({
+      try: async () => process.env.TRY_PROMISE_OBJECT_SECRET,
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => process.env.NESTED_SECRET)
+    

--- a/testdata/baselines/reference/effect-v3/processEnvInEffect_thunks.flows.processEnvInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v3/processEnvInEffect_thunks.flows.processEnvInEffect_thunks.mermaid
@@ -1,0 +1,43 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: Equals#lt;A, #123;#125;#gt; extends true ? void : #123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: Equals#lt;A, #123;#125;#gt; extends true ? void : #123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3((("type: #40;#41; =#gt; string #124; undefined<br/>node: #40;#41; =#gt; process.env.SYNC_SECRET")))
+  4["type: Effect#lt;string #124; undefined, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  5[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  6[["type: #40;#41; =#gt; string #124; undefined<br/>node: #40;#41; =#gt; process.env.SYNC_SECRET"]]
+  7[/"type: string #124; undefined<br/>node: process.env.SYNC_SECRET"/]
+  8[["type: #40;#41; =#gt; string #124; undefined<br/>node: #40;#41; =#gt; process.env.TRY_SECRET"]]
+  9[/"type: string #124; undefined<br/>node: process.env.TRY_SECRET"/]
+  10[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  11[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  12[["type: #40;#41; =#gt; Promise#lt;string #124; undefined#gt;<br/>node: async #40;#41; =#gt; process.env.TRY_PROMISE_SECRET"]]
+  13[/"type: string #124; undefined<br/>node: process.env.TRY_PROMISE_SECRET"/]
+  14[["type: #40;#41; =#gt; Promise#lt;string #124; undefined#gt;<br/>node: async #40;#41; =#gt; process.env.TRY_PROMISE_OBJECT_SECRET"]]
+  15[/"type: string #124; undefined<br/>node: process.env.TRY_PROMISE_OBJECT_SECRET"/]
+  16[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  17[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  18((("type: #40;#41; =#gt; #40;#41; =#gt; string #124; undefined<br/>node: #40;#41; =#gt; #40;#41; =#gt; process.env.NESTED_SECRET")))
+  19["type: Effect#lt;#40;#41; =#gt; string #124; undefined, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  20[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  21[["type: #40;#41; =#gt; #40;#41; =#gt; string #124; undefined<br/>node: #40;#41; =#gt; #40;#41; =#gt; process.env.NESTED_SECRET"]]
+  22((("type: #40;#41; =#gt; string #124; undefined<br/>node: #40;#41; =#gt; process.env.NESTED_SECRET")))
+  23[["type: #40;#41; =#gt; string #124; undefined<br/>node: #40;#41; =#gt; process.env.NESTED_SECRET"]]
+  24[/"type: string #124; undefined<br/>node: process.env.NESTED_SECRET"/]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  7 -->|"kind: potentialReturn"| 6
+  6 -->|"kind: connect"| 3
+  9 -->|"kind: potentialReturn"| 8
+  11 -->|"kind: potentialReturn"| 10
+  13 -->|"kind: potentialReturn"| 12
+  15 -->|"kind: potentialReturn"| 14
+  17 -->|"kind: potentialReturn"| 16
+  18 -->|"kind: pipe"| 19
+  20 -->|"kind: transformCallee"| 19
+  22 -->|"kind: potentialReturn"| 21
+  21 -->|"kind: connect"| 18
+  24 -->|"kind: potentialReturn"| 23
+  23 -->|"kind: connect"| 22

--- a/testdata/baselines/reference/effect-v3/processEnvInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v3/processEnvInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/processEnvInEffect_thunks.ts -> processEnvInEffect_thunks.flows.processEnvInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v3/processEnvInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v3/processEnvInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/processEnvInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v3/processEnvInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v3/processEnvInEffect_thunks.pipings.txt
@@ -1,0 +1,85 @@
+==== /.src/processEnvInEffect_thunks.ts (6 flows) ====
+
+=== Piping Flow ===
+Location: 5:27 - 5:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: Equals<A, {}> extends true ? void : { readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 7:25 - 7:68
+Node: Effect.sync(() => process.env.SYNC_SECRET)
+Node Kind: KindCallExpression
+
+Subject: () => process.env.SYNC_SECRET
+Subject Type: () => string | undefined
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<string | undefined, never, never>
+
+=== Piping Flow ===
+Location: 9:30 - 12:3
+Node: Effect.try({\n  try: () => process.env.TRY_SECRET,\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => process.env.TRY_SECRET,\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => string | undefined; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<string | undefined, ExampleError, never>
+
+=== Piping Flow ===
+Location: 14:31 - 14:93
+Node: Effect.tryPromise(async () => process.env.TRY_PROMISE_SECRET)
+Node Kind: KindCallExpression
+
+Subject: async () => process.env.TRY_PROMISE_SECRET
+Subject Type: () => Promise<string | undefined>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<string | undefined, UnknownException, never>
+
+=== Piping Flow ===
+Location: 16:37 - 19:3
+Node: Effect.tryPromise({\n  try: async () => process.env.TRY_PROMISE_OBJECT_SECRET,\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => process.env.TRY_PROMISE_OBJECT_SECRET,\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<string | undefined>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<string | undefined, ExampleError, never>
+
+=== Piping Flow ===
+Location: 21:48 - 21:99
+Node: Effect.sync(() => () => process.env.NESTED_SECRET)
+Node Kind: KindCallExpression
+
+Subject: () => () => process.env.NESTED_SECRET
+Subject Type: () => () => string | undefined
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => string | undefined, never, never>

--- a/testdata/baselines/reference/effect-v3/processEnvInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/processEnvInEffect_thunks.quickfixes.txt
@@ -1,0 +1,43 @@
+=== Quick Fix Inventory ===
+
+[D1] (7:44-7:67) TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+  Fix 0: "Disable processEnvInEffect for this line"
+  Fix 1: "Disable processEnvInEffect for entire file"
+
+[D2] (10:14-10:36) TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+  Fix 0: "Disable processEnvInEffect for this line"
+  Fix 1: "Disable processEnvInEffect for entire file"
+
+[D3] (14:62-14:92) TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+  Fix 0: "Disable processEnvInEffect for this line"
+  Fix 1: "Disable processEnvInEffect for entire file"
+
+[D4] (17:20-17:57) TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+  Fix 0: "Disable processEnvInEffect for this line"
+  Fix 1: "Disable processEnvInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable processEnvInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable processEnvInEffect for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable processEnvInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable processEnvInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable processEnvInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable processEnvInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable processEnvInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable processEnvInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v3/schemaSyncInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v3/schemaSyncInEffect_thunks.errors.txt
@@ -1,0 +1,45 @@
+=== Metadata ===
+Effect version: 3.19.19
+
+/.src/schemaSyncInEffect_thunks.ts(10,47): suggestion TS377037: `Schema.decodeSync` is used inside an Effect generator. `Schema.decode` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+/.src/schemaSyncInEffect_thunks.ts(13,14): suggestion TS377037: `Schema.decodeSync` is used inside an Effect generator. `Schema.decode` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+/.src/schemaSyncInEffect_thunks.ts(17,65): suggestion TS377037: `Schema.encodeSync` is used inside an Effect generator. `Schema.encode` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+/.src/schemaSyncInEffect_thunks.ts(20,20): suggestion TS377037: `Schema.encodeUnknownSync` is used inside an Effect generator. `Schema.encodeUnknown` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+
+
+==== /.src/schemaSyncInEffect_thunks.ts (4 errors) ====
+    import { Data, Effect, Schema } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    const Person = Schema.Struct({
+      name: Schema.String,
+      age: Schema.Number
+    })
+    
+    export const decodeInSync = Effect.sync(() => Schema.decodeSync(Person)({ name: "John", age: 30 }))
+                                                  ~~~~~~~~~~~~~~~~~
+!!! suggestion TS377037: `Schema.decodeSync` is used inside an Effect generator. `Schema.decode` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+    
+    export const decodeInTryObject = Effect.try({
+      try: () => Schema.decodeSync(Person)({ name: "Jane", age: 25 }),
+                 ~~~~~~~~~~~~~~~~~
+!!! suggestion TS377037: `Schema.decodeSync` is used inside an Effect generator. `Schema.decode` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const encodeInTryPromise = Effect.tryPromise(async () => Schema.encodeSync(Person)({ name: "Bob", age: 40 }))
+                                                                    ~~~~~~~~~~~~~~~~~
+!!! suggestion TS377037: `Schema.encodeSync` is used inside an Effect generator. `Schema.encode` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+    
+    export const encodeInTryPromiseObject = Effect.tryPromise({
+      try: async () => Schema.encodeUnknownSync(Person)({ name: "Carol", age: 50 }),
+                       ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! suggestion TS377037: `Schema.encodeUnknownSync` is used inside an Effect generator. `Schema.encodeUnknown` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(
+      () => () => Schema.decodeSync(Person)({ name: "Nested", age: 10 })
+    )
+    

--- a/testdata/baselines/reference/effect-v3/schemaSyncInEffect_thunks.flows.schemaSyncInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v3/schemaSyncInEffect_thunks.flows.schemaSyncInEffect_thunks.mermaid
@@ -1,0 +1,43 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: Equals#lt;A, #123;#125;#gt; extends true ? void : #123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: Equals#lt;A, #123;#125;#gt; extends true ? void : #123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3((("type: #40;#41; =#gt; #123; readonly name: string; readonly age: number; #125;<br/>node: #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;John#quot;, age: 30 #125;#41;")))
+  4["type: Effect#lt;#123; readonly name: string; readonly age: number; #125;, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  5[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  6[["type: #40;#41; =#gt; #123; readonly name: string; readonly age: number; #125;<br/>node: #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;John#quot;, age: 30 #125;#41;"]]
+  7[/"type: #123; readonly name: string; readonly age: number; #125;<br/>node: Schema.decodeSync#40;Person#41;#40;#123; name: #quot;John#quot;, age: 30 #125;#41;"/]
+  8[["type: #40;#41; =#gt; #123; readonly name: string; readonly age: number; #125;<br/>node: #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Jane#quot;, age: 25 #125;#41;"]]
+  9[/"type: #123; readonly name: string; readonly age: number; #125;<br/>node: Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Jane#quot;, age: 25 #125;#41;"/]
+  10[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  11[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  12[["type: #40;#41; =#gt; Promise#lt;#123; readonly age: number; readonly name: string; #125;#gt;<br/>node: async #40;#41; =#gt; Schema.encodeSync#40;Person#41;#40;#123; name: #quot;Bob#quot;, age: 40 #125;#41;"]]
+  13[/"type: #123; readonly age: number; readonly name: string; #125;<br/>node: Schema.encodeSync#40;Person#41;#40;#123; name: #quot;Bob#quot;, age: 40 #125;#41;"/]
+  14[["type: #40;#41; =#gt; Promise#lt;#123; readonly age: number; readonly name: string; #125;#gt;<br/>node: async #40;#41; =#gt; Schema.encodeUnknownSync#40;Person#41;#40;#123; name: #quot;Carol#quot;, age: 50 #125;#41;"]]
+  15[/"type: #123; readonly age: number; readonly name: string; #125;<br/>node: Schema.encodeUnknownSync#40;Person#41;#40;#123; name: #quot;Carol#quot;, age: 50 #125;#41;"/]
+  16[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  17[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  18((("type: #40;#41; =#gt; #40;#41; =#gt; #123; readonly name: string; readonly age: number; #125;<br/>node: #40;#41; =#gt; #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Nested#quot;, age: 10 #125;#41;")))
+  19["type: Effect#lt;#40;#41; =#gt; #123; readonly name: string; readonly age: number; #125;, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  20[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  21[["type: #40;#41; =#gt; #40;#41; =#gt; #123; readonly name: string; readonly age: number; #125;<br/>node: #40;#41; =#gt; #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Nested#quot;, age: 10 #125;#41;"]]
+  22((("type: #40;#41; =#gt; #123; readonly name: string; readonly age: number; #125;<br/>node: #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Nested#quot;, age: 10 #125;#41;")))
+  23[["type: #40;#41; =#gt; #123; readonly name: string; readonly age: number; #125;<br/>node: #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Nested#quot;, age: 10 #125;#41;"]]
+  24[/"type: #123; readonly name: string; readonly age: number; #125;<br/>node: Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Nested#quot;, age: 10 #125;#41;"/]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  7 -->|"kind: potentialReturn"| 6
+  6 -->|"kind: connect"| 3
+  9 -->|"kind: potentialReturn"| 8
+  11 -->|"kind: potentialReturn"| 10
+  13 -->|"kind: potentialReturn"| 12
+  15 -->|"kind: potentialReturn"| 14
+  17 -->|"kind: potentialReturn"| 16
+  18 -->|"kind: pipe"| 19
+  20 -->|"kind: transformCallee"| 19
+  22 -->|"kind: potentialReturn"| 21
+  21 -->|"kind: connect"| 18
+  24 -->|"kind: potentialReturn"| 23
+  23 -->|"kind: connect"| 22

--- a/testdata/baselines/reference/effect-v3/schemaSyncInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v3/schemaSyncInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/schemaSyncInEffect_thunks.ts -> schemaSyncInEffect_thunks.flows.schemaSyncInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v3/schemaSyncInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v3/schemaSyncInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/schemaSyncInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v3/schemaSyncInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v3/schemaSyncInEffect_thunks.pipings.txt
@@ -1,0 +1,169 @@
+==== /.src/schemaSyncInEffect_thunks.ts (12 flows) ====
+
+=== Piping Flow ===
+Location: 3:27 - 3:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: Equals<A, {}> extends true ? void : { readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 5:15 - 8:3
+Node: Schema.Struct({\n  name: Schema.String,\n  age: Schema.Number\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  name: Schema.String,\n  age: Schema.Number\n}
+Subject Type: { name: typeof String$; age: typeof Number$; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.Struct
+      args: (constant)
+      outType: Struct<{ name: typeof String$; age: typeof Number$; }>
+
+=== Piping Flow ===
+Location: 10:28 - 10:100
+Node: Effect.sync(() => Schema.decodeSync(Person)({ name: "John", age: 30 }))
+Node Kind: KindCallExpression
+
+Subject: () => Schema.decodeSync(Person)({ name: "John", age: 30 })
+Subject Type: () => { readonly name: string; readonly age: number; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<{ readonly name: string; readonly age: number; }, never, never>
+
+=== Piping Flow ===
+Location: 10:46 - 10:99
+Node: Schema.decodeSync(Person)({ name: "John", age: 30 })
+Node Kind: KindCallExpression
+
+Subject: { name: "John", age: 30 }
+Subject Type: { name: string; age: number; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.decodeSync(Person)
+      args: (constant)
+      outType: { readonly name: string; readonly age: number; }
+
+=== Piping Flow ===
+Location: 12:33 - 15:3
+Node: Effect.try({\n  try: () => Schema.decodeSync(Person)({ name: "Jane", age: 25 }),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => Schema.decodeSync(Person)({ name: "Jane", age: 25 }),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => { readonly name: string; readonly age: number; }; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<{ readonly name: string; readonly age: number; }, ExampleError, never>
+
+=== Piping Flow ===
+Location: 13:13 - 13:66
+Node: Schema.decodeSync(Person)({ name: "Jane", age: 25 })
+Node Kind: KindCallExpression
+
+Subject: { name: "Jane", age: 25 }
+Subject Type: { name: string; age: number; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.decodeSync(Person)
+      args: (constant)
+      outType: { readonly name: string; readonly age: number; }
+
+=== Piping Flow ===
+Location: 17:34 - 17:117
+Node: Effect.tryPromise(async () => Schema.encodeSync(Person)({ name: "Bob", age: 40 }))
+Node Kind: KindCallExpression
+
+Subject: async () => Schema.encodeSync(Person)({ name: "Bob", age: 40 })
+Subject Type: () => Promise<{ readonly age: number; readonly name: string; }>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<{ readonly age: number; readonly name: string; }, UnknownException, never>
+
+=== Piping Flow ===
+Location: 17:64 - 17:116
+Node: Schema.encodeSync(Person)({ name: "Bob", age: 40 })
+Node Kind: KindCallExpression
+
+Subject: { name: "Bob", age: 40 }
+Subject Type: { name: string; age: number; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.encodeSync(Person)
+      args: (constant)
+      outType: { readonly age: number; readonly name: string; }
+
+=== Piping Flow ===
+Location: 19:40 - 22:3
+Node: Effect.tryPromise({\n  try: async () => Schema.encodeUnknownSync(Person)({ name: "Carol", age: 50 }),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => Schema.encodeUnknownSync(Person)({ name: "Carol", age: 50 }),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<{ readonly age: number; readonly name: string; }>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<{ readonly age: number; readonly name: string; }, ExampleError, never>
+
+=== Piping Flow ===
+Location: 20:19 - 20:80
+Node: Schema.encodeUnknownSync(Person)({ name: "Carol", age: 50 })
+Node Kind: KindCallExpression
+
+Subject: { name: "Carol", age: 50 }
+Subject Type: { name: string; age: number; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.encodeUnknownSync(Person)
+      args: (constant)
+      outType: { readonly age: number; readonly name: string; }
+
+=== Piping Flow ===
+Location: 24:48 - 26:2
+Node: Effect.sync(\n  () => () => Schema.decodeSync(Person)({ name: "Nested", age: 10 })\n)
+Node Kind: KindCallExpression
+
+Subject: () => () => Schema.decodeSync(Person)({ name: "Nested", age: 10 })
+Subject Type: () => () => { readonly name: string; readonly age: number; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => { readonly name: string; readonly age: number; }, never, never>
+
+=== Piping Flow ===
+Location: 25:14 - 25:69
+Node: Schema.decodeSync(Person)({ name: "Nested", age: 10 })
+Node Kind: KindCallExpression
+
+Subject: { name: "Nested", age: 10 }
+Subject Type: { name: string; age: number; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.decodeSync(Person)
+      args: (constant)
+      outType: { readonly name: string; readonly age: number; }

--- a/testdata/baselines/reference/effect-v3/schemaSyncInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/schemaSyncInEffect_thunks.quickfixes.txt
@@ -1,0 +1,43 @@
+=== Quick Fix Inventory ===
+
+[D1] (10:47-10:64) TS377037: `Schema.decodeSync` is used inside an Effect generator. `Schema.decodeEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+  Fix 0: "Disable schemaSyncInEffect for this line"
+  Fix 1: "Disable schemaSyncInEffect for entire file"
+
+[D2] (13:14-13:31) TS377037: `Schema.decodeSync` is used inside an Effect generator. `Schema.decodeEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+  Fix 0: "Disable schemaSyncInEffect for this line"
+  Fix 1: "Disable schemaSyncInEffect for entire file"
+
+[D3] (17:65-17:82) TS377037: `Schema.encodeSync` is used inside an Effect generator. `Schema.encodeEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+  Fix 0: "Disable schemaSyncInEffect for this line"
+  Fix 1: "Disable schemaSyncInEffect for entire file"
+
+[D4] (20:20-20:44) TS377037: `Schema.encodeUnknownSync` is used inside an Effect generator. `Schema.encodeUnknownEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+  Fix 0: "Disable schemaSyncInEffect for this line"
+  Fix 1: "Disable schemaSyncInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable schemaSyncInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable schemaSyncInEffect for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable schemaSyncInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable schemaSyncInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable schemaSyncInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable schemaSyncInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable schemaSyncInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable schemaSyncInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v4/cryptoRandomUUIDInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v4/cryptoRandomUUIDInEffect_thunks.errors.txt
@@ -1,0 +1,39 @@
+=== Metadata ===
+Effect version: 4.0.0
+
+/.src/cryptoRandomUUIDInEffect_thunks.ts(6,45): warning TS377079: This Effect code uses `crypto.randomUUID()`, prefer the Effect `Random` module instead because it uses Effect-injected randomness rather than the `crypto` module behind the scenes. effect(cryptoRandomUUIDInEffect)
+/.src/cryptoRandomUUIDInEffect_thunks.ts(9,14): warning TS377079: This Effect code uses `crypto.randomUUID()`, prefer the Effect `Random` module instead because it uses Effect-injected randomness rather than the `crypto` module behind the scenes. effect(cryptoRandomUUIDInEffect)
+/.src/cryptoRandomUUIDInEffect_thunks.ts(13,63): warning TS377079: This Effect code uses `crypto.randomUUID()`, prefer the Effect `Random` module instead because it uses Effect-injected randomness rather than the `crypto` module behind the scenes. effect(cryptoRandomUUIDInEffect)
+/.src/cryptoRandomUUIDInEffect_thunks.ts(16,20): warning TS377079: This Effect code uses `crypto.randomUUID()`, prefer the Effect `Random` module instead because it uses Effect-injected randomness rather than the `crypto` module behind the scenes. effect(cryptoRandomUUIDInEffect)
+
+
+==== /.src/cryptoRandomUUIDInEffect_thunks.ts (4 errors) ====
+    // @effect-diagnostics cryptoRandomUUIDInEffect:warning
+    import { Data, Effect } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    export const uuidInSync = Effect.sync(() => crypto.randomUUID())
+                                                ~~~~~~~~~~~~~~~~~~~
+!!! warning TS377079: This Effect code uses `crypto.randomUUID()`, prefer the Effect `Random` module instead because it uses Effect-injected randomness rather than the `crypto` module behind the scenes. effect(cryptoRandomUUIDInEffect)
+    
+    export const uuidInTryObject = Effect.try({
+      try: () => crypto.randomUUID(),
+                 ~~~~~~~~~~~~~~~~~~~
+!!! warning TS377079: This Effect code uses `crypto.randomUUID()`, prefer the Effect `Random` module instead because it uses Effect-injected randomness rather than the `crypto` module behind the scenes. effect(cryptoRandomUUIDInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const uuidInTryPromise = Effect.tryPromise(async () => crypto.randomUUID())
+                                                                  ~~~~~~~~~~~~~~~~~~~
+!!! warning TS377079: This Effect code uses `crypto.randomUUID()`, prefer the Effect `Random` module instead because it uses Effect-injected randomness rather than the `crypto` module behind the scenes. effect(cryptoRandomUUIDInEffect)
+    
+    export const uuidInTryPromiseObject = Effect.tryPromise({
+      try: async () => crypto.randomUUID(),
+                       ~~~~~~~~~~~~~~~~~~~
+!!! warning TS377079: This Effect code uses `crypto.randomUUID()`, prefer the Effect `Random` module instead because it uses Effect-injected randomness rather than the `crypto` module behind the scenes. effect(cryptoRandomUUIDInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => crypto.randomUUID())
+    

--- a/testdata/baselines/reference/effect-v4/cryptoRandomUUIDInEffect_thunks.flows.cryptoRandomUUIDInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v4/cryptoRandomUUIDInEffect_thunks.flows.cryptoRandomUUIDInEffect_thunks.mermaid
@@ -1,0 +1,59 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3((("type: #40;#41; =#gt; `$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`<br/>node: #40;#41; =#gt; crypto.randomUUID#40;#41;")))
+  4["type: Effect#lt;`$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  5[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  6[["type: #40;#41; =#gt; `$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`<br/>node: #40;#41; =#gt; crypto.randomUUID#40;#41;"]]
+  7[/"type: `$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`<br/>node: crypto.randomUUID#40;#41;"/]
+  8[/"type: #123; try: #40;#41; =#gt; `$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: #40;#41; =#gt; crypto.randomUUID#40;#41;,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  9["type: Effect#lt;`$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`, ExampleError, never#gt;<br/>callee: Effect.try<br/>args: #91;#93;"]
+  10[/"type: #lt;A, E#gt;#40;options: #123; try: LazyArg#lt;A#gt;; catch: #40;error: unknown#41; =#gt; E; #125;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.try"/]
+  11[["type: #40;#41; =#gt; `$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`<br/>node: #40;#41; =#gt; crypto.randomUUID#40;#41;"]]
+  12[/"type: `$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`<br/>node: crypto.randomUUID#40;#41;"/]
+  13[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  14[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  15((("type: #40;#41; =#gt; Promise#lt;`$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`#gt;<br/>node: async #40;#41; =#gt; crypto.randomUUID#40;#41;")))
+  16["type: Effect#lt;`$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`, UnknownError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  17[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  18[["type: #40;#41; =#gt; Promise#lt;`$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`#gt;<br/>node: async #40;#41; =#gt; crypto.randomUUID#40;#41;"]]
+  19[/"type: `$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`<br/>node: crypto.randomUUID#40;#41;"/]
+  20[/"type: #123; try: #40;#41; =#gt; Promise#lt;`$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`#gt;; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: async #40;#41; =#gt; crypto.randomUUID#40;#41;,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  21["type: Effect#lt;`$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`, ExampleError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  22[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  23[["type: #40;#41; =#gt; Promise#lt;`$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`#gt;<br/>node: async #40;#41; =#gt; crypto.randomUUID#40;#41;"]]
+  24[/"type: `$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`<br/>node: crypto.randomUUID#40;#41;"/]
+  25[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  26[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  27((("type: #40;#41; =#gt; #40;#41; =#gt; `$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`<br/>node: #40;#41; =#gt; #40;#41; =#gt; crypto.randomUUID#40;#41;")))
+  28["type: Effect#lt;#40;#41; =#gt; `$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  29[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  30[["type: #40;#41; =#gt; #40;#41; =#gt; `$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`<br/>node: #40;#41; =#gt; #40;#41; =#gt; crypto.randomUUID#40;#41;"]]
+  31((("type: #40;#41; =#gt; `$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`<br/>node: #40;#41; =#gt; crypto.randomUUID#40;#41;")))
+  32[["type: #40;#41; =#gt; `$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`<br/>node: #40;#41; =#gt; crypto.randomUUID#40;#41;"]]
+  33[/"type: `$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;-$#123;string#125;`<br/>node: crypto.randomUUID#40;#41;"/]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  7 -->|"kind: potentialReturn"| 6
+  6 -->|"kind: connect"| 3
+  8 -->|"kind: pipe"| 9
+  10 -->|"kind: transformCallee"| 9
+  12 -->|"kind: potentialReturn"| 11
+  14 -->|"kind: potentialReturn"| 13
+  15 -->|"kind: pipe"| 16
+  17 -->|"kind: transformCallee"| 16
+  19 -->|"kind: potentialReturn"| 18
+  18 -->|"kind: connect"| 15
+  20 -->|"kind: pipe"| 21
+  22 -->|"kind: transformCallee"| 21
+  24 -->|"kind: potentialReturn"| 23
+  26 -->|"kind: potentialReturn"| 25
+  27 -->|"kind: pipe"| 28
+  29 -->|"kind: transformCallee"| 28
+  31 -->|"kind: potentialReturn"| 30
+  30 -->|"kind: connect"| 27
+  33 -->|"kind: potentialReturn"| 32
+  32 -->|"kind: connect"| 31

--- a/testdata/baselines/reference/effect-v4/cryptoRandomUUIDInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v4/cryptoRandomUUIDInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/cryptoRandomUUIDInEffect_thunks.ts -> cryptoRandomUUIDInEffect_thunks.flows.cryptoRandomUUIDInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v4/cryptoRandomUUIDInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v4/cryptoRandomUUIDInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/cryptoRandomUUIDInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v4/cryptoRandomUUIDInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/cryptoRandomUUIDInEffect_thunks.pipings.txt
@@ -1,0 +1,85 @@
+==== /.src/cryptoRandomUUIDInEffect_thunks.ts (6 flows) ====
+
+=== Piping Flow ===
+Location: 4:27 - 4:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: VoidIfEmpty<{ readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }>) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 6:26 - 6:65
+Node: Effect.sync(() => crypto.randomUUID())
+Node Kind: KindCallExpression
+
+Subject: () => crypto.randomUUID()
+Subject Type: () => `${string}-${string}-${string}-${string}-${string}`
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<`${string}-${string}-${string}-${string}-${string}`, never, never>
+
+=== Piping Flow ===
+Location: 8:31 - 11:3
+Node: Effect.try({\n  try: () => crypto.randomUUID(),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => crypto.randomUUID(),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => `${string}-${string}-${string}-${string}-${string}`; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<`${string}-${string}-${string}-${string}-${string}`, ExampleError, never>
+
+=== Piping Flow ===
+Location: 13:32 - 13:83
+Node: Effect.tryPromise(async () => crypto.randomUUID())
+Node Kind: KindCallExpression
+
+Subject: async () => crypto.randomUUID()
+Subject Type: () => Promise<`${string}-${string}-${string}-${string}-${string}`>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<`${string}-${string}-${string}-${string}-${string}`, UnknownError, never>
+
+=== Piping Flow ===
+Location: 15:38 - 18:3
+Node: Effect.tryPromise({\n  try: async () => crypto.randomUUID(),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => crypto.randomUUID(),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<`${string}-${string}-${string}-${string}-${string}`>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<`${string}-${string}-${string}-${string}-${string}`, ExampleError, never>
+
+=== Piping Flow ===
+Location: 20:48 - 20:93
+Node: Effect.sync(() => () => crypto.randomUUID())
+Node Kind: KindCallExpression
+
+Subject: () => () => crypto.randomUUID()
+Subject Type: () => () => `${string}-${string}-${string}-${string}-${string}`
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => `${string}-${string}-${string}-${string}-${string}`, never, never>

--- a/testdata/baselines/reference/effect-v4/cryptoRandomUUIDInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/cryptoRandomUUIDInEffect_thunks.quickfixes.txt
@@ -1,0 +1,43 @@
+=== Quick Fix Inventory ===
+
+[D1] (6:45-6:64) TS377079: This Effect code uses `crypto.randomUUID()`, prefer the Effect `Random` module instead because it uses Effect-injected randomness rather than the `crypto` module behind the scenes. effect(cryptoRandomUUIDInEffect)
+  Fix 0: "Disable cryptoRandomUUIDInEffect for this line"
+  Fix 1: "Disable cryptoRandomUUIDInEffect for entire file"
+
+[D2] (9:14-9:33) TS377079: This Effect code uses `crypto.randomUUID()`, prefer the Effect `Random` module instead because it uses Effect-injected randomness rather than the `crypto` module behind the scenes. effect(cryptoRandomUUIDInEffect)
+  Fix 0: "Disable cryptoRandomUUIDInEffect for this line"
+  Fix 1: "Disable cryptoRandomUUIDInEffect for entire file"
+
+[D3] (13:63-13:82) TS377079: This Effect code uses `crypto.randomUUID()`, prefer the Effect `Random` module instead because it uses Effect-injected randomness rather than the `crypto` module behind the scenes. effect(cryptoRandomUUIDInEffect)
+  Fix 0: "Disable cryptoRandomUUIDInEffect for this line"
+  Fix 1: "Disable cryptoRandomUUIDInEffect for entire file"
+
+[D4] (16:20-16:39) TS377079: This Effect code uses `crypto.randomUUID()`, prefer the Effect `Random` module instead because it uses Effect-injected randomness rather than the `crypto` module behind the scenes. effect(cryptoRandomUUIDInEffect)
+  Fix 0: "Disable cryptoRandomUUIDInEffect for this line"
+  Fix 1: "Disable cryptoRandomUUIDInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable cryptoRandomUUIDInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable cryptoRandomUUIDInEffect for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable cryptoRandomUUIDInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable cryptoRandomUUIDInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable cryptoRandomUUIDInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable cryptoRandomUUIDInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable cryptoRandomUUIDInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable cryptoRandomUUIDInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v4/globalConsoleInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v4/globalConsoleInEffect_thunks.errors.txt
@@ -1,0 +1,39 @@
+=== Metadata ===
+Effect version: 4.0.0
+
+/.src/globalConsoleInEffect_thunks.ts(6,48): warning TS377065: This Effect code uses `console.log`, logging in Effect code is represented through `Effect.log or Logger`. effect(globalConsoleInEffect)
+/.src/globalConsoleInEffect_thunks.ts(9,14): warning TS377065: This Effect code uses `console.warn`, logging in Effect code is represented through `Effect.logWarning or Logger`. effect(globalConsoleInEffect)
+/.src/globalConsoleInEffect_thunks.ts(13,66): warning TS377065: This Effect code uses `console.log`, logging in Effect code is represented through `Effect.log or Logger`. effect(globalConsoleInEffect)
+/.src/globalConsoleInEffect_thunks.ts(16,20): warning TS377065: This Effect code uses `console.warn`, logging in Effect code is represented through `Effect.logWarning or Logger`. effect(globalConsoleInEffect)
+
+
+==== /.src/globalConsoleInEffect_thunks.ts (4 errors) ====
+    // @effect-diagnostics globalConsoleInEffect:warning
+    import { Data, Effect } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    export const consoleInSync = Effect.sync(() => console.log("sync"))
+                                                   ~~~~~~~~~~~~~~~~~~~
+!!! warning TS377065: This Effect code uses `console.log`, logging in Effect code is represented through `Effect.log or Logger`. effect(globalConsoleInEffect)
+    
+    export const consoleInTryObject = Effect.try({
+      try: () => console.warn("try"),
+                 ~~~~~~~~~~~~~~~~~~~
+!!! warning TS377065: This Effect code uses `console.warn`, logging in Effect code is represented through `Effect.logWarning or Logger`. effect(globalConsoleInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const consoleInTryPromise = Effect.tryPromise(async () => console.log("try-promise"))
+                                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377065: This Effect code uses `console.log`, logging in Effect code is represented through `Effect.log or Logger`. effect(globalConsoleInEffect)
+    
+    export const consoleInTryPromiseObject = Effect.tryPromise({
+      try: async () => console.warn("try-promise-object"),
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377065: This Effect code uses `console.warn`, logging in Effect code is represented through `Effect.logWarning or Logger`. effect(globalConsoleInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => console.log("nested"))
+    

--- a/testdata/baselines/reference/effect-v4/globalConsoleInEffect_thunks.flows.globalConsoleInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v4/globalConsoleInEffect_thunks.flows.globalConsoleInEffect_thunks.mermaid
@@ -1,0 +1,89 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3((("type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; console.log#40;#quot;sync#quot;#41;")))
+  4["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  5[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  6[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; console.log#40;#quot;sync#quot;#41;"]]
+  7((("type: void<br/>node: console.log#40;#quot;sync#quot;#41;")))
+  8[/"type: #quot;sync#quot;<br/>node: #quot;sync#quot;"/]
+  9["type: void<br/>callee: console.log<br/>args: #91;#93;"]
+  10[/"type: #40;...data: any#91;#93;#41; =#gt; void<br/>node: console.log"/]
+  11[/"type: #123; try: #40;#41; =#gt; void; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: #40;#41; =#gt; console.warn#40;#quot;try#quot;#41;,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  12["type: Effect#lt;void, ExampleError, never#gt;<br/>callee: Effect.try<br/>args: #91;#93;"]
+  13[/"type: #lt;A, E#gt;#40;options: #123; try: LazyArg#lt;A#gt;; catch: #40;error: unknown#41; =#gt; E; #125;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.try"/]
+  14[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; console.warn#40;#quot;try#quot;#41;"]]
+  15((("type: void<br/>node: console.warn#40;#quot;try#quot;#41;")))
+  16[/"type: #quot;try#quot;<br/>node: #quot;try#quot;"/]
+  17["type: void<br/>callee: console.warn<br/>args: #91;#93;"]
+  18[/"type: #40;...data: any#91;#93;#41; =#gt; void<br/>node: console.warn"/]
+  19[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  20[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  21((("type: #40;#41; =#gt; Promise#lt;void#gt;<br/>node: async #40;#41; =#gt; console.log#40;#quot;try-promise#quot;#41;")))
+  22["type: Effect#lt;void, UnknownError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  23[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  24[["type: #40;#41; =#gt; Promise#lt;void#gt;<br/>node: async #40;#41; =#gt; console.log#40;#quot;try-promise#quot;#41;"]]
+  25((("type: void<br/>node: console.log#40;#quot;try-promise#quot;#41;")))
+  26[/"type: #quot;try-promise#quot;<br/>node: #quot;try-promise#quot;"/]
+  27["type: void<br/>callee: console.log<br/>args: #91;#93;"]
+  28[/"type: #40;...data: any#91;#93;#41; =#gt; void<br/>node: console.log"/]
+  29[/"type: #123; try: #40;#41; =#gt; Promise#lt;void#gt;; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: async #40;#41; =#gt; console.warn#40;#quot;try-promise-object#quot;#41;,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  30["type: Effect#lt;void, ExampleError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  31[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  32[["type: #40;#41; =#gt; Promise#lt;void#gt;<br/>node: async #40;#41; =#gt; console.warn#40;#quot;try-promise-object#quot;#41;"]]
+  33((("type: void<br/>node: console.warn#40;#quot;try-promise-object#quot;#41;")))
+  34[/"type: #quot;try-promise-object#quot;<br/>node: #quot;try-promise-object#quot;"/]
+  35["type: void<br/>callee: console.warn<br/>args: #91;#93;"]
+  36[/"type: #40;...data: any#91;#93;#41; =#gt; void<br/>node: console.warn"/]
+  37[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  38[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  39((("type: #40;#41; =#gt; #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #40;#41; =#gt; console.log#40;#quot;nested#quot;#41;")))
+  40["type: Effect#lt;#40;#41; =#gt; void, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  41[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  42[["type: #40;#41; =#gt; #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #40;#41; =#gt; console.log#40;#quot;nested#quot;#41;"]]
+  43((("type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; console.log#40;#quot;nested#quot;#41;")))
+  44[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; console.log#40;#quot;nested#quot;#41;"]]
+  45((("type: void<br/>node: console.log#40;#quot;nested#quot;#41;")))
+  46[/"type: #quot;nested#quot;<br/>node: #quot;nested#quot;"/]
+  47["type: void<br/>callee: console.log<br/>args: #91;#93;"]
+  48[/"type: #40;...data: any#91;#93;#41; =#gt; void<br/>node: console.log"/]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  7 -->|"kind: potentialReturn"| 6
+  6 -->|"kind: connect"| 3
+  8 -->|"kind: pipe"| 9
+  9 -->|"kind: connect"| 7
+  10 -->|"kind: transformCallee"| 9
+  11 -->|"kind: pipe"| 12
+  13 -->|"kind: transformCallee"| 12
+  15 -->|"kind: potentialReturn"| 14
+  16 -->|"kind: pipe"| 17
+  17 -->|"kind: connect"| 15
+  18 -->|"kind: transformCallee"| 17
+  20 -->|"kind: potentialReturn"| 19
+  21 -->|"kind: pipe"| 22
+  23 -->|"kind: transformCallee"| 22
+  25 -->|"kind: potentialReturn"| 24
+  24 -->|"kind: connect"| 21
+  26 -->|"kind: pipe"| 27
+  27 -->|"kind: connect"| 25
+  28 -->|"kind: transformCallee"| 27
+  29 -->|"kind: pipe"| 30
+  31 -->|"kind: transformCallee"| 30
+  33 -->|"kind: potentialReturn"| 32
+  34 -->|"kind: pipe"| 35
+  35 -->|"kind: connect"| 33
+  36 -->|"kind: transformCallee"| 35
+  38 -->|"kind: potentialReturn"| 37
+  39 -->|"kind: pipe"| 40
+  41 -->|"kind: transformCallee"| 40
+  43 -->|"kind: potentialReturn"| 42
+  42 -->|"kind: connect"| 39
+  45 -->|"kind: potentialReturn"| 44
+  44 -->|"kind: connect"| 43
+  46 -->|"kind: pipe"| 47
+  47 -->|"kind: connect"| 45
+  48 -->|"kind: transformCallee"| 47

--- a/testdata/baselines/reference/effect-v4/globalConsoleInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v4/globalConsoleInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/globalConsoleInEffect_thunks.ts -> globalConsoleInEffect_thunks.flows.globalConsoleInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v4/globalConsoleInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v4/globalConsoleInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/globalConsoleInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v4/globalConsoleInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/globalConsoleInEffect_thunks.pipings.txt
@@ -1,0 +1,155 @@
+==== /.src/globalConsoleInEffect_thunks.ts (11 flows) ====
+
+=== Piping Flow ===
+Location: 4:27 - 4:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: VoidIfEmpty<{ readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }>) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 6:29 - 6:68
+Node: Effect.sync(() => console.log("sync"))
+Node Kind: KindCallExpression
+
+Subject: () => console.log("sync")
+Subject Type: () => void
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 6:47 - 6:67
+Node: console.log("sync")
+Node Kind: KindCallExpression
+
+Subject: "sync"
+Subject Type: "sync"
+
+Transformations (1):
+  [0] kind: call
+      callee: console.log
+      args: (constant)
+      outType: void
+
+=== Piping Flow ===
+Location: 8:34 - 11:3
+Node: Effect.try({\n  try: () => console.warn("try"),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => console.warn("try"),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => void; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<void, ExampleError, never>
+
+=== Piping Flow ===
+Location: 9:13 - 9:33
+Node: console.warn("try")
+Node Kind: KindCallExpression
+
+Subject: "try"
+Subject Type: "try"
+
+Transformations (1):
+  [0] kind: call
+      callee: console.warn
+      args: (constant)
+      outType: void
+
+=== Piping Flow ===
+Location: 13:35 - 13:93
+Node: Effect.tryPromise(async () => console.log("try-promise"))
+Node Kind: KindCallExpression
+
+Subject: async () => console.log("try-promise")
+Subject Type: () => Promise<void>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<void, UnknownError, never>
+
+=== Piping Flow ===
+Location: 13:65 - 13:92
+Node: console.log("try-promise")
+Node Kind: KindCallExpression
+
+Subject: "try-promise"
+Subject Type: "try-promise"
+
+Transformations (1):
+  [0] kind: call
+      callee: console.log
+      args: (constant)
+      outType: void
+
+=== Piping Flow ===
+Location: 15:41 - 18:3
+Node: Effect.tryPromise({\n  try: async () => console.warn("try-promise-object"),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => console.warn("try-promise-object"),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<void>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<void, ExampleError, never>
+
+=== Piping Flow ===
+Location: 16:19 - 16:54
+Node: console.warn("try-promise-object")
+Node Kind: KindCallExpression
+
+Subject: "try-promise-object"
+Subject Type: "try-promise-object"
+
+Transformations (1):
+  [0] kind: call
+      callee: console.warn
+      args: (constant)
+      outType: void
+
+=== Piping Flow ===
+Location: 20:48 - 20:95
+Node: Effect.sync(() => () => console.log("nested"))
+Node Kind: KindCallExpression
+
+Subject: () => () => console.log("nested")
+Subject Type: () => () => void
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => void, never, never>
+
+=== Piping Flow ===
+Location: 20:72 - 20:94
+Node: console.log("nested")
+Node Kind: KindCallExpression
+
+Subject: "nested"
+Subject Type: "nested"
+
+Transformations (1):
+  [0] kind: call
+      callee: console.log
+      args: (constant)
+      outType: void

--- a/testdata/baselines/reference/effect-v4/globalConsoleInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/globalConsoleInEffect_thunks.quickfixes.txt
@@ -1,0 +1,43 @@
+=== Quick Fix Inventory ===
+
+[D1] (6:48-6:67) TS377065: This Effect code uses `console.log`, logging in Effect code is represented through `Effect.log or Logger`. effect(globalConsoleInEffect)
+  Fix 0: "Disable globalConsoleInEffect for this line"
+  Fix 1: "Disable globalConsoleInEffect for entire file"
+
+[D2] (9:14-9:33) TS377065: This Effect code uses `console.warn`, logging in Effect code is represented through `Effect.logWarning or Logger`. effect(globalConsoleInEffect)
+  Fix 0: "Disable globalConsoleInEffect for this line"
+  Fix 1: "Disable globalConsoleInEffect for entire file"
+
+[D3] (13:66-13:92) TS377065: This Effect code uses `console.log`, logging in Effect code is represented through `Effect.log or Logger`. effect(globalConsoleInEffect)
+  Fix 0: "Disable globalConsoleInEffect for this line"
+  Fix 1: "Disable globalConsoleInEffect for entire file"
+
+[D4] (16:20-16:54) TS377065: This Effect code uses `console.warn`, logging in Effect code is represented through `Effect.logWarning or Logger`. effect(globalConsoleInEffect)
+  Fix 0: "Disable globalConsoleInEffect for this line"
+  Fix 1: "Disable globalConsoleInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable globalConsoleInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable globalConsoleInEffect for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable globalConsoleInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable globalConsoleInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable globalConsoleInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable globalConsoleInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable globalConsoleInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable globalConsoleInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v4/globalDateInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v4/globalDateInEffect_thunks.errors.txt
@@ -1,0 +1,39 @@
+=== Metadata ===
+Effect version: 4.0.0
+
+/.src/globalDateInEffect_thunks.ts(6,45): warning TS377067: This Effect code uses `Date.now()`, time access in Effect code is represented through `Clock` from Effect. effect(globalDateInEffect)
+/.src/globalDateInEffect_thunks.ts(9,14): warning TS377069: This Effect code constructs `new Date()`, date values in Effect code are represented through `DateTime` from Effect. effect(globalDateInEffect)
+/.src/globalDateInEffect_thunks.ts(13,63): warning TS377067: This Effect code uses `Date.now()`, time access in Effect code is represented through `Clock` from Effect. effect(globalDateInEffect)
+/.src/globalDateInEffect_thunks.ts(16,20): warning TS377069: This Effect code constructs `new Date()`, date values in Effect code are represented through `DateTime` from Effect. effect(globalDateInEffect)
+
+
+==== /.src/globalDateInEffect_thunks.ts (4 errors) ====
+    // @effect-diagnostics globalDateInEffect:warning
+    import { Data, Effect } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    export const dateInSync = Effect.sync(() => Date.now())
+                                                ~~~~~~~~~~
+!!! warning TS377067: This Effect code uses `Date.now()`, time access in Effect code is represented through `Clock` from Effect. effect(globalDateInEffect)
+    
+    export const newDateInTryObject = Effect.try({
+      try: () => new Date(),
+                 ~~~~~~~~~~
+!!! warning TS377069: This Effect code constructs `new Date()`, date values in Effect code are represented through `DateTime` from Effect. effect(globalDateInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const dateInTryPromise = Effect.tryPromise(async () => Date.now())
+                                                                  ~~~~~~~~~~
+!!! warning TS377067: This Effect code uses `Date.now()`, time access in Effect code is represented through `Clock` from Effect. effect(globalDateInEffect)
+    
+    export const newDateInTryPromiseObject = Effect.tryPromise({
+      try: async () => new Date(),
+                       ~~~~~~~~~~
+!!! warning TS377069: This Effect code constructs `new Date()`, date values in Effect code are represented through `DateTime` from Effect. effect(globalDateInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => Date.now())
+    

--- a/testdata/baselines/reference/effect-v4/globalDateInEffect_thunks.flows.globalDateInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v4/globalDateInEffect_thunks.flows.globalDateInEffect_thunks.mermaid
@@ -1,0 +1,59 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3((("type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Date.now#40;#41;")))
+  4["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  5[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  6[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Date.now#40;#41;"]]
+  7[/"type: number<br/>node: Date.now#40;#41;"/]
+  8[/"type: #123; try: #40;#41; =#gt; Date; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: #40;#41; =#gt; new Date#40;#41;,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  9["type: Effect#lt;Date, ExampleError, never#gt;<br/>callee: Effect.try<br/>args: #91;#93;"]
+  10[/"type: #lt;A, E#gt;#40;options: #123; try: LazyArg#lt;A#gt;; catch: #40;error: unknown#41; =#gt; E; #125;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.try"/]
+  11[["type: #40;#41; =#gt; Date<br/>node: #40;#41; =#gt; new Date#40;#41;"]]
+  12[/"type: Date<br/>node: new Date#40;#41;"/]
+  13[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  14[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  15((("type: #40;#41; =#gt; Promise#lt;number#gt;<br/>node: async #40;#41; =#gt; Date.now#40;#41;")))
+  16["type: Effect#lt;number, UnknownError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  17[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  18[["type: #40;#41; =#gt; Promise#lt;number#gt;<br/>node: async #40;#41; =#gt; Date.now#40;#41;"]]
+  19[/"type: number<br/>node: Date.now#40;#41;"/]
+  20[/"type: #123; try: #40;#41; =#gt; Promise#lt;Date#gt;; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: async #40;#41; =#gt; new Date#40;#41;,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  21["type: Effect#lt;Date, ExampleError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  22[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  23[["type: #40;#41; =#gt; Promise#lt;Date#gt;<br/>node: async #40;#41; =#gt; new Date#40;#41;"]]
+  24[/"type: Date<br/>node: new Date#40;#41;"/]
+  25[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  26[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  27((("type: #40;#41; =#gt; #40;#41; =#gt; number<br/>node: #40;#41; =#gt; #40;#41; =#gt; Date.now#40;#41;")))
+  28["type: Effect#lt;#40;#41; =#gt; number, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  29[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  30[["type: #40;#41; =#gt; #40;#41; =#gt; number<br/>node: #40;#41; =#gt; #40;#41; =#gt; Date.now#40;#41;"]]
+  31((("type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Date.now#40;#41;")))
+  32[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Date.now#40;#41;"]]
+  33[/"type: number<br/>node: Date.now#40;#41;"/]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  7 -->|"kind: potentialReturn"| 6
+  6 -->|"kind: connect"| 3
+  8 -->|"kind: pipe"| 9
+  10 -->|"kind: transformCallee"| 9
+  12 -->|"kind: potentialReturn"| 11
+  14 -->|"kind: potentialReturn"| 13
+  15 -->|"kind: pipe"| 16
+  17 -->|"kind: transformCallee"| 16
+  19 -->|"kind: potentialReturn"| 18
+  18 -->|"kind: connect"| 15
+  20 -->|"kind: pipe"| 21
+  22 -->|"kind: transformCallee"| 21
+  24 -->|"kind: potentialReturn"| 23
+  26 -->|"kind: potentialReturn"| 25
+  27 -->|"kind: pipe"| 28
+  29 -->|"kind: transformCallee"| 28
+  31 -->|"kind: potentialReturn"| 30
+  30 -->|"kind: connect"| 27
+  33 -->|"kind: potentialReturn"| 32
+  32 -->|"kind: connect"| 31

--- a/testdata/baselines/reference/effect-v4/globalDateInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v4/globalDateInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/globalDateInEffect_thunks.ts -> globalDateInEffect_thunks.flows.globalDateInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v4/globalDateInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v4/globalDateInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/globalDateInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v4/globalDateInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/globalDateInEffect_thunks.pipings.txt
@@ -1,0 +1,85 @@
+==== /.src/globalDateInEffect_thunks.ts (6 flows) ====
+
+=== Piping Flow ===
+Location: 4:27 - 4:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: VoidIfEmpty<{ readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }>) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 6:26 - 6:56
+Node: Effect.sync(() => Date.now())
+Node Kind: KindCallExpression
+
+Subject: () => Date.now()
+Subject Type: () => number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 8:34 - 11:3
+Node: Effect.try({\n  try: () => new Date(),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => new Date(),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Date; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<Date, ExampleError, never>
+
+=== Piping Flow ===
+Location: 13:32 - 13:74
+Node: Effect.tryPromise(async () => Date.now())
+Node Kind: KindCallExpression
+
+Subject: async () => Date.now()
+Subject Type: () => Promise<number>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<number, UnknownError, never>
+
+=== Piping Flow ===
+Location: 15:41 - 18:3
+Node: Effect.tryPromise({\n  try: async () => new Date(),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => new Date(),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<Date>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<Date, ExampleError, never>
+
+=== Piping Flow ===
+Location: 20:48 - 20:84
+Node: Effect.sync(() => () => Date.now())
+Node Kind: KindCallExpression
+
+Subject: () => () => Date.now()
+Subject Type: () => () => number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => number, never, never>

--- a/testdata/baselines/reference/effect-v4/globalDateInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/globalDateInEffect_thunks.quickfixes.txt
@@ -1,0 +1,43 @@
+=== Quick Fix Inventory ===
+
+[D1] (6:45-6:55) TS377067: This Effect code uses `Date.now()`, time access in Effect code is represented through `Clock` from Effect. effect(globalDateInEffect)
+  Fix 0: "Disable globalDateInEffect for this line"
+  Fix 1: "Disable globalDateInEffect for entire file"
+
+[D2] (9:14-9:24) TS377069: This Effect code constructs `new Date()`, date values in Effect code are represented through `DateTime` from Effect. effect(globalDateInEffect)
+  Fix 0: "Disable globalDateInEffect for this line"
+  Fix 1: "Disable globalDateInEffect for entire file"
+
+[D3] (13:63-13:73) TS377067: This Effect code uses `Date.now()`, time access in Effect code is represented through `Clock` from Effect. effect(globalDateInEffect)
+  Fix 0: "Disable globalDateInEffect for this line"
+  Fix 1: "Disable globalDateInEffect for entire file"
+
+[D4] (16:20-16:30) TS377069: This Effect code constructs `new Date()`, date values in Effect code are represented through `DateTime` from Effect. effect(globalDateInEffect)
+  Fix 0: "Disable globalDateInEffect for this line"
+  Fix 1: "Disable globalDateInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable globalDateInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable globalDateInEffect for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable globalDateInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable globalDateInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable globalDateInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable globalDateInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable globalDateInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable globalDateInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v4/globalFetchInEffect_preview.errors.txt
+++ b/testdata/baselines/reference/effect-v4/globalFetchInEffect_preview.errors.txt
@@ -1,14 +1,17 @@
 === Metadata ===
 Effect version: 4.0.0
 
+/.src/globalFetchInEffect_preview.ts(6,38): warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
 
 
-==== /.src/globalFetchInEffect_preview.ts (0 errors) ====
+==== /.src/globalFetchInEffect_preview.ts (1 errors) ====
     // @effect-diagnostics *:off
     // @effect-diagnostics globalFetchInEffect:warning
     import { Effect } from "effect"
     
     export const preview = Effect.gen(function*() {
       return yield* Effect.promise(() => fetch("https://example.com"))
+                                         ~~~~~
+!!! warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
     })
     

--- a/testdata/baselines/reference/effect-v4/globalFetchInEffect_preview.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/globalFetchInEffect_preview.quickfixes.txt
@@ -1,5 +1,13 @@
 === Quick Fix Inventory ===
-(no diagnostics)
+
+[D1] (6:38-6:43) TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+  Fix 0: "Disable globalFetchInEffect for this line"
+  Fix 1: "Disable globalFetchInEffect for entire file"
 
 === Quick Fix Application Results ===
-(no quick fixes to apply)
+
+=== [D1] Fix 0: "Disable globalFetchInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable globalFetchInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v4/globalFetchInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v4/globalFetchInEffect_thunks.errors.txt
@@ -1,0 +1,42 @@
+=== Metadata ===
+Effect version: 4.0.0
+
+/.src/globalFetchInEffect_thunks.ts(6,40): warning TS377082: This `Effect.sync` thunk returns a Promise. Use `Effect.promise` or `Effect.tryPromise` to represent async work. effect(lazyPromiseInEffectSync)
+/.src/globalFetchInEffect_thunks.ts(6,46): warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+/.src/globalFetchInEffect_thunks.ts(9,14): warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+/.src/globalFetchInEffect_thunks.ts(13,64): warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+/.src/globalFetchInEffect_thunks.ts(16,20): warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+
+
+==== /.src/globalFetchInEffect_thunks.ts (5 errors) ====
+    // @effect-diagnostics globalFetchInEffect:warning
+    import { Data, Effect } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    export const fetchInSync = Effect.sync(() => fetch("https://example.com/sync"))
+                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377082: This `Effect.sync` thunk returns a Promise. Use `Effect.promise` or `Effect.tryPromise` to represent async work. effect(lazyPromiseInEffectSync)
+                                                 ~~~~~
+!!! warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+    
+    export const fetchInTryObject = Effect.try({
+      try: () => fetch("https://example.com/try"),
+                 ~~~~~
+!!! warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const fetchInTryPromise = Effect.tryPromise(async () => fetch("https://example.com/try-promise"))
+                                                                   ~~~~~
+!!! warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+    
+    export const fetchInTryPromiseObject = Effect.tryPromise({
+      try: async () => fetch("https://example.com/try-promise-object"),
+                       ~~~~~
+!!! warning TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => fetch("https://example.com/nested"))
+    

--- a/testdata/baselines/reference/effect-v4/globalFetchInEffect_thunks.flows.globalFetchInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v4/globalFetchInEffect_thunks.flows.globalFetchInEffect_thunks.mermaid
@@ -1,0 +1,59 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3((("type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: #40;#41; =#gt; fetch#40;#quot;https://example.com/sync#quot;#41;")))
+  4["type: Effect#lt;Promise#lt;Response#gt;, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  5[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  6[["type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: #40;#41; =#gt; fetch#40;#quot;https://example.com/sync#quot;#41;"]]
+  7[/"type: Promise#lt;Response#gt;<br/>node: fetch#40;#quot;https://example.com/sync#quot;#41;"/]
+  8[/"type: #123; try: #40;#41; =#gt; Promise#lt;Response#gt;; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: #40;#41; =#gt; fetch#40;#quot;https://example.com/try#quot;#41;,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  9["type: Effect#lt;Promise#lt;Response#gt;, ExampleError, never#gt;<br/>callee: Effect.try<br/>args: #91;#93;"]
+  10[/"type: #lt;A, E#gt;#40;options: #123; try: LazyArg#lt;A#gt;; catch: #40;error: unknown#41; =#gt; E; #125;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.try"/]
+  11[["type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: #40;#41; =#gt; fetch#40;#quot;https://example.com/try#quot;#41;"]]
+  12[/"type: Promise#lt;Response#gt;<br/>node: fetch#40;#quot;https://example.com/try#quot;#41;"/]
+  13[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  14[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  15((("type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: async #40;#41; =#gt; fetch#40;#quot;https://example.com/try-promise#quot;#41;")))
+  16["type: Effect#lt;Response, UnknownError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  17[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  18[["type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: async #40;#41; =#gt; fetch#40;#quot;https://example.com/try-promise#quot;#41;"]]
+  19[/"type: Promise#lt;Response#gt;<br/>node: fetch#40;#quot;https://example.com/try-promise#quot;#41;"/]
+  20[/"type: #123; try: #40;#41; =#gt; Promise#lt;Response#gt;; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: async #40;#41; =#gt; fetch#40;#quot;https://example.com/try-promise-object#quot;#41;,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  21["type: Effect#lt;Response, ExampleError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  22[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  23[["type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: async #40;#41; =#gt; fetch#40;#quot;https://example.com/try-promise-object#quot;#41;"]]
+  24[/"type: Promise#lt;Response#gt;<br/>node: fetch#40;#quot;https://example.com/try-promise-object#quot;#41;"/]
+  25[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  26[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  27((("type: #40;#41; =#gt; #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: #40;#41; =#gt; #40;#41; =#gt; fetch#40;#quot;https://example.com/nested#quot;#41;")))
+  28["type: Effect#lt;#40;#41; =#gt; Promise#lt;Response#gt;, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  29[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  30[["type: #40;#41; =#gt; #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: #40;#41; =#gt; #40;#41; =#gt; fetch#40;#quot;https://example.com/nested#quot;#41;"]]
+  31((("type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: #40;#41; =#gt; fetch#40;#quot;https://example.com/nested#quot;#41;")))
+  32[["type: #40;#41; =#gt; Promise#lt;Response#gt;<br/>node: #40;#41; =#gt; fetch#40;#quot;https://example.com/nested#quot;#41;"]]
+  33[/"type: Promise#lt;Response#gt;<br/>node: fetch#40;#quot;https://example.com/nested#quot;#41;"/]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  7 -->|"kind: potentialReturn"| 6
+  6 -->|"kind: connect"| 3
+  8 -->|"kind: pipe"| 9
+  10 -->|"kind: transformCallee"| 9
+  12 -->|"kind: potentialReturn"| 11
+  14 -->|"kind: potentialReturn"| 13
+  15 -->|"kind: pipe"| 16
+  17 -->|"kind: transformCallee"| 16
+  19 -->|"kind: potentialReturn"| 18
+  18 -->|"kind: connect"| 15
+  20 -->|"kind: pipe"| 21
+  22 -->|"kind: transformCallee"| 21
+  24 -->|"kind: potentialReturn"| 23
+  26 -->|"kind: potentialReturn"| 25
+  27 -->|"kind: pipe"| 28
+  29 -->|"kind: transformCallee"| 28
+  31 -->|"kind: potentialReturn"| 30
+  30 -->|"kind: connect"| 27
+  33 -->|"kind: potentialReturn"| 32
+  32 -->|"kind: connect"| 31

--- a/testdata/baselines/reference/effect-v4/globalFetchInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v4/globalFetchInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/globalFetchInEffect_thunks.ts -> globalFetchInEffect_thunks.flows.globalFetchInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v4/globalFetchInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v4/globalFetchInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/globalFetchInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v4/globalFetchInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/globalFetchInEffect_thunks.pipings.txt
@@ -1,0 +1,155 @@
+==== /.src/globalFetchInEffect_thunks.ts (11 flows) ====
+
+=== Piping Flow ===
+Location: 4:27 - 4:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: VoidIfEmpty<{ readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }>) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 6:27 - 6:80
+Node: Effect.sync(() => fetch("https://example.com/sync"))
+Node Kind: KindCallExpression
+
+Subject: () => fetch("https://example.com/sync")
+Subject Type: () => Promise<Response>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<Promise<Response>, never, never>
+
+=== Piping Flow ===
+Location: 6:45 - 6:79
+Node: fetch("https://example.com/sync")
+Node Kind: KindCallExpression
+
+Subject: "https://example.com/sync"
+Subject Type: "https://example.com/sync"
+
+Transformations (1):
+  [0] kind: call
+      callee: fetch
+      args: (constant)
+      outType: Promise<Response>
+
+=== Piping Flow ===
+Location: 8:32 - 11:3
+Node: Effect.try({\n  try: () => fetch("https://example.com/try"),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => fetch("https://example.com/try"),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<Response>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<Promise<Response>, ExampleError, never>
+
+=== Piping Flow ===
+Location: 9:13 - 9:46
+Node: fetch("https://example.com/try")
+Node Kind: KindCallExpression
+
+Subject: "https://example.com/try"
+Subject Type: "https://example.com/try"
+
+Transformations (1):
+  [0] kind: call
+      callee: fetch
+      args: (constant)
+      outType: Promise<Response>
+
+=== Piping Flow ===
+Location: 13:33 - 13:105
+Node: Effect.tryPromise(async () => fetch("https://example.com/try-promise"))
+Node Kind: KindCallExpression
+
+Subject: async () => fetch("https://example.com/try-promise")
+Subject Type: () => Promise<Response>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<Response, UnknownError, never>
+
+=== Piping Flow ===
+Location: 13:63 - 13:104
+Node: fetch("https://example.com/try-promise")
+Node Kind: KindCallExpression
+
+Subject: "https://example.com/try-promise"
+Subject Type: "https://example.com/try-promise"
+
+Transformations (1):
+  [0] kind: call
+      callee: fetch
+      args: (constant)
+      outType: Promise<Response>
+
+=== Piping Flow ===
+Location: 15:39 - 18:3
+Node: Effect.tryPromise({\n  try: async () => fetch("https://example.com/try-promise-object"),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => fetch("https://example.com/try-promise-object"),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<Response>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<Response, ExampleError, never>
+
+=== Piping Flow ===
+Location: 16:19 - 16:67
+Node: fetch("https://example.com/try-promise-object")
+Node Kind: KindCallExpression
+
+Subject: "https://example.com/try-promise-object"
+Subject Type: "https://example.com/try-promise-object"
+
+Transformations (1):
+  [0] kind: call
+      callee: fetch
+      args: (constant)
+      outType: Promise<Response>
+
+=== Piping Flow ===
+Location: 20:48 - 20:109
+Node: Effect.sync(() => () => fetch("https://example.com/nested"))
+Node Kind: KindCallExpression
+
+Subject: () => () => fetch("https://example.com/nested")
+Subject Type: () => () => Promise<Response>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => Promise<Response>, never, never>
+
+=== Piping Flow ===
+Location: 20:72 - 20:108
+Node: fetch("https://example.com/nested")
+Node Kind: KindCallExpression
+
+Subject: "https://example.com/nested"
+Subject Type: "https://example.com/nested"
+
+Transformations (1):
+  [0] kind: call
+      callee: fetch
+      args: (constant)
+      outType: Promise<Response>

--- a/testdata/baselines/reference/effect-v4/globalFetchInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/globalFetchInEffect_thunks.quickfixes.txt
@@ -1,0 +1,53 @@
+=== Quick Fix Inventory ===
+
+[D1] (6:40-6:79) TS377082: This `Effect.sync` thunk returns a Promise. Use `Effect.promise` or `Effect.tryPromise` to represent async work. effect(lazyPromiseInEffectSync)
+  Fix 0: "Disable lazyPromiseInEffectSync for this line"
+  Fix 1: "Disable lazyPromiseInEffectSync for entire file"
+
+[D2] (6:46-6:51) TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+  Fix 0: "Disable globalFetchInEffect for this line"
+  Fix 1: "Disable globalFetchInEffect for entire file"
+
+[D3] (9:14-9:19) TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+  Fix 0: "Disable globalFetchInEffect for this line"
+  Fix 1: "Disable globalFetchInEffect for entire file"
+
+[D4] (13:64-13:69) TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+  Fix 0: "Disable globalFetchInEffect for this line"
+  Fix 1: "Disable globalFetchInEffect for entire file"
+
+[D5] (16:20-16:25) TS377063: This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)
+  Fix 0: "Disable globalFetchInEffect for this line"
+  Fix 1: "Disable globalFetchInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable lazyPromiseInEffectSync for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable lazyPromiseInEffectSync for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable globalFetchInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable globalFetchInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable globalFetchInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable globalFetchInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable globalFetchInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable globalFetchInEffect for entire file" ===
+skipped by default
+
+=== [D5] Fix 0: "Disable globalFetchInEffect for this line" ===
+skipped by default
+
+=== [D5] Fix 1: "Disable globalFetchInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v4/globalRandomInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v4/globalRandomInEffect_thunks.errors.txt
@@ -1,0 +1,39 @@
+=== Metadata ===
+Effect version: 4.0.0
+
+/.src/globalRandomInEffect_thunks.ts(6,47): warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+/.src/globalRandomInEffect_thunks.ts(9,14): warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+/.src/globalRandomInEffect_thunks.ts(13,65): warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+/.src/globalRandomInEffect_thunks.ts(16,20): warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+
+
+==== /.src/globalRandomInEffect_thunks.ts (4 errors) ====
+    // @effect-diagnostics globalRandomInEffect:warning
+    import { Data, Effect } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    export const randomInSync = Effect.sync(() => Math.random())
+                                                  ~~~~~~~~~~~~~
+!!! warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+    
+    export const randomInTryObject = Effect.try({
+      try: () => Math.random(),
+                 ~~~~~~~~~~~~~
+!!! warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const randomInTryPromise = Effect.tryPromise(async () => Math.random())
+                                                                    ~~~~~~~~~~~~~
+!!! warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+    
+    export const randomInTryPromiseObject = Effect.tryPromise({
+      try: async () => Math.random(),
+                       ~~~~~~~~~~~~~
+!!! warning TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => Math.random())
+    

--- a/testdata/baselines/reference/effect-v4/globalRandomInEffect_thunks.flows.globalRandomInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v4/globalRandomInEffect_thunks.flows.globalRandomInEffect_thunks.mermaid
@@ -1,0 +1,59 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3((("type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Math.random#40;#41;")))
+  4["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  5[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  6[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Math.random#40;#41;"]]
+  7[/"type: number<br/>node: Math.random#40;#41;"/]
+  8[/"type: #123; try: #40;#41; =#gt; number; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: #40;#41; =#gt; Math.random#40;#41;,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  9["type: Effect#lt;number, ExampleError, never#gt;<br/>callee: Effect.try<br/>args: #91;#93;"]
+  10[/"type: #lt;A, E#gt;#40;options: #123; try: LazyArg#lt;A#gt;; catch: #40;error: unknown#41; =#gt; E; #125;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.try"/]
+  11[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Math.random#40;#41;"]]
+  12[/"type: number<br/>node: Math.random#40;#41;"/]
+  13[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  14[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  15((("type: #40;#41; =#gt; Promise#lt;number#gt;<br/>node: async #40;#41; =#gt; Math.random#40;#41;")))
+  16["type: Effect#lt;number, UnknownError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  17[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  18[["type: #40;#41; =#gt; Promise#lt;number#gt;<br/>node: async #40;#41; =#gt; Math.random#40;#41;"]]
+  19[/"type: number<br/>node: Math.random#40;#41;"/]
+  20[/"type: #123; try: #40;#41; =#gt; Promise#lt;number#gt;; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: async #40;#41; =#gt; Math.random#40;#41;,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  21["type: Effect#lt;number, ExampleError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  22[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  23[["type: #40;#41; =#gt; Promise#lt;number#gt;<br/>node: async #40;#41; =#gt; Math.random#40;#41;"]]
+  24[/"type: number<br/>node: Math.random#40;#41;"/]
+  25[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  26[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  27((("type: #40;#41; =#gt; #40;#41; =#gt; number<br/>node: #40;#41; =#gt; #40;#41; =#gt; Math.random#40;#41;")))
+  28["type: Effect#lt;#40;#41; =#gt; number, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  29[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  30[["type: #40;#41; =#gt; #40;#41; =#gt; number<br/>node: #40;#41; =#gt; #40;#41; =#gt; Math.random#40;#41;"]]
+  31((("type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Math.random#40;#41;")))
+  32[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; Math.random#40;#41;"]]
+  33[/"type: number<br/>node: Math.random#40;#41;"/]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  7 -->|"kind: potentialReturn"| 6
+  6 -->|"kind: connect"| 3
+  8 -->|"kind: pipe"| 9
+  10 -->|"kind: transformCallee"| 9
+  12 -->|"kind: potentialReturn"| 11
+  14 -->|"kind: potentialReturn"| 13
+  15 -->|"kind: pipe"| 16
+  17 -->|"kind: transformCallee"| 16
+  19 -->|"kind: potentialReturn"| 18
+  18 -->|"kind: connect"| 15
+  20 -->|"kind: pipe"| 21
+  22 -->|"kind: transformCallee"| 21
+  24 -->|"kind: potentialReturn"| 23
+  26 -->|"kind: potentialReturn"| 25
+  27 -->|"kind: pipe"| 28
+  29 -->|"kind: transformCallee"| 28
+  31 -->|"kind: potentialReturn"| 30
+  30 -->|"kind: connect"| 27
+  33 -->|"kind: potentialReturn"| 32
+  32 -->|"kind: connect"| 31

--- a/testdata/baselines/reference/effect-v4/globalRandomInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v4/globalRandomInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/globalRandomInEffect_thunks.ts -> globalRandomInEffect_thunks.flows.globalRandomInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v4/globalRandomInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v4/globalRandomInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/globalRandomInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v4/globalRandomInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/globalRandomInEffect_thunks.pipings.txt
@@ -1,0 +1,85 @@
+==== /.src/globalRandomInEffect_thunks.ts (6 flows) ====
+
+=== Piping Flow ===
+Location: 4:27 - 4:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: VoidIfEmpty<{ readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }>) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 6:28 - 6:61
+Node: Effect.sync(() => Math.random())
+Node Kind: KindCallExpression
+
+Subject: () => Math.random()
+Subject Type: () => number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 8:33 - 11:3
+Node: Effect.try({\n  try: () => Math.random(),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => Math.random(),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => number; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<number, ExampleError, never>
+
+=== Piping Flow ===
+Location: 13:34 - 13:79
+Node: Effect.tryPromise(async () => Math.random())
+Node Kind: KindCallExpression
+
+Subject: async () => Math.random()
+Subject Type: () => Promise<number>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<number, UnknownError, never>
+
+=== Piping Flow ===
+Location: 15:40 - 18:3
+Node: Effect.tryPromise({\n  try: async () => Math.random(),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => Math.random(),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<number>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<number, ExampleError, never>
+
+=== Piping Flow ===
+Location: 20:48 - 20:87
+Node: Effect.sync(() => () => Math.random())
+Node Kind: KindCallExpression
+
+Subject: () => () => Math.random()
+Subject Type: () => () => number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => number, never, never>

--- a/testdata/baselines/reference/effect-v4/globalRandomInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/globalRandomInEffect_thunks.quickfixes.txt
@@ -1,0 +1,43 @@
+=== Quick Fix Inventory ===
+
+[D1] (6:47-6:60) TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+  Fix 0: "Disable globalRandomInEffect for this line"
+  Fix 1: "Disable globalRandomInEffect for entire file"
+
+[D2] (9:14-9:27) TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+  Fix 0: "Disable globalRandomInEffect for this line"
+  Fix 1: "Disable globalRandomInEffect for entire file"
+
+[D3] (13:65-13:78) TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+  Fix 0: "Disable globalRandomInEffect for this line"
+  Fix 1: "Disable globalRandomInEffect for entire file"
+
+[D4] (16:20-16:33) TS377071: This Effect code uses `Math.random()`, randomness is represented through the Effect `Random` service. effect(globalRandomInEffect)
+  Fix 0: "Disable globalRandomInEffect for this line"
+  Fix 1: "Disable globalRandomInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable globalRandomInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable globalRandomInEffect for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable globalRandomInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable globalRandomInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable globalRandomInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable globalRandomInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable globalRandomInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable globalRandomInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v4/globalTimersInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v4/globalTimersInEffect_thunks.errors.txt
@@ -1,0 +1,39 @@
+=== Metadata ===
+Effect version: 4.0.0
+
+/.src/globalTimersInEffect_thunks.ts(6,48): warning TS377073: This Effect code uses `setTimeout`, the corresponding timer API in this context is `Effect.sleep or Schedule` from Effect. effect(globalTimersInEffect)
+/.src/globalTimersInEffect_thunks.ts(9,14): warning TS377073: This Effect code uses `setInterval`, the corresponding timer API in this context is `Schedule or Effect.repeat` from Effect. effect(globalTimersInEffect)
+/.src/globalTimersInEffect_thunks.ts(13,66): warning TS377073: This Effect code uses `setTimeout`, the corresponding timer API in this context is `Effect.sleep or Schedule` from Effect. effect(globalTimersInEffect)
+/.src/globalTimersInEffect_thunks.ts(16,20): warning TS377073: This Effect code uses `setInterval`, the corresponding timer API in this context is `Schedule or Effect.repeat` from Effect. effect(globalTimersInEffect)
+
+
+==== /.src/globalTimersInEffect_thunks.ts (4 errors) ====
+    // @effect-diagnostics globalTimersInEffect:warning
+    import { Data, Effect } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    export const timeoutInSync = Effect.sync(() => setTimeout(() => {}, 100))
+                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377073: This Effect code uses `setTimeout`, the corresponding timer API in this context is `Effect.sleep or Schedule` from Effect. effect(globalTimersInEffect)
+    
+    export const intervalInTryObject = Effect.try({
+      try: () => setInterval(() => {}, 100),
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377073: This Effect code uses `setInterval`, the corresponding timer API in this context is `Schedule or Effect.repeat` from Effect. effect(globalTimersInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const timeoutInTryPromise = Effect.tryPromise(async () => setTimeout(() => {}, 100))
+                                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377073: This Effect code uses `setTimeout`, the corresponding timer API in this context is `Effect.sleep or Schedule` from Effect. effect(globalTimersInEffect)
+    
+    export const intervalInTryPromiseObject = Effect.tryPromise({
+      try: async () => setInterval(() => {}, 100),
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377073: This Effect code uses `setInterval`, the corresponding timer API in this context is `Schedule or Effect.repeat` from Effect. effect(globalTimersInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => setTimeout(() => {}, 100))
+    

--- a/testdata/baselines/reference/effect-v4/globalTimersInEffect_thunks.flows.globalTimersInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v4/globalTimersInEffect_thunks.flows.globalTimersInEffect_thunks.mermaid
@@ -1,0 +1,64 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3((("type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;")))
+  4["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  5[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  6[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;"]]
+  7[/"type: number<br/>node: setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;"/]
+  8[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #123;#125;"]]
+  9[/"type: #123; try: #40;#41; =#gt; number; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: #40;#41; =#gt; setInterval#40;#40;#41; =#gt; #123;#125;, 100#41;,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  10["type: Effect#lt;number, ExampleError, never#gt;<br/>callee: Effect.try<br/>args: #91;#93;"]
+  11[/"type: #lt;A, E#gt;#40;options: #123; try: LazyArg#lt;A#gt;; catch: #40;error: unknown#41; =#gt; E; #125;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.try"/]
+  12[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; setInterval#40;#40;#41; =#gt; #123;#125;, 100#41;"]]
+  13[/"type: number<br/>node: setInterval#40;#40;#41; =#gt; #123;#125;, 100#41;"/]
+  14[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #123;#125;"]]
+  15[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  16[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  17((("type: #40;#41; =#gt; Promise#lt;number#gt;<br/>node: async #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;")))
+  18["type: Effect#lt;number, UnknownError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  19[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  20[["type: #40;#41; =#gt; Promise#lt;number#gt;<br/>node: async #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;"]]
+  21[/"type: number<br/>node: setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;"/]
+  22[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #123;#125;"]]
+  23[/"type: #123; try: #40;#41; =#gt; Promise#lt;number#gt;; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: async #40;#41; =#gt; setInterval#40;#40;#41; =#gt; #123;#125;, 100#41;,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  24["type: Effect#lt;number, ExampleError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  25[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  26[["type: #40;#41; =#gt; Promise#lt;number#gt;<br/>node: async #40;#41; =#gt; setInterval#40;#40;#41; =#gt; #123;#125;, 100#41;"]]
+  27[/"type: number<br/>node: setInterval#40;#40;#41; =#gt; #123;#125;, 100#41;"/]
+  28[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #123;#125;"]]
+  29[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  30[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  31((("type: #40;#41; =#gt; #40;#41; =#gt; number<br/>node: #40;#41; =#gt; #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;")))
+  32["type: Effect#lt;#40;#41; =#gt; number, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  33[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  34[["type: #40;#41; =#gt; #40;#41; =#gt; number<br/>node: #40;#41; =#gt; #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;"]]
+  35((("type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;")))
+  36[["type: #40;#41; =#gt; number<br/>node: #40;#41; =#gt; setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;"]]
+  37[/"type: number<br/>node: setTimeout#40;#40;#41; =#gt; #123;#125;, 100#41;"/]
+  38[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #123;#125;"]]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  7 -->|"kind: potentialReturn"| 6
+  6 -->|"kind: connect"| 3
+  9 -->|"kind: pipe"| 10
+  11 -->|"kind: transformCallee"| 10
+  13 -->|"kind: potentialReturn"| 12
+  16 -->|"kind: potentialReturn"| 15
+  17 -->|"kind: pipe"| 18
+  19 -->|"kind: transformCallee"| 18
+  21 -->|"kind: potentialReturn"| 20
+  20 -->|"kind: connect"| 17
+  23 -->|"kind: pipe"| 24
+  25 -->|"kind: transformCallee"| 24
+  27 -->|"kind: potentialReturn"| 26
+  30 -->|"kind: potentialReturn"| 29
+  31 -->|"kind: pipe"| 32
+  33 -->|"kind: transformCallee"| 32
+  35 -->|"kind: potentialReturn"| 34
+  34 -->|"kind: connect"| 31
+  37 -->|"kind: potentialReturn"| 36
+  36 -->|"kind: connect"| 35

--- a/testdata/baselines/reference/effect-v4/globalTimersInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v4/globalTimersInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/globalTimersInEffect_thunks.ts -> globalTimersInEffect_thunks.flows.globalTimersInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v4/globalTimersInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v4/globalTimersInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/globalTimersInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v4/globalTimersInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/globalTimersInEffect_thunks.pipings.txt
@@ -1,0 +1,85 @@
+==== /.src/globalTimersInEffect_thunks.ts (6 flows) ====
+
+=== Piping Flow ===
+Location: 4:27 - 4:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: VoidIfEmpty<{ readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }>) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 6:29 - 6:74
+Node: Effect.sync(() => setTimeout(() => {}, 100))
+Node Kind: KindCallExpression
+
+Subject: () => setTimeout(() => {}, 100)
+Subject Type: () => number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 8:35 - 11:3
+Node: Effect.try({\n  try: () => setInterval(() => {}, 100),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => setInterval(() => {}, 100),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => number; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<number, ExampleError, never>
+
+=== Piping Flow ===
+Location: 13:35 - 13:92
+Node: Effect.tryPromise(async () => setTimeout(() => {}, 100))
+Node Kind: KindCallExpression
+
+Subject: async () => setTimeout(() => {}, 100)
+Subject Type: () => Promise<number>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<number, UnknownError, never>
+
+=== Piping Flow ===
+Location: 15:42 - 18:3
+Node: Effect.tryPromise({\n  try: async () => setInterval(() => {}, 100),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => setInterval(() => {}, 100),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<number>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<number, ExampleError, never>
+
+=== Piping Flow ===
+Location: 20:48 - 20:99
+Node: Effect.sync(() => () => setTimeout(() => {}, 100))
+Node Kind: KindCallExpression
+
+Subject: () => () => setTimeout(() => {}, 100)
+Subject Type: () => () => number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => number, never, never>

--- a/testdata/baselines/reference/effect-v4/globalTimersInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/globalTimersInEffect_thunks.quickfixes.txt
@@ -1,0 +1,43 @@
+=== Quick Fix Inventory ===
+
+[D1] (6:48-6:73) TS377073: This Effect code uses `setTimeout`, the corresponding timer API in this context is `Effect.sleep or Schedule` from Effect. effect(globalTimersInEffect)
+  Fix 0: "Disable globalTimersInEffect for this line"
+  Fix 1: "Disable globalTimersInEffect for entire file"
+
+[D2] (9:14-9:40) TS377073: This Effect code uses `setInterval`, the corresponding timer API in this context is `Schedule or Effect.repeat` from Effect. effect(globalTimersInEffect)
+  Fix 0: "Disable globalTimersInEffect for this line"
+  Fix 1: "Disable globalTimersInEffect for entire file"
+
+[D3] (13:66-13:91) TS377073: This Effect code uses `setTimeout`, the corresponding timer API in this context is `Effect.sleep or Schedule` from Effect. effect(globalTimersInEffect)
+  Fix 0: "Disable globalTimersInEffect for this line"
+  Fix 1: "Disable globalTimersInEffect for entire file"
+
+[D4] (16:20-16:46) TS377073: This Effect code uses `setInterval`, the corresponding timer API in this context is `Schedule or Effect.repeat` from Effect. effect(globalTimersInEffect)
+  Fix 0: "Disable globalTimersInEffect for this line"
+  Fix 1: "Disable globalTimersInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable globalTimersInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable globalTimersInEffect for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable globalTimersInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable globalTimersInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable globalTimersInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable globalTimersInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable globalTimersInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable globalTimersInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v4/processEnvInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v4/processEnvInEffect_thunks.errors.txt
@@ -1,0 +1,40 @@
+=== Metadata ===
+Effect version: 4.0.0
+
+/.src/processEnvInEffect_thunks.ts(7,44): warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+/.src/processEnvInEffect_thunks.ts(10,14): warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+/.src/processEnvInEffect_thunks.ts(14,62): warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+/.src/processEnvInEffect_thunks.ts(17,20): warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+
+
+==== /.src/processEnvInEffect_thunks.ts (4 errors) ====
+    // @effect-diagnostics processEnvInEffect:warning
+    /// <reference types="node" />
+    import { Data, Effect } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    export const envInSync = Effect.sync(() => process.env.SYNC_SECRET)
+                                               ~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+    
+    export const envInTryObject = Effect.try({
+      try: () => process.env.TRY_SECRET,
+                 ~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const envInTryPromise = Effect.tryPromise(async () => process.env.TRY_PROMISE_SECRET)
+                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+    
+    export const envInTryPromiseObject = Effect.tryPromise({
+      try: async () => process.env.TRY_PROMISE_OBJECT_SECRET,
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => process.env.NESTED_SECRET)
+    

--- a/testdata/baselines/reference/effect-v4/processEnvInEffect_thunks.flows.processEnvInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v4/processEnvInEffect_thunks.flows.processEnvInEffect_thunks.mermaid
@@ -1,0 +1,59 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3((("type: #40;#41; =#gt; string #124; undefined<br/>node: #40;#41; =#gt; process.env.SYNC_SECRET")))
+  4["type: Effect#lt;string #124; undefined, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  5[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  6[["type: #40;#41; =#gt; string #124; undefined<br/>node: #40;#41; =#gt; process.env.SYNC_SECRET"]]
+  7[/"type: string #124; undefined<br/>node: process.env.SYNC_SECRET"/]
+  8[/"type: #123; try: #40;#41; =#gt; string #124; undefined; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: #40;#41; =#gt; process.env.TRY_SECRET,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  9["type: Effect#lt;string #124; undefined, ExampleError, never#gt;<br/>callee: Effect.try<br/>args: #91;#93;"]
+  10[/"type: #lt;A, E#gt;#40;options: #123; try: LazyArg#lt;A#gt;; catch: #40;error: unknown#41; =#gt; E; #125;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.try"/]
+  11[["type: #40;#41; =#gt; string #124; undefined<br/>node: #40;#41; =#gt; process.env.TRY_SECRET"]]
+  12[/"type: string #124; undefined<br/>node: process.env.TRY_SECRET"/]
+  13[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  14[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  15((("type: #40;#41; =#gt; Promise#lt;string #124; undefined#gt;<br/>node: async #40;#41; =#gt; process.env.TRY_PROMISE_SECRET")))
+  16["type: Effect#lt;string #124; undefined, UnknownError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  17[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  18[["type: #40;#41; =#gt; Promise#lt;string #124; undefined#gt;<br/>node: async #40;#41; =#gt; process.env.TRY_PROMISE_SECRET"]]
+  19[/"type: string #124; undefined<br/>node: process.env.TRY_PROMISE_SECRET"/]
+  20[/"type: #123; try: #40;#41; =#gt; Promise#lt;string #124; undefined#gt;; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: async #40;#41; =#gt; process.env.TRY_PROMISE_OBJECT_SECRET,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  21["type: Effect#lt;string #124; undefined, ExampleError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  22[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  23[["type: #40;#41; =#gt; Promise#lt;string #124; undefined#gt;<br/>node: async #40;#41; =#gt; process.env.TRY_PROMISE_OBJECT_SECRET"]]
+  24[/"type: string #124; undefined<br/>node: process.env.TRY_PROMISE_OBJECT_SECRET"/]
+  25[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  26[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  27((("type: #40;#41; =#gt; #40;#41; =#gt; string #124; undefined<br/>node: #40;#41; =#gt; #40;#41; =#gt; process.env.NESTED_SECRET")))
+  28["type: Effect#lt;#40;#41; =#gt; string #124; undefined, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  29[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  30[["type: #40;#41; =#gt; #40;#41; =#gt; string #124; undefined<br/>node: #40;#41; =#gt; #40;#41; =#gt; process.env.NESTED_SECRET"]]
+  31((("type: #40;#41; =#gt; string #124; undefined<br/>node: #40;#41; =#gt; process.env.NESTED_SECRET")))
+  32[["type: #40;#41; =#gt; string #124; undefined<br/>node: #40;#41; =#gt; process.env.NESTED_SECRET"]]
+  33[/"type: string #124; undefined<br/>node: process.env.NESTED_SECRET"/]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  7 -->|"kind: potentialReturn"| 6
+  6 -->|"kind: connect"| 3
+  8 -->|"kind: pipe"| 9
+  10 -->|"kind: transformCallee"| 9
+  12 -->|"kind: potentialReturn"| 11
+  14 -->|"kind: potentialReturn"| 13
+  15 -->|"kind: pipe"| 16
+  17 -->|"kind: transformCallee"| 16
+  19 -->|"kind: potentialReturn"| 18
+  18 -->|"kind: connect"| 15
+  20 -->|"kind: pipe"| 21
+  22 -->|"kind: transformCallee"| 21
+  24 -->|"kind: potentialReturn"| 23
+  26 -->|"kind: potentialReturn"| 25
+  27 -->|"kind: pipe"| 28
+  29 -->|"kind: transformCallee"| 28
+  31 -->|"kind: potentialReturn"| 30
+  30 -->|"kind: connect"| 27
+  33 -->|"kind: potentialReturn"| 32
+  32 -->|"kind: connect"| 31

--- a/testdata/baselines/reference/effect-v4/processEnvInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v4/processEnvInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/processEnvInEffect_thunks.ts -> processEnvInEffect_thunks.flows.processEnvInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v4/processEnvInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v4/processEnvInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/processEnvInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v4/processEnvInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/processEnvInEffect_thunks.pipings.txt
@@ -1,0 +1,85 @@
+==== /.src/processEnvInEffect_thunks.ts (6 flows) ====
+
+=== Piping Flow ===
+Location: 5:27 - 5:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: VoidIfEmpty<{ readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }>) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 7:25 - 7:68
+Node: Effect.sync(() => process.env.SYNC_SECRET)
+Node Kind: KindCallExpression
+
+Subject: () => process.env.SYNC_SECRET
+Subject Type: () => string | undefined
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<string | undefined, never, never>
+
+=== Piping Flow ===
+Location: 9:30 - 12:3
+Node: Effect.try({\n  try: () => process.env.TRY_SECRET,\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => process.env.TRY_SECRET,\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => string | undefined; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<string | undefined, ExampleError, never>
+
+=== Piping Flow ===
+Location: 14:31 - 14:93
+Node: Effect.tryPromise(async () => process.env.TRY_PROMISE_SECRET)
+Node Kind: KindCallExpression
+
+Subject: async () => process.env.TRY_PROMISE_SECRET
+Subject Type: () => Promise<string | undefined>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<string | undefined, UnknownError, never>
+
+=== Piping Flow ===
+Location: 16:37 - 19:3
+Node: Effect.tryPromise({\n  try: async () => process.env.TRY_PROMISE_OBJECT_SECRET,\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => process.env.TRY_PROMISE_OBJECT_SECRET,\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<string | undefined>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<string | undefined, ExampleError, never>
+
+=== Piping Flow ===
+Location: 21:48 - 21:99
+Node: Effect.sync(() => () => process.env.NESTED_SECRET)
+Node Kind: KindCallExpression
+
+Subject: () => () => process.env.NESTED_SECRET
+Subject Type: () => () => string | undefined
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => string | undefined, never, never>

--- a/testdata/baselines/reference/effect-v4/processEnvInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/processEnvInEffect_thunks.quickfixes.txt
@@ -1,0 +1,43 @@
+=== Quick Fix Inventory ===
+
+[D1] (7:44-7:67) TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+  Fix 0: "Disable processEnvInEffect for this line"
+  Fix 1: "Disable processEnvInEffect for entire file"
+
+[D2] (10:14-10:36) TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+  Fix 0: "Disable processEnvInEffect for this line"
+  Fix 1: "Disable processEnvInEffect for entire file"
+
+[D3] (14:62-14:92) TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+  Fix 0: "Disable processEnvInEffect for this line"
+  Fix 1: "Disable processEnvInEffect for entire file"
+
+[D4] (17:20-17:57) TS377077: This Effect code reads from `process.env`, environment configuration in Effect code is represented through `Config` from Effect. effect(processEnvInEffect)
+  Fix 0: "Disable processEnvInEffect for this line"
+  Fix 1: "Disable processEnvInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable processEnvInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable processEnvInEffect for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable processEnvInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable processEnvInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable processEnvInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable processEnvInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable processEnvInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable processEnvInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/effect-v4/schemaSyncInEffect_thunks.errors.txt
+++ b/testdata/baselines/reference/effect-v4/schemaSyncInEffect_thunks.errors.txt
@@ -1,0 +1,45 @@
+=== Metadata ===
+Effect version: 4.0.0
+
+/.src/schemaSyncInEffect_thunks.ts(10,47): suggestion TS377037: `Schema.decodeSync` is used inside an Effect generator. `Schema.decodeEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+/.src/schemaSyncInEffect_thunks.ts(13,14): suggestion TS377037: `Schema.decodeSync` is used inside an Effect generator. `Schema.decodeEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+/.src/schemaSyncInEffect_thunks.ts(17,65): suggestion TS377037: `Schema.encodeSync` is used inside an Effect generator. `Schema.encodeEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+/.src/schemaSyncInEffect_thunks.ts(20,20): suggestion TS377037: `Schema.encodeUnknownSync` is used inside an Effect generator. `Schema.encodeUnknownEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+
+
+==== /.src/schemaSyncInEffect_thunks.ts (4 errors) ====
+    import { Data, Effect, Schema } from "effect"
+    
+    class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+    
+    const Person = Schema.Struct({
+      name: Schema.String,
+      age: Schema.Number
+    })
+    
+    export const decodeInSync = Effect.sync(() => Schema.decodeSync(Person)({ name: "John", age: 30 }))
+                                                  ~~~~~~~~~~~~~~~~~
+!!! suggestion TS377037: `Schema.decodeSync` is used inside an Effect generator. `Schema.decodeEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+    
+    export const decodeInTryObject = Effect.try({
+      try: () => Schema.decodeSync(Person)({ name: "Jane", age: 25 }),
+                 ~~~~~~~~~~~~~~~~~
+!!! suggestion TS377037: `Schema.decodeSync` is used inside an Effect generator. `Schema.decodeEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const encodeInTryPromise = Effect.tryPromise(async () => Schema.encodeSync(Person)({ name: "Bob", age: 40 }))
+                                                                    ~~~~~~~~~~~~~~~~~
+!!! suggestion TS377037: `Schema.encodeSync` is used inside an Effect generator. `Schema.encodeEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+    
+    export const encodeInTryPromiseObject = Effect.tryPromise({
+      try: async () => Schema.encodeUnknownSync(Person)({ name: "Carol", age: 50 }),
+                       ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! suggestion TS377037: `Schema.encodeUnknownSync` is used inside an Effect generator. `Schema.encodeUnknownEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+      catch: () => new ExampleError()
+    })
+    
+    export const shouldNotTriggerReturnedFunction = Effect.sync(
+      () => () => Schema.decodeSync(Person)({ name: "Nested", age: 10 })
+    )
+    

--- a/testdata/baselines/reference/effect-v4/schemaSyncInEffect_thunks.flows.schemaSyncInEffect_thunks.mermaid
+++ b/testdata/baselines/reference/effect-v4/schemaSyncInEffect_thunks.flows.schemaSyncInEffect_thunks.mermaid
@@ -1,0 +1,89 @@
+flowchart TB
+  0[/"type: #quot;ExampleError#quot;<br/>node: #quot;ExampleError#quot;"/]
+  1["type: new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: #quot;ExampleError#quot;; #125; #amp; Readonly#lt;A#gt;<br/>callee: Data.TaggedError<br/>args: #91;#93;"]
+  2[/"type: #lt;Tag extends string#gt;#40;tag: Tag#41; =#gt; new #lt;A extends Record#lt;string, any#gt; = #123;#125;#gt;#40;args: VoidIfEmpty#lt;#123; readonly #91;P in keyof A as P extends #quot;_tag#quot; ? never : P#93;: A#91;P#93;; #125;#gt;#41; =#gt; YieldableError #amp; #123; readonly _tag: Tag; #125; #amp; Readonly#lt;A#gt;<br/>node: Data.TaggedError"/]
+  3[/"type: #123; name: String; age: Number; #125;<br/>node: #123;#92;n  name: Schema.String,#92;n  age: Schema.Number#92;n#125;"/]
+  4["type: Struct#lt;#123; readonly name: String; readonly age: Number; #125;#gt;<br/>callee: Schema.Struct<br/>args: #91;#93;"]
+  5[/"type: #lt;const Fields extends Struct.Fields#gt;#40;fields: Fields#41; =#gt; Struct#lt;Fields#gt;<br/>node: Schema.Struct"/]
+  6((("type: #40;#41; =#gt; #123; readonly age: number; readonly name: string; #125;<br/>node: #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;John#quot;, age: 30 #125;#41;")))
+  7["type: Effect#lt;#123; readonly age: number; readonly name: string; #125;, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  8[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  9[["type: #40;#41; =#gt; #123; readonly age: number; readonly name: string; #125;<br/>node: #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;John#quot;, age: 30 #125;#41;"]]
+  10[/"type: #123; readonly age: number; readonly name: string; #125;<br/>node: Schema.decodeSync#40;Person#41;#40;#123; name: #quot;John#quot;, age: 30 #125;#41;"/]
+  11[/"type: Struct#lt;#123; readonly name: String; readonly age: Number; #125;#gt;<br/>node: Person"/]
+  12["type: #40;input: #123; readonly age: number; readonly name: string; #125;, options?: ParseOptions #124; undefined#41; =#gt; #123; readonly age: number; readonly name: string; #125;<br/>callee: Schema.decodeSync<br/>args: #91;#93;"]
+  13[/"type: #lt;S extends Decoder#lt;unknown#gt;#gt;#40;schema: S#41; =#gt; #40;input: S#91;#quot;Encoded#quot;#93;, options?: ParseOptions #124; undefined#41; =#gt; S#91;#quot;Type#quot;#93;<br/>node: Schema.decodeSync"/]
+  14[/"type: #123; try: #40;#41; =#gt; #123; readonly age: number; readonly name: string; #125;; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Jane#quot;, age: 25 #125;#41;,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  15["type: Effect#lt;#123; readonly age: number; readonly name: string; #125;, ExampleError, never#gt;<br/>callee: Effect.try<br/>args: #91;#93;"]
+  16[/"type: #lt;A, E#gt;#40;options: #123; try: LazyArg#lt;A#gt;; catch: #40;error: unknown#41; =#gt; E; #125;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.try"/]
+  17[["type: #40;#41; =#gt; #123; readonly age: number; readonly name: string; #125;<br/>node: #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Jane#quot;, age: 25 #125;#41;"]]
+  18[/"type: #123; readonly age: number; readonly name: string; #125;<br/>node: Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Jane#quot;, age: 25 #125;#41;"/]
+  19[/"type: Struct#lt;#123; readonly name: String; readonly age: Number; #125;#gt;<br/>node: Person"/]
+  20["type: #40;input: #123; readonly age: number; readonly name: string; #125;, options?: ParseOptions #124; undefined#41; =#gt; #123; readonly age: number; readonly name: string; #125;<br/>callee: Schema.decodeSync<br/>args: #91;#93;"]
+  21[/"type: #lt;S extends Decoder#lt;unknown#gt;#gt;#40;schema: S#41; =#gt; #40;input: S#91;#quot;Encoded#quot;#93;, options?: ParseOptions #124; undefined#41; =#gt; S#91;#quot;Type#quot;#93;<br/>node: Schema.decodeSync"/]
+  22[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  23[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  24((("type: #40;#41; =#gt; Promise#lt;#123; readonly age: number; readonly name: string; #125;#gt;<br/>node: async #40;#41; =#gt; Schema.encodeSync#40;Person#41;#40;#123; name: #quot;Bob#quot;, age: 40 #125;#41;")))
+  25["type: Effect#lt;#123; readonly age: number; readonly name: string; #125;, UnknownError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  26[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  27[["type: #40;#41; =#gt; Promise#lt;#123; readonly age: number; readonly name: string; #125;#gt;<br/>node: async #40;#41; =#gt; Schema.encodeSync#40;Person#41;#40;#123; name: #quot;Bob#quot;, age: 40 #125;#41;"]]
+  28[/"type: #123; readonly age: number; readonly name: string; #125;<br/>node: Schema.encodeSync#40;Person#41;#40;#123; name: #quot;Bob#quot;, age: 40 #125;#41;"/]
+  29[/"type: Struct#lt;#123; readonly name: String; readonly age: Number; #125;#gt;<br/>node: Person"/]
+  30["type: #40;input: #123; readonly age: number; readonly name: string; #125;, options?: ParseOptions #124; undefined#41; =#gt; #123; readonly age: number; readonly name: string; #125;<br/>callee: Schema.encodeSync<br/>args: #91;#93;"]
+  31[/"type: #lt;S extends Encoder#lt;unknown#gt;#gt;#40;schema: S#41; =#gt; #40;input: S#91;#quot;Type#quot;#93;, options?: ParseOptions #124; undefined#41; =#gt; S#91;#quot;Encoded#quot;#93;<br/>node: Schema.encodeSync"/]
+  32[/"type: #123; try: #40;#41; =#gt; Promise#lt;#123; readonly age: number; readonly name: string; #125;#gt;; catch: #40;#41; =#gt; ExampleError; #125;<br/>node: #123;#92;n  try: async #40;#41; =#gt; Schema.encodeUnknownSync#40;Person#41;#40;#123; name: #quot;Carol#quot;, age: 50 #125;#41;,#92;n  catch: #40;#41; =#gt; new ExampleError#40;#41;#92;n#125;"/]
+  33["type: Effect#lt;#123; readonly age: number; readonly name: string; #125;, ExampleError, never#gt;<br/>callee: Effect.tryPromise<br/>args: #91;#93;"]
+  34[/"type: #lt;A, E = UnknownError#gt;#40;options: #123; readonly try: #40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;; readonly catch: #40;error: unknown#41; =#gt; E; #125; #124; #40;#40;signal: AbortSignal#41; =#gt; PromiseLike#lt;A#gt;#41;#41; =#gt; Effect#lt;A, E, never#gt;<br/>node: Effect.tryPromise"/]
+  35[["type: #40;#41; =#gt; Promise#lt;#123; readonly age: number; readonly name: string; #125;#gt;<br/>node: async #40;#41; =#gt; Schema.encodeUnknownSync#40;Person#41;#40;#123; name: #quot;Carol#quot;, age: 50 #125;#41;"]]
+  36[/"type: #123; readonly age: number; readonly name: string; #125;<br/>node: Schema.encodeUnknownSync#40;Person#41;#40;#123; name: #quot;Carol#quot;, age: 50 #125;#41;"/]
+  37[/"type: Struct#lt;#123; readonly name: String; readonly age: Number; #125;#gt;<br/>node: Person"/]
+  38["type: #40;input: unknown, options?: ParseOptions #124; undefined#41; =#gt; #123; readonly age: number; readonly name: string; #125;<br/>callee: Schema.encodeUnknownSync<br/>args: #91;#93;"]
+  39[/"type: #lt;S extends Schema.Encoder#lt;unknown#gt;#gt;#40;schema: S#41; =#gt; #40;input: unknown, options?: ParseOptions #124; undefined#41; =#gt; S#91;#quot;Encoded#quot;#93;<br/>node: Schema.encodeUnknownSync"/]
+  40[["type: #40;#41; =#gt; ExampleError<br/>node: #40;#41; =#gt; new ExampleError#40;#41;"]]
+  41[/"type: ExampleError<br/>node: new ExampleError#40;#41;"/]
+  42((("type: #40;#41; =#gt; #40;#41; =#gt; #123; readonly age: number; readonly name: string; #125;<br/>node: #40;#41; =#gt; #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Nested#quot;, age: 10 #125;#41;")))
+  43["type: Effect#lt;#40;#41; =#gt; #123; readonly age: number; readonly name: string; #125;, never, never#gt;<br/>callee: Effect.sync<br/>args: #91;#93;"]
+  44[/"type: #lt;A#gt;#40;thunk: LazyArg#lt;A#gt;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.sync"/]
+  45[["type: #40;#41; =#gt; #40;#41; =#gt; #123; readonly age: number; readonly name: string; #125;<br/>node: #40;#41; =#gt; #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Nested#quot;, age: 10 #125;#41;"]]
+  46((("type: #40;#41; =#gt; #123; readonly age: number; readonly name: string; #125;<br/>node: #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Nested#quot;, age: 10 #125;#41;")))
+  47[["type: #40;#41; =#gt; #123; readonly age: number; readonly name: string; #125;<br/>node: #40;#41; =#gt; Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Nested#quot;, age: 10 #125;#41;"]]
+  48[/"type: #123; readonly age: number; readonly name: string; #125;<br/>node: Schema.decodeSync#40;Person#41;#40;#123; name: #quot;Nested#quot;, age: 10 #125;#41;"/]
+  49[/"type: Struct#lt;#123; readonly name: String; readonly age: Number; #125;#gt;<br/>node: Person"/]
+  50["type: #40;input: #123; readonly age: number; readonly name: string; #125;, options?: ParseOptions #124; undefined#41; =#gt; #123; readonly age: number; readonly name: string; #125;<br/>callee: Schema.decodeSync<br/>args: #91;#93;"]
+  51[/"type: #lt;S extends Decoder#lt;unknown#gt;#gt;#40;schema: S#41; =#gt; #40;input: S#91;#quot;Encoded#quot;#93;, options?: ParseOptions #124; undefined#41; =#gt; S#91;#quot;Type#quot;#93;<br/>node: Schema.decodeSync"/]
+  0 -->|"kind: pipe"| 1
+  2 -->|"kind: transformCallee"| 1
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  6 -->|"kind: pipe"| 7
+  8 -->|"kind: transformCallee"| 7
+  10 -->|"kind: potentialReturn"| 9
+  9 -->|"kind: connect"| 6
+  11 -->|"kind: pipe"| 12
+  13 -->|"kind: transformCallee"| 12
+  14 -->|"kind: pipe"| 15
+  16 -->|"kind: transformCallee"| 15
+  18 -->|"kind: potentialReturn"| 17
+  19 -->|"kind: pipe"| 20
+  21 -->|"kind: transformCallee"| 20
+  23 -->|"kind: potentialReturn"| 22
+  24 -->|"kind: pipe"| 25
+  26 -->|"kind: transformCallee"| 25
+  28 -->|"kind: potentialReturn"| 27
+  27 -->|"kind: connect"| 24
+  29 -->|"kind: pipe"| 30
+  31 -->|"kind: transformCallee"| 30
+  32 -->|"kind: pipe"| 33
+  34 -->|"kind: transformCallee"| 33
+  36 -->|"kind: potentialReturn"| 35
+  37 -->|"kind: pipe"| 38
+  39 -->|"kind: transformCallee"| 38
+  41 -->|"kind: potentialReturn"| 40
+  42 -->|"kind: pipe"| 43
+  44 -->|"kind: transformCallee"| 43
+  46 -->|"kind: potentialReturn"| 45
+  45 -->|"kind: connect"| 42
+  48 -->|"kind: potentialReturn"| 47
+  47 -->|"kind: connect"| 46
+  49 -->|"kind: pipe"| 50
+  51 -->|"kind: transformCallee"| 50

--- a/testdata/baselines/reference/effect-v4/schemaSyncInEffect_thunks.flows.txt
+++ b/testdata/baselines/reference/effect-v4/schemaSyncInEffect_thunks.flows.txt
@@ -1,0 +1,1 @@
+/.src/schemaSyncInEffect_thunks.ts -> schemaSyncInEffect_thunks.flows.schemaSyncInEffect_thunks.mermaid

--- a/testdata/baselines/reference/effect-v4/schemaSyncInEffect_thunks.layers.txt
+++ b/testdata/baselines/reference/effect-v4/schemaSyncInEffect_thunks.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/schemaSyncInEffect_thunks.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v4/schemaSyncInEffect_thunks.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/schemaSyncInEffect_thunks.pipings.txt
@@ -1,0 +1,169 @@
+==== /.src/schemaSyncInEffect_thunks.ts (12 flows) ====
+
+=== Piping Flow ===
+Location: 3:27 - 3:60
+Node: Data.TaggedError("ExampleError")
+Node Kind: KindCallExpression
+
+Subject: "ExampleError"
+Subject Type: "ExampleError"
+
+Transformations (1):
+  [0] kind: call
+      callee: Data.TaggedError
+      args: (constant)
+      outType: new <A extends Record<string, any> = {}>(args: VoidIfEmpty<{ readonly [P in keyof A as P extends "_tag" ? never : P]: A[P]; }>) => YieldableError & { readonly _tag: "ExampleError"; } & Readonly<A>
+
+=== Piping Flow ===
+Location: 5:15 - 8:3
+Node: Schema.Struct({\n  name: Schema.String,\n  age: Schema.Number\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  name: Schema.String,\n  age: Schema.Number\n}
+Subject Type: { name: String; age: Number; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.Struct
+      args: (constant)
+      outType: Struct<{ readonly name: String; readonly age: Number; }>
+
+=== Piping Flow ===
+Location: 10:28 - 10:100
+Node: Effect.sync(() => Schema.decodeSync(Person)({ name: "John", age: 30 }))
+Node Kind: KindCallExpression
+
+Subject: () => Schema.decodeSync(Person)({ name: "John", age: 30 })
+Subject Type: () => { readonly age: number; readonly name: string; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<{ readonly age: number; readonly name: string; }, never, never>
+
+=== Piping Flow ===
+Location: 10:46 - 10:99
+Node: Schema.decodeSync(Person)({ name: "John", age: 30 })
+Node Kind: KindCallExpression
+
+Subject: { name: "John", age: 30 }
+Subject Type: { name: string; age: number; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.decodeSync(Person)
+      args: (constant)
+      outType: { readonly age: number; readonly name: string; }
+
+=== Piping Flow ===
+Location: 12:33 - 15:3
+Node: Effect.try({\n  try: () => Schema.decodeSync(Person)({ name: "Jane", age: 25 }),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: () => Schema.decodeSync(Person)({ name: "Jane", age: 25 }),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => { readonly age: number; readonly name: string; }; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.try
+      args: (constant)
+      outType: Effect<{ readonly age: number; readonly name: string; }, ExampleError, never>
+
+=== Piping Flow ===
+Location: 13:13 - 13:66
+Node: Schema.decodeSync(Person)({ name: "Jane", age: 25 })
+Node Kind: KindCallExpression
+
+Subject: { name: "Jane", age: 25 }
+Subject Type: { name: string; age: number; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.decodeSync(Person)
+      args: (constant)
+      outType: { readonly age: number; readonly name: string; }
+
+=== Piping Flow ===
+Location: 17:34 - 17:117
+Node: Effect.tryPromise(async () => Schema.encodeSync(Person)({ name: "Bob", age: 40 }))
+Node Kind: KindCallExpression
+
+Subject: async () => Schema.encodeSync(Person)({ name: "Bob", age: 40 })
+Subject Type: () => Promise<{ readonly age: number; readonly name: string; }>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<{ readonly age: number; readonly name: string; }, UnknownError, never>
+
+=== Piping Flow ===
+Location: 17:64 - 17:116
+Node: Schema.encodeSync(Person)({ name: "Bob", age: 40 })
+Node Kind: KindCallExpression
+
+Subject: { name: "Bob", age: 40 }
+Subject Type: { name: string; age: number; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.encodeSync(Person)
+      args: (constant)
+      outType: { readonly age: number; readonly name: string; }
+
+=== Piping Flow ===
+Location: 19:40 - 22:3
+Node: Effect.tryPromise({\n  try: async () => Schema.encodeUnknownSync(Person)({ name: "Carol", age: 50 }),\n  catch: () => new ExampleError()\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  try: async () => Schema.encodeUnknownSync(Person)({ name: "Carol", age: 50 }),\n  catch: () => new ExampleError()\n}
+Subject Type: { try: () => Promise<{ readonly age: number; readonly name: string; }>; catch: () => ExampleError; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.tryPromise
+      args: (constant)
+      outType: Effect<{ readonly age: number; readonly name: string; }, ExampleError, never>
+
+=== Piping Flow ===
+Location: 20:19 - 20:80
+Node: Schema.encodeUnknownSync(Person)({ name: "Carol", age: 50 })
+Node Kind: KindCallExpression
+
+Subject: { name: "Carol", age: 50 }
+Subject Type: { name: string; age: number; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.encodeUnknownSync(Person)
+      args: (constant)
+      outType: { readonly age: number; readonly name: string; }
+
+=== Piping Flow ===
+Location: 24:48 - 26:2
+Node: Effect.sync(\n  () => () => Schema.decodeSync(Person)({ name: "Nested", age: 10 })\n)
+Node Kind: KindCallExpression
+
+Subject: () => () => Schema.decodeSync(Person)({ name: "Nested", age: 10 })
+Subject Type: () => () => { readonly age: number; readonly name: string; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.sync
+      args: (constant)
+      outType: Effect<() => { readonly age: number; readonly name: string; }, never, never>
+
+=== Piping Flow ===
+Location: 25:14 - 25:69
+Node: Schema.decodeSync(Person)({ name: "Nested", age: 10 })
+Node Kind: KindCallExpression
+
+Subject: { name: "Nested", age: 10 }
+Subject Type: { name: string; age: number; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.decodeSync(Person)
+      args: (constant)
+      outType: { readonly age: number; readonly name: string; }

--- a/testdata/baselines/reference/effect-v4/schemaSyncInEffect_thunks.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/schemaSyncInEffect_thunks.quickfixes.txt
@@ -1,0 +1,43 @@
+=== Quick Fix Inventory ===
+
+[D1] (10:47-10:64) TS377037: `Schema.decodeSync` is used inside an Effect generator. `Schema.decodeEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+  Fix 0: "Disable schemaSyncInEffect for this line"
+  Fix 1: "Disable schemaSyncInEffect for entire file"
+
+[D2] (13:14-13:31) TS377037: `Schema.decodeSync` is used inside an Effect generator. `Schema.decodeEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+  Fix 0: "Disable schemaSyncInEffect for this line"
+  Fix 1: "Disable schemaSyncInEffect for entire file"
+
+[D3] (17:65-17:82) TS377037: `Schema.encodeSync` is used inside an Effect generator. `Schema.encodeEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+  Fix 0: "Disable schemaSyncInEffect for this line"
+  Fix 1: "Disable schemaSyncInEffect for entire file"
+
+[D4] (20:20-20:44) TS377037: `Schema.encodeUnknownSync` is used inside an Effect generator. `Schema.encodeUnknownEffect` preserves the typed Effect error channel for this operation without throwing. effect(schemaSyncInEffect)
+  Fix 0: "Disable schemaSyncInEffect for this line"
+  Fix 1: "Disable schemaSyncInEffect for entire file"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable schemaSyncInEffect for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable schemaSyncInEffect for entire file" ===
+skipped by default
+
+=== [D2] Fix 0: "Disable schemaSyncInEffect for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable schemaSyncInEffect for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable schemaSyncInEffect for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable schemaSyncInEffect for entire file" ===
+skipped by default
+
+=== [D4] Fix 0: "Disable schemaSyncInEffect for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable schemaSyncInEffect for entire file" ===
+skipped by default

--- a/testdata/baselines/reference/metadata.json
+++ b/testdata/baselines/reference/metadata.json
@@ -1064,7 +1064,13 @@
       ],
       "preview": {
         "sourceText": "import { Effect } from \"effect\"\n\nexport const preview = Effect.gen(function*() {\n  return yield* Effect.promise(() =\u003e fetch(\"https://example.com\"))\n})\n",
-        "diagnostics": []
+        "diagnostics": [
+          {
+            "start": 118,
+            "end": 123,
+            "text": "This Effect code calls the global `fetch` function, HTTP requests in Effect code are represented through `HttpClient` from `effect/unstable/http`. effect(globalFetchInEffect)"
+          }
+        ]
       }
     },
     {
@@ -1356,6 +1362,30 @@
       }
     },
     {
+      "name": "effectDoNotation",
+      "group": "style",
+      "description": "Suggests using Effect.gen or Effect.fn instead of the Effect.Do notation helpers",
+      "defaultSeverity": "off",
+      "fixable": false,
+      "supportedEffect": [
+        "v3",
+        "v4"
+      ],
+      "codes": [
+        377085
+      ],
+      "preview": {
+        "sourceText": "import { Effect } from \"effect\"\nimport { pipe } from \"effect/Function\"\n\nexport const preview = pipe(\n  Effect.Do,\n  Effect.bind(\"a\", () =\u003e Effect.succeed(1)),\n  Effect.let(\"b\", ({ a }) =\u003e a + 1),\n  Effect.bind(\"c\", ({ b }) =\u003e Effect.succeed(b.toString()))\n)\n",
+        "diagnostics": [
+          {
+            "start": 103,
+            "end": 112,
+            "text": "This uses the Effect do emulation. `Effect.gen` or `Effect.fn` achieve the same result with native JS scopes. effect(effectDoNotation)"
+          }
+        ]
+      }
+    },
+    {
       "name": "effectFnOpportunity",
       "group": "style",
       "description": "Suggests using Effect.fn for functions that return an Effect",
@@ -1375,6 +1405,30 @@
             "start": 54,
             "end": 61,
             "text": "This expression can be rewritten in the reusable function form `Effect.fn(function*() { ... })`. effect(effectFnOpportunity)"
+          }
+        ]
+      }
+    },
+    {
+      "name": "effectMapFlatten",
+      "group": "style",
+      "description": "Suggests using Effect.flatMap instead of Effect.map followed by Effect.flatten in piping flows",
+      "defaultSeverity": "suggestion",
+      "fixable": false,
+      "supportedEffect": [
+        "v3",
+        "v4"
+      ],
+      "codes": [
+        377086
+      ],
+      "preview": {
+        "sourceText": "import { Effect } from \"effect\"\n\nexport const preview = Effect.succeed(1).pipe(\n  Effect.map((n) =\u003e Effect.succeed(n + 1)),\n  Effect.flatten\n)\n",
+        "diagnostics": [
+          {
+            "start": 126,
+            "end": 140,
+            "text": "`Effect.map` + `Effect.flatten` is the same as `Effect.flatMap` that expresses the same steps more directly. effect(effectMapFlatten)"
           }
         ]
       }
@@ -1471,6 +1525,30 @@
             "start": 128,
             "end": 132,
             "text": "Service 'Db' is required but not provided by dependencies. effect(missingEffectServiceDependency)"
+          }
+        ]
+      }
+    },
+    {
+      "name": "nestedEffectGenYield",
+      "group": "style",
+      "description": "Warns when yielding a nested bare Effect.gen inside an existing Effect generator context",
+      "defaultSeverity": "off",
+      "fixable": false,
+      "supportedEffect": [
+        "v3",
+        "v4"
+      ],
+      "codes": [
+        377083
+      ],
+      "preview": {
+        "sourceText": "import { Effect } from \"effect\"\n\nexport const preview = Effect.gen(function*() {\n\tyield* Effect.gen(function*() {\n\t\treturn 1\n\t})\n})\n",
+        "diagnostics": [
+          {
+            "start": 89,
+            "end": 128,
+            "text": "This `yield*` is applied to a nested `Effect.gen(...)` that can be inlined in the parent Effect generator context. effect(nestedEffectGenYield)"
           }
         ]
       }
@@ -1594,6 +1672,30 @@
             "start": 64,
             "end": 69,
             "text": "Unexpected `undefined` type in condition, expected strictly a boolean instead. effect(strictBooleanExpressions)"
+          }
+        ]
+      }
+    },
+    {
+      "name": "unnecessaryArrowBlock",
+      "group": "style",
+      "description": "Suggests using a concise arrow body when the block only returns an expression",
+      "defaultSeverity": "off",
+      "fixable": true,
+      "supportedEffect": [
+        "v3",
+        "v4"
+      ],
+      "codes": [
+        377084
+      ],
+      "preview": {
+        "sourceText": "export const preview = (value: string) =\u003e {\n\treturn value.trim()\n}\n",
+        "diagnostics": [
+          {
+            "start": 42,
+            "end": 66,
+            "text": "This arrow function block only returns an expression and can use a concise body. effect(unnecessaryArrowBlock)"
           }
         ]
       }

--- a/testdata/tests/effect-v3/globalConsoleInEffect_thunks.ts
+++ b/testdata/tests/effect-v3/globalConsoleInEffect_thunks.ts
@@ -1,0 +1,20 @@
+// @effect-diagnostics globalConsoleInEffect:warning
+import { Data, Effect } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+export const consoleInSync = Effect.sync(() => console.log("sync"))
+
+export const consoleInTryObject = Effect.try({
+  try: () => console.warn("try"),
+  catch: () => new ExampleError()
+})
+
+export const consoleInTryPromise = Effect.tryPromise(async () => console.log("try-promise"))
+
+export const consoleInTryPromiseObject = Effect.tryPromise({
+  try: async () => console.warn("try-promise-object"),
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => console.log("nested"))

--- a/testdata/tests/effect-v3/globalDateInEffect_thunks.ts
+++ b/testdata/tests/effect-v3/globalDateInEffect_thunks.ts
@@ -1,0 +1,20 @@
+// @effect-diagnostics globalDateInEffect:warning
+import { Data, Effect } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+export const dateInSync = Effect.sync(() => Date.now())
+
+export const newDateInTryObject = Effect.try({
+  try: () => new Date(),
+  catch: () => new ExampleError()
+})
+
+export const dateInTryPromise = Effect.tryPromise(async () => Date.now())
+
+export const newDateInTryPromiseObject = Effect.tryPromise({
+  try: async () => new Date(),
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => Date.now())

--- a/testdata/tests/effect-v3/globalFetchInEffect_thunks.ts
+++ b/testdata/tests/effect-v3/globalFetchInEffect_thunks.ts
@@ -1,0 +1,20 @@
+// @effect-diagnostics globalFetchInEffect:warning
+import { Data, Effect } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+export const fetchInSync = Effect.sync(() => fetch("https://example.com/sync"))
+
+export const fetchInTryObject = Effect.try({
+  try: () => fetch("https://example.com/try"),
+  catch: () => new ExampleError()
+})
+
+export const fetchInTryPromise = Effect.tryPromise(async () => fetch("https://example.com/try-promise"))
+
+export const fetchInTryPromiseObject = Effect.tryPromise({
+  try: async () => fetch("https://example.com/try-promise-object"),
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => fetch("https://example.com/nested"))

--- a/testdata/tests/effect-v3/globalRandomInEffect_thunks.ts
+++ b/testdata/tests/effect-v3/globalRandomInEffect_thunks.ts
@@ -1,0 +1,20 @@
+// @effect-diagnostics globalRandomInEffect:warning
+import { Data, Effect } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+export const randomInSync = Effect.sync(() => Math.random())
+
+export const randomInTryObject = Effect.try({
+  try: () => Math.random(),
+  catch: () => new ExampleError()
+})
+
+export const randomInTryPromise = Effect.tryPromise(async () => Math.random())
+
+export const randomInTryPromiseObject = Effect.tryPromise({
+  try: async () => Math.random(),
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => Math.random())

--- a/testdata/tests/effect-v3/globalTimersInEffect_thunks.ts
+++ b/testdata/tests/effect-v3/globalTimersInEffect_thunks.ts
@@ -1,0 +1,20 @@
+// @effect-diagnostics globalTimersInEffect:warning
+import { Data, Effect } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+export const timeoutInSync = Effect.sync(() => setTimeout(() => {}, 100))
+
+export const intervalInTryObject = Effect.try({
+  try: () => setInterval(() => {}, 100),
+  catch: () => new ExampleError()
+})
+
+export const timeoutInTryPromise = Effect.tryPromise(async () => setTimeout(() => {}, 100))
+
+export const intervalInTryPromiseObject = Effect.tryPromise({
+  try: async () => setInterval(() => {}, 100),
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => setTimeout(() => {}, 100))

--- a/testdata/tests/effect-v3/processEnvInEffect_thunks.ts
+++ b/testdata/tests/effect-v3/processEnvInEffect_thunks.ts
@@ -1,0 +1,21 @@
+// @effect-diagnostics processEnvInEffect:warning
+/// <reference types="node" />
+import { Data, Effect } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+export const envInSync = Effect.sync(() => process.env.SYNC_SECRET)
+
+export const envInTryObject = Effect.try({
+  try: () => process.env.TRY_SECRET,
+  catch: () => new ExampleError()
+})
+
+export const envInTryPromise = Effect.tryPromise(async () => process.env.TRY_PROMISE_SECRET)
+
+export const envInTryPromiseObject = Effect.tryPromise({
+  try: async () => process.env.TRY_PROMISE_OBJECT_SECRET,
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => process.env.NESTED_SECRET)

--- a/testdata/tests/effect-v3/schemaSyncInEffect_thunks.ts
+++ b/testdata/tests/effect-v3/schemaSyncInEffect_thunks.ts
@@ -1,0 +1,26 @@
+import { Data, Effect, Schema } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+const Person = Schema.Struct({
+  name: Schema.String,
+  age: Schema.Number
+})
+
+export const decodeInSync = Effect.sync(() => Schema.decodeSync(Person)({ name: "John", age: 30 }))
+
+export const decodeInTryObject = Effect.try({
+  try: () => Schema.decodeSync(Person)({ name: "Jane", age: 25 }),
+  catch: () => new ExampleError()
+})
+
+export const encodeInTryPromise = Effect.tryPromise(async () => Schema.encodeSync(Person)({ name: "Bob", age: 40 }))
+
+export const encodeInTryPromiseObject = Effect.tryPromise({
+  try: async () => Schema.encodeUnknownSync(Person)({ name: "Carol", age: 50 }),
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(
+  () => () => Schema.decodeSync(Person)({ name: "Nested", age: 10 })
+)

--- a/testdata/tests/effect-v4/cryptoRandomUUIDInEffect_thunks.ts
+++ b/testdata/tests/effect-v4/cryptoRandomUUIDInEffect_thunks.ts
@@ -1,0 +1,20 @@
+// @effect-diagnostics cryptoRandomUUIDInEffect:warning
+import { Data, Effect } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+export const uuidInSync = Effect.sync(() => crypto.randomUUID())
+
+export const uuidInTryObject = Effect.try({
+  try: () => crypto.randomUUID(),
+  catch: () => new ExampleError()
+})
+
+export const uuidInTryPromise = Effect.tryPromise(async () => crypto.randomUUID())
+
+export const uuidInTryPromiseObject = Effect.tryPromise({
+  try: async () => crypto.randomUUID(),
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => crypto.randomUUID())

--- a/testdata/tests/effect-v4/globalConsoleInEffect_thunks.ts
+++ b/testdata/tests/effect-v4/globalConsoleInEffect_thunks.ts
@@ -1,0 +1,20 @@
+// @effect-diagnostics globalConsoleInEffect:warning
+import { Data, Effect } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+export const consoleInSync = Effect.sync(() => console.log("sync"))
+
+export const consoleInTryObject = Effect.try({
+  try: () => console.warn("try"),
+  catch: () => new ExampleError()
+})
+
+export const consoleInTryPromise = Effect.tryPromise(async () => console.log("try-promise"))
+
+export const consoleInTryPromiseObject = Effect.tryPromise({
+  try: async () => console.warn("try-promise-object"),
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => console.log("nested"))

--- a/testdata/tests/effect-v4/globalDateInEffect_thunks.ts
+++ b/testdata/tests/effect-v4/globalDateInEffect_thunks.ts
@@ -1,0 +1,20 @@
+// @effect-diagnostics globalDateInEffect:warning
+import { Data, Effect } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+export const dateInSync = Effect.sync(() => Date.now())
+
+export const newDateInTryObject = Effect.try({
+  try: () => new Date(),
+  catch: () => new ExampleError()
+})
+
+export const dateInTryPromise = Effect.tryPromise(async () => Date.now())
+
+export const newDateInTryPromiseObject = Effect.tryPromise({
+  try: async () => new Date(),
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => Date.now())

--- a/testdata/tests/effect-v4/globalFetchInEffect_thunks.ts
+++ b/testdata/tests/effect-v4/globalFetchInEffect_thunks.ts
@@ -1,0 +1,20 @@
+// @effect-diagnostics globalFetchInEffect:warning
+import { Data, Effect } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+export const fetchInSync = Effect.sync(() => fetch("https://example.com/sync"))
+
+export const fetchInTryObject = Effect.try({
+  try: () => fetch("https://example.com/try"),
+  catch: () => new ExampleError()
+})
+
+export const fetchInTryPromise = Effect.tryPromise(async () => fetch("https://example.com/try-promise"))
+
+export const fetchInTryPromiseObject = Effect.tryPromise({
+  try: async () => fetch("https://example.com/try-promise-object"),
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => fetch("https://example.com/nested"))

--- a/testdata/tests/effect-v4/globalRandomInEffect_thunks.ts
+++ b/testdata/tests/effect-v4/globalRandomInEffect_thunks.ts
@@ -1,0 +1,20 @@
+// @effect-diagnostics globalRandomInEffect:warning
+import { Data, Effect } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+export const randomInSync = Effect.sync(() => Math.random())
+
+export const randomInTryObject = Effect.try({
+  try: () => Math.random(),
+  catch: () => new ExampleError()
+})
+
+export const randomInTryPromise = Effect.tryPromise(async () => Math.random())
+
+export const randomInTryPromiseObject = Effect.tryPromise({
+  try: async () => Math.random(),
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => Math.random())

--- a/testdata/tests/effect-v4/globalTimersInEffect_thunks.ts
+++ b/testdata/tests/effect-v4/globalTimersInEffect_thunks.ts
@@ -1,0 +1,20 @@
+// @effect-diagnostics globalTimersInEffect:warning
+import { Data, Effect } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+export const timeoutInSync = Effect.sync(() => setTimeout(() => {}, 100))
+
+export const intervalInTryObject = Effect.try({
+  try: () => setInterval(() => {}, 100),
+  catch: () => new ExampleError()
+})
+
+export const timeoutInTryPromise = Effect.tryPromise(async () => setTimeout(() => {}, 100))
+
+export const intervalInTryPromiseObject = Effect.tryPromise({
+  try: async () => setInterval(() => {}, 100),
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => setTimeout(() => {}, 100))

--- a/testdata/tests/effect-v4/processEnvInEffect_thunks.ts
+++ b/testdata/tests/effect-v4/processEnvInEffect_thunks.ts
@@ -1,0 +1,21 @@
+// @effect-diagnostics processEnvInEffect:warning
+/// <reference types="node" />
+import { Data, Effect } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+export const envInSync = Effect.sync(() => process.env.SYNC_SECRET)
+
+export const envInTryObject = Effect.try({
+  try: () => process.env.TRY_SECRET,
+  catch: () => new ExampleError()
+})
+
+export const envInTryPromise = Effect.tryPromise(async () => process.env.TRY_PROMISE_SECRET)
+
+export const envInTryPromiseObject = Effect.tryPromise({
+  try: async () => process.env.TRY_PROMISE_OBJECT_SECRET,
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(() => () => process.env.NESTED_SECRET)

--- a/testdata/tests/effect-v4/schemaSyncInEffect_thunks.ts
+++ b/testdata/tests/effect-v4/schemaSyncInEffect_thunks.ts
@@ -1,0 +1,26 @@
+import { Data, Effect, Schema } from "effect"
+
+class ExampleError extends Data.TaggedError("ExampleError")<{}> {}
+
+const Person = Schema.Struct({
+  name: Schema.String,
+  age: Schema.Number
+})
+
+export const decodeInSync = Effect.sync(() => Schema.decodeSync(Person)({ name: "John", age: 30 }))
+
+export const decodeInTryObject = Effect.try({
+  try: () => Schema.decodeSync(Person)({ name: "Jane", age: 25 }),
+  catch: () => new ExampleError()
+})
+
+export const encodeInTryPromise = Effect.tryPromise(async () => Schema.encodeSync(Person)({ name: "Bob", age: 40 }))
+
+export const encodeInTryPromiseObject = Effect.tryPromise({
+  try: async () => Schema.encodeUnknownSync(Person)({ name: "Carol", age: 50 }),
+  catch: () => new ExampleError()
+})
+
+export const shouldNotTriggerReturnedFunction = Effect.sync(
+  () => () => Schema.decodeSync(Person)({ name: "Nested", age: 10 })
+)


### PR DESCRIPTION
## Summary
- port the Effect context tracking refactor from reference commit `14d57985e22545c49f6b8fba954096f3cb670372`
- teach thunk-aware diagnostics to treat `Effect.sync`, `Effect.promise`, `Effect.try`, `Effect.tryPromise`, `Effect.callback`, and `Effect.suspend` bodies as Effect context where applicable
- add v3 and v4 thunk-focused fixtures, baselines, metadata updates, and a changeset for the port

## Validation
- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`