### PR TITLE
chore: update typescript-go to 8c45757f8

### DIFF
--- a/.changeset/update-typescript-go-8c45757f.md
+++ b/.changeset/update-typescript-go-8c45757f.md
@@ -1,0 +1,7 @@
+---
+"@effect/tsgo": patch
+---
+
+Update the bundled `typescript-go` submodule to `8c45757f8` and refresh the local compatibility layer for the upstream hover and printer API changes.
+
+This updates the hover patch, regenerates shims, and adjusts local callers to the new `TypeToStringEx` and `SignatureToStringEx` signatures so setup, check, test, and lint continue to pass.

--- a/_patches/012-ls-hover.patch
+++ b/_patches/012-ls-hover.patch
@@ -1,5 +1,5 @@
 diff --git a/internal/ls/hover.go b/internal/ls/hover.go
-index 32bbf9347..bd7bb3709 100644
+index 564109a83..7a403395d 100644
 --- a/internal/ls/hover.go
 +++ b/internal/ls/hover.go
 @@ -20,6 +20,18 @@ const (
@@ -18,13 +18,13 @@ index 32bbf9347..bd7bb3709 100644
 +	AfterQuickInfoCallback = cb
 +}
 +
- func (l *LanguageService) ProvideHover(ctx context.Context, documentURI lsproto.DocumentUri, lspPosition lsproto.Position) (lsproto.HoverResponse, error) {
+ func (l *LanguageService) ProvideHover(ctx context.Context, params *lsproto.HoverParams) (lsproto.HoverResponse, error) {
  	caps := lsproto.GetClientCapabilities(ctx)
  	contentFormat := lsproto.PreferredMarkupKind(caps.TextDocument.Hover.ContentFormat)
-@@ -36,6 +48,17 @@ func (l *LanguageService) ProvideHover(ctx context.Context, documentURI lsproto.
- 	rangeNode := getNodeForQuickInfo(node)
- 	symbol := getSymbolAtLocationForQuickInfo(c, node)
- 	quickInfo, documentation := l.getQuickInfoAndDocumentationForSymbol(c, symbol, rangeNode, contentFormat)
+@@ -54,6 +66,17 @@ func (l *LanguageService) ProvideHover(ctx context.Context, params *lsproto.Hove
+ 	}
+ 
+ 	quickInfo, documentation := l.getQuickInfoAndDocumentationForSymbol(c, symbol, rangeNode, contentFormat, vc)
 +
 +	// EFFECT HOOK: Allow Effect to enrich hover responses
 +	if AfterQuickInfoCallback != nil {

--- a/etslshooks/document_symbols.go
+++ b/etslshooks/document_symbols.go
@@ -311,7 +311,7 @@ func typeToDetail(c *checker.Checker, t *checker.Type, node *ast.Node) *string {
 	if c == nil || t == nil || node == nil {
 		return nil
 	}
-	detail := c.TypeToStringEx(t, node, checker.TypeFormatFlagsNoTruncation)
+	detail := c.TypeToStringEx(t, node, checker.TypeFormatFlagsNoTruncation, nil)
 	return &detail
 }
 
@@ -346,9 +346,9 @@ func layerSymbolDetail(tp *typeparser.TypeParser, c *checker.Checker, node *ast.
 		if layer == nil {
 			continue
 		}
-		rOut := c.TypeToStringEx(layer.ROut, typeCheckNode, checker.TypeFormatFlagsNoTruncation)
-		e := c.TypeToStringEx(layer.E, typeCheckNode, checker.TypeFormatFlagsNoTruncation)
-		rIn := c.TypeToStringEx(layer.RIn, typeCheckNode, checker.TypeFormatFlagsNoTruncation)
+		rOut := c.TypeToStringEx(layer.ROut, typeCheckNode, checker.TypeFormatFlagsNoTruncation, nil)
+		e := c.TypeToStringEx(layer.E, typeCheckNode, checker.TypeFormatFlagsNoTruncation, nil)
+		rIn := c.TypeToStringEx(layer.RIn, typeCheckNode, checker.TypeFormatFlagsNoTruncation, nil)
 		detail := "<" + rOut + ", " + e + ", " + rIn + ">"
 		return &detail
 	}

--- a/etslshooks/init.go
+++ b/etslshooks/init.go
@@ -184,7 +184,7 @@ func afterQuickInfo(program checker.Program, c *checker.Checker, sf *ast.SourceF
 				if t != nil {
 					effect := tp.EffectYieldableType(t, yield.Expression)
 					if effect != nil {
-						typeStr := c.TypeToStringEx(t, nil, checker.TypeFormatFlagsNoTruncation)
+						typeStr := c.TypeToStringEx(t, nil, checker.TypeFormatFlagsNoTruncation, nil)
 						quickInfo = "(yield*) " + typeStr
 						documentation = formatEffectTypeParams(c, effect, "", isMarkdown)
 						return quickInfo, documentation, node.Parent
@@ -307,9 +307,9 @@ func formatLayerHover(tp *typeparser.TypeParser, c *checker.Checker, sf *ast.Sou
 
 // formatLayerTypeParams formats Layer type parameters (Provides, Error, Requires).
 func formatLayerTypeParams(c *checker.Checker, layer *typeparser.Layer, isMarkdown bool) string {
-	rOutStr := c.TypeToStringEx(layer.ROut, nil, checker.TypeFormatFlagsNoTruncation)
-	eStr := c.TypeToStringEx(layer.E, nil, checker.TypeFormatFlagsNoTruncation)
-	rInStr := c.TypeToStringEx(layer.RIn, nil, checker.TypeFormatFlagsNoTruncation)
+	rOutStr := c.TypeToStringEx(layer.ROut, nil, checker.TypeFormatFlagsNoTruncation, nil)
+	eStr := c.TypeToStringEx(layer.E, nil, checker.TypeFormatFlagsNoTruncation, nil)
+	rInStr := c.TypeToStringEx(layer.RIn, nil, checker.TypeFormatFlagsNoTruncation, nil)
 
 	if isMarkdown {
 		return fmt.Sprintf("```ts\n/* Layer Type Parameters */\ntype Provides = %s\ntype Error = %s\ntype Requires = %s\n```\n", rOutStr, eStr, rInStr)
@@ -335,9 +335,9 @@ func isDeclarationName(node *ast.Node) bool {
 
 // formatEffectTypeParams formats Effect type parameters (A, E, R) and prepends them to documentation.
 func formatEffectTypeParams(c *checker.Checker, effect *typeparser.Effect, documentation string, isMarkdown bool) string {
-	aStr := c.TypeToStringEx(effect.A, nil, checker.TypeFormatFlagsNoTruncation)
-	eStr := c.TypeToStringEx(effect.E, nil, checker.TypeFormatFlagsNoTruncation)
-	rStr := c.TypeToStringEx(effect.R, nil, checker.TypeFormatFlagsNoTruncation)
+	aStr := c.TypeToStringEx(effect.A, nil, checker.TypeFormatFlagsNoTruncation, nil)
+	eStr := c.TypeToStringEx(effect.E, nil, checker.TypeFormatFlagsNoTruncation, nil)
+	rStr := c.TypeToStringEx(effect.R, nil, checker.TypeFormatFlagsNoTruncation, nil)
 
 	var prefix string
 	if isMarkdown {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     /* Source of truth: git submodule `typescript-go` commit.
        Keep in sync via `_tools/update-flake-vendor-hash.sh`. */
     typescript-go-src = {
-      url = "github:microsoft/typescript-go/cf6d69d83c999e5e12ec9d81aec3883fe8d8b110?submodules=1";
+      url = "github:microsoft/typescript-go/8c45757f80cc94cdeea0f5f99b57fd547c1f229d?submodules=1";
       flake = false;
     };
     /* Source of truth: typescript-go's `_submodules/TypeScript` commit.

--- a/internal/effecttest/baseline.go
+++ b/internal/effecttest/baseline.go
@@ -278,7 +278,7 @@ func generatePipingFlowBaseline(
 			subjectText := scanner.GetSourceTextOfNodeFromSourceFile(sf, flow.Subject.Node, false)
 			fmt.Fprintf(&sb, "Subject: %s\n", escapeNewlines(subjectText))
 			if flow.Subject.OutType != nil {
-				fmt.Fprintf(&sb, "Subject Type: %s\n", c.TypeToStringEx(flow.Subject.OutType, nil, checker.TypeFormatFlagsNoTruncation))
+				fmt.Fprintf(&sb, "Subject Type: %s\n", c.TypeToStringEx(flow.Subject.OutType, nil, checker.TypeFormatFlagsNoTruncation, nil))
 			} else {
 				sb.WriteString("Subject Type: \n")
 			}
@@ -303,7 +303,7 @@ func generatePipingFlowBaseline(
 
 				outTypeStr := ""
 				if t.OutType != nil {
-					outTypeStr = c.TypeToStringEx(t.OutType, nil, checker.TypeFormatFlagsNoTruncation)
+					outTypeStr = c.TypeToStringEx(t.OutType, nil, checker.TypeFormatFlagsNoTruncation, nil)
 				}
 
 				fmt.Fprintf(&sb, "  [%d] kind: %s\n", i, string(t.Kind))
@@ -451,7 +451,7 @@ func formatExecutionType(c *checker.Checker, typ *checker.Type) string {
 	if typ == nil {
 		return ""
 	}
-	return c.TypeToStringEx(typ, nil, checker.TypeFormatFlagsNoTruncation)
+	return c.TypeToStringEx(typ, nil, checker.TypeFormatFlagsNoTruncation, nil)
 }
 
 func formatExecutionSourceNode(sf *ast.SourceFile, node *ast.Node) string {

--- a/internal/layergraph/format.go
+++ b/internal/layergraph/format.go
@@ -106,7 +106,7 @@ func formatLocation(node *ast.Node, fromSourceFile *ast.SourceFile) string {
 
 // getTypeDisplayName returns the string representation of a type with no truncation.
 func getTypeDisplayName(c *checker.Checker, t *checker.Type) string {
-	return c.TypeToStringEx(t, nil, checker.TypeFormatFlagsNoTruncation)
+	return c.TypeToStringEx(t, nil, checker.TypeFormatFlagsNoTruncation, nil)
 }
 
 // mermaidEscapeOutputLabel applies standard Mermaid escaping for backslash, brackets, and pipe

--- a/internal/refactors/layer_magic.go
+++ b/internal/refactors/layer_magic.go
@@ -202,7 +202,7 @@ func buildLayerMagicBuild(tracker *change.Tracker, ctx *refactor.Context, c *che
 	if len(magicResult.MissingOutputTypes) > 0 {
 		var typeNames []string
 		for _, t := range magicResult.MissingOutputTypes {
-			typeNames = append(typeNames, c.TypeToStringEx(t, nil, checker.TypeFormatFlagsNoTruncation))
+			typeNames = append(typeNames, c.TypeToStringEx(t, nil, checker.TypeFormatFlagsNoTruncation, nil))
 		}
 		comment := " Unable to find " + strings.Join(typeNames, ", ") + " in the provided layers. "
 		newDeclaration = tracker.AddSyntheticTrailingComment(newDeclaration, ast.KindMultiLineCommentTrivia, comment, false)
@@ -339,7 +339,7 @@ func buildLayerMagicPrepare(
 	} else {
 		var typeNodes []*ast.Node
 		for _, t := range newlyIntroduced {
-			typeStr := c.TypeToStringEx(t, nil, checker.TypeFormatFlagsNoTruncation)
+			typeStr := c.TypeToStringEx(t, nil, checker.TypeFormatFlagsNoTruncation, nil)
 			typeNodes = append(typeNodes, tracker.NewTypeReferenceNode(tracker.NewIdentifier(typeStr), nil))
 		}
 		if len(typeNodes) == 1 {
@@ -353,7 +353,7 @@ func buildLayerMagicPrepare(
 	if len(existingBefore) > 0 {
 		var typeStrings []string
 		for _, t := range existingBefore {
-			typeStrings = append(typeStrings, c.TypeToStringEx(t, nil, checker.TypeFormatFlagsNoTruncation))
+			typeStrings = append(typeStrings, c.TypeToStringEx(t, nil, checker.TypeFormatFlagsNoTruncation, nil))
 		}
 		comment := " " + strings.Join(typeStrings, " | ") + " "
 		providesType = tracker.AddSyntheticTrailingComment(providesType, ast.KindMultiLineCommentTrivia, comment, false)
@@ -400,8 +400,8 @@ func sortedTypeSlice(c *checker.Checker, types map[*checker.Type]bool) []*checke
 		result = append(result, t)
 	}
 	sort.Slice(result, func(i, j int) bool {
-		return c.TypeToStringEx(result[i], nil, checker.TypeFormatFlagsNoTruncation) <
-			c.TypeToStringEx(result[j], nil, checker.TypeFormatFlagsNoTruncation)
+		return c.TypeToStringEx(result[i], nil, checker.TypeFormatFlagsNoTruncation, nil) <
+			c.TypeToStringEx(result[j], nil, checker.TypeFormatFlagsNoTruncation, nil)
 	})
 	return result
 }

--- a/internal/refactors/toggle_return_type_annotation.go
+++ b/internal/refactors/toggle_return_type_annotation.go
@@ -88,7 +88,7 @@ func runToggleReturnTypeAnnotation(ctx *refactor.Context) []ls.CodeAction {
 		return nil
 	}
 
-	typeStr := c.TypeToStringEx(returnType, matchedNode, checker.TypeFormatFlagsNoTruncation)
+	typeStr := c.TypeToStringEx(returnType, matchedNode, checker.TypeFormatFlagsNoTruncation, nil)
 	if typeStr == "" {
 		return nil
 	}

--- a/internal/refactors/toggle_type_annotation.go
+++ b/internal/refactors/toggle_type_annotation.go
@@ -103,7 +103,7 @@ func runToggleTypeAnnotation(ctx *refactor.Context) []ls.CodeAction {
 		return nil
 	}
 
-	typeStr := c.TypeToStringEx(initializerType, matchedNode, checker.TypeFormatFlagsNoTruncation)
+	typeStr := c.TypeToStringEx(initializerType, matchedNode, checker.TypeFormatFlagsNoTruncation, nil)
 	if typeStr == "" {
 		return nil
 	}

--- a/internal/refactors/write_tag_class_accessors.go
+++ b/internal/refactors/write_tag_class_accessors.go
@@ -292,7 +292,7 @@ func buildProxySignatureText(
 			constraintType := c.GetConstraintOfTypeParameter(tp)
 			if constraintType != nil {
 				sb.WriteString(" extends ")
-				sb.WriteString(c.TypeToStringEx(constraintType, classNode, checker.TypeFormatFlagsNoTruncation))
+				sb.WriteString(c.TypeToStringEx(constraintType, classNode, checker.TypeFormatFlagsNoTruncation, nil))
 			}
 		}
 		sb.WriteString(">")
@@ -311,7 +311,7 @@ func buildProxySignatureText(
 		sb.WriteString(param.Name)
 		sb.WriteString(": ")
 		paramType := c.GetTypeOfSymbolAtLocation(param, classNode)
-		sb.WriteString(c.TypeToStringEx(paramType, classNode, checker.TypeFormatFlagsNoTruncation))
+		sb.WriteString(c.TypeToStringEx(paramType, classNode, checker.TypeFormatFlagsNoTruncation, nil))
 	}
 	sb.WriteString(")")
 
@@ -336,27 +336,27 @@ func buildWrappedReturnTypeText(
 	// Try to parse as Effect type
 	effect := tp.EffectType(returnType, classNode)
 	if effect != nil {
-		aStr := c.TypeToStringEx(effect.A, classNode, checker.TypeFormatFlagsNoTruncation)
-		eStr := c.TypeToStringEx(effect.E, classNode, checker.TypeFormatFlagsNoTruncation)
+		aStr := c.TypeToStringEx(effect.A, classNode, checker.TypeFormatFlagsNoTruncation, nil)
+		eStr := c.TypeToStringEx(effect.E, classNode, checker.TypeFormatFlagsNoTruncation, nil)
 
 		var rStr string
 		if effect.R != nil && effect.R.Flags()&checker.TypeFlagsNever != 0 {
 			rStr = classNameText
 		} else {
-			rStr = classNameText + " | " + c.TypeToStringEx(effect.R, classNode, checker.TypeFormatFlagsNoTruncation)
+			rStr = classNameText + " | " + c.TypeToStringEx(effect.R, classNode, checker.TypeFormatFlagsNoTruncation, nil)
 		}
 
 		return effectIdentifier + ".Effect<" + aStr + ", " + eStr + ", " + rStr + ">"
 	}
 
 	// Try to detect Promise<T>
-	returnTypeStr := c.TypeToStringEx(returnType, classNode, checker.TypeFormatFlagsNoTruncation)
+	returnTypeStr := c.TypeToStringEx(returnType, classNode, checker.TypeFormatFlagsNoTruncation, nil)
 	if innerTypeStr, ok := isPromiseTypeString(returnTypeStr); ok {
 		return effectIdentifier + ".Effect<" + innerTypeStr + ", Cause.UnknownException, " + classNameText + ">"
 	}
 
 	// Fallback: Effect<A, never, ClassName>
-	aStr := c.TypeToStringEx(returnType, classNode, checker.TypeFormatFlagsNoTruncation)
+	aStr := c.TypeToStringEx(returnType, classNode, checker.TypeFormatFlagsNoTruncation, nil)
 	return effectIdentifier + ".Effect<" + aStr + ", never, " + classNameText + ">"
 }
 

--- a/internal/typeparser/data_first_signature_test.go
+++ b/internal/typeparser/data_first_signature_test.go
@@ -241,7 +241,7 @@ func signatureString(c *checker.Checker, sig *checker.Signature) string {
 	if c == nil || sig == nil {
 		return "<nil>"
 	}
-	return c.SignatureToStringEx(sig, nil, checker.TypeFormatFlagsWriteArrowStyleSignature)
+	return c.SignatureToStringEx(sig, nil, checker.TypeFormatFlagsWriteArrowStyleSignature, nil)
 }
 
 func findFlowByNode(t *testing.T, sf *ast.SourceFile, flows []*PipingFlow, node *ast.Node) *PipingFlow {

--- a/shim/ast/shim.go
+++ b/shim/ast/shim.go
@@ -148,8 +148,6 @@ const CommentDirectiveKindExpectError = ast.CommentDirectiveKindExpectError
 const CommentDirectiveKindIgnore = ast.CommentDirectiveKindIgnore
 const CommentDirectiveKindUnknown = ast.CommentDirectiveKindUnknown
 type CommentRange = ast.CommentRange
-type CommonJSExport = ast.CommonJSExport
-type CommonJSExportNode = ast.CommonJSExportNode
 //go:linkname CompareDiagnostics github.com/microsoft/typescript-go/internal/ast.CompareDiagnostics
 func CompareDiagnostics(d1 *ast.Diagnostic, d2 *ast.Diagnostic) int
 //go:linkname CompareNodePositions github.com/microsoft/typescript-go/internal/ast.CompareNodePositions
@@ -221,8 +219,6 @@ type EqualsToken = ast.EqualsToken
 type ExclamationToken = ast.ExclamationToken
 type ExponentiationOperator = ast.ExponentiationOperator
 type ExportAssignment = ast.ExportAssignment
-//go:linkname ExportAssignmentIsAlias github.com/microsoft/typescript-go/internal/ast.ExportAssignmentIsAlias
-func ExportAssignmentIsAlias(node *ast.Node) bool
 type ExportAssignmentNode = ast.ExportAssignmentNode
 type ExportDeclaration = ast.ExportDeclaration
 type ExportDeclarationNode = ast.ExportDeclarationNode
@@ -233,6 +229,8 @@ type ExportSpecifierNode = ast.ExportSpecifierNode
 type ExportableBase = ast.ExportableBase
 type Expression = ast.Expression
 type ExpressionBase = ast.ExpressionBase
+//go:linkname ExpressionIsAlias github.com/microsoft/typescript-go/internal/ast.ExpressionIsAlias
+func ExpressionIsAlias(node *ast.Node) bool
 type ExpressionStatement = ast.ExpressionStatement
 type ExpressionStatementNode = ast.ExpressionStatementNode
 type ExpressionWithTypeArguments = ast.ExpressionWithTypeArguments
@@ -373,6 +371,8 @@ func GetFunctionFlags(node *ast.Node) ast.FunctionFlags
 func GetHeritageClause(node *ast.Node, kind ast.Kind) *ast.Node
 //go:linkname GetHeritageElements github.com/microsoft/typescript-go/internal/ast.GetHeritageElements
 func GetHeritageElements(node *ast.Node, kind ast.Kind) []*ast.Node
+//go:linkname GetHostSignatureFromJSDoc github.com/microsoft/typescript-go/internal/ast.GetHostSignatureFromJSDoc
+func GetHostSignatureFromJSDoc(node *ast.Node) *ast.Node
 //go:linkname GetImmediatelyInvokedFunctionExpression github.com/microsoft/typescript-go/internal/ast.GetImmediatelyInvokedFunctionExpression
 func GetImmediatelyInvokedFunctionExpression(fn *ast.Node) *ast.Node
 //go:linkname GetImplementsHeritageClauseElements github.com/microsoft/typescript-go/internal/ast.GetImplementsHeritageClauseElements
@@ -391,6 +391,10 @@ func GetInitializerOfBinaryExpression(expr *ast.BinaryExpression) *ast.Expressio
 func GetInvokedExpression(node *ast.Node) *ast.Node
 //go:linkname GetJSDocDeprecatedTag github.com/microsoft/typescript-go/internal/ast.GetJSDocDeprecatedTag
 func GetJSDocDeprecatedTag(node *ast.Node) *ast.Node
+//go:linkname GetJSDocHost github.com/microsoft/typescript-go/internal/ast.GetJSDocHost
+func GetJSDocHost(node *ast.Node) *ast.Node
+//go:linkname GetJSDocRoot github.com/microsoft/typescript-go/internal/ast.GetJSDocRoot
+func GetJSDocRoot(node *ast.Node) *ast.Node
 //go:linkname GetJSXImplicitImportBase github.com/microsoft/typescript-go/internal/ast.GetJSXImplicitImportBase
 func GetJSXImplicitImportBase(compilerOptions *core.CompilerOptions, file *ast.SourceFile) string
 //go:linkname GetJSXRuntimeImport github.com/microsoft/typescript-go/internal/ast.GetJSXRuntimeImport
@@ -690,8 +694,6 @@ func IsClassStaticBlockDeclaration(node *ast.Node) bool
 func IsCommaExpression(node *ast.Node) bool
 //go:linkname IsCommaSequence github.com/microsoft/typescript-go/internal/ast.IsCommaSequence
 func IsCommaSequence(node *ast.Node) bool
-//go:linkname IsCommonJSExport github.com/microsoft/typescript-go/internal/ast.IsCommonJSExport
-func IsCommonJSExport(node *ast.Node) bool
 //go:linkname IsCompoundAssignment github.com/microsoft/typescript-go/internal/ast.IsCompoundAssignment
 func IsCompoundAssignment(token ast.Kind) bool
 //go:linkname IsCompoundAssignmentOperator github.com/microsoft/typescript-go/internal/ast.IsCompoundAssignmentOperator
@@ -1020,8 +1022,6 @@ func IsJSDocTypedefTag(node *ast.Node) bool
 func IsJSDocUnknownTag(node *ast.Node) bool
 //go:linkname IsJSDocVariadicType github.com/microsoft/typescript-go/internal/ast.IsJSDocVariadicType
 func IsJSDocVariadicType(node *ast.Node) bool
-//go:linkname IsJSExportAssignment github.com/microsoft/typescript-go/internal/ast.IsJSExportAssignment
-func IsJSExportAssignment(node *ast.Node) bool
 //go:linkname IsJSImportDeclaration github.com/microsoft/typescript-go/internal/ast.IsJSImportDeclaration
 func IsJSImportDeclaration(node *ast.Node) bool
 //go:linkname IsJSTypeAliasDeclaration github.com/microsoft/typescript-go/internal/ast.IsJSTypeAliasDeclaration
@@ -1684,7 +1684,6 @@ const KindCloseBracketToken = ast.KindCloseBracketToken
 const KindCloseParenToken = ast.KindCloseParenToken
 const KindColonToken = ast.KindColonToken
 const KindCommaToken = ast.KindCommaToken
-const KindCommonJSExport = ast.KindCommonJSExport
 const KindComputedPropertyName = ast.KindComputedPropertyName
 const KindConditionalExpression = ast.KindConditionalExpression
 const KindConditionalType = ast.KindConditionalType
@@ -1832,7 +1831,6 @@ const KindJSDocTypeTag = ast.KindJSDocTypeTag
 const KindJSDocTypedefTag = ast.KindJSDocTypedefTag
 const KindJSDocUnknownTag = ast.KindJSDocUnknownTag
 const KindJSDocVariadicType = ast.KindJSDocVariadicType
-const KindJSExportAssignment = ast.KindJSExportAssignment
 const KindJSImportDeclaration = ast.KindJSImportDeclaration
 const KindJSTypeAliasDeclaration = ast.KindJSTypeAliasDeclaration
 const KindJsxAttribute = ast.KindJsxAttribute

--- a/shim/checker/shim.go
+++ b/shim/checker/shim.go
@@ -1091,6 +1091,7 @@ const VarianceFlagsUnmeasurable = checker.VarianceFlagsUnmeasurable
 const VarianceFlagsUnreliable = checker.VarianceFlagsUnreliable
 const VarianceFlagsVarianceMask = checker.VarianceFlagsVarianceMask
 type VarianceLinks = checker.VarianceLinks
+type VerbosityContext = checker.VerbosityContext
 type WideningContext = checker.WideningContext
 type WideningKind = checker.WideningKind
 const WideningKindFunctionReturn = checker.WideningKindFunctionReturn


### PR DESCRIPTION
## Summary
- update the `typescript-go` submodule to `8c45757f80cc94cdeea0f5f99b57fd547c1f229d`
- refresh the local hover patch and regenerate shims for upstream AST/checker API changes
- update local `TypeToStringEx` and `SignatureToStringEx` call sites to use the new default `nil` verbosity argument so setup, check, test, and lint pass

## Validation
- `pnpm setup-repo`
- `pnpm check`
- `pnpm test`
- `pnpm lint`