### PR TITLE
fix: check out target ref in refresh flake hash workflow

### DIFF
--- a/.changeset/refresh-flake-hash-schedule.md
+++ b/.changeset/refresh-flake-hash-schedule.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix the refresh flake hash workflow so scheduled TypeScript Go update runs check out the generated branch before refreshing the vendor hash.

--- a/.github/workflows/refresh-flake-hash.yml
+++ b/.github/workflows/refresh-flake-hash.yml
@@ -52,20 +52,20 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
 
-      - name: Checkout current branch
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ inputs.target_ref || github.ref_name }}
-          submodules: recursive
-
       - name: Checkout requested branch
-        if: github.event_name == 'workflow_call'
+        if: github.event_name != 'pull_request_target' && inputs.target_ref != ''
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ inputs.target_ref }}
+          submodules: recursive
+
+      - name: Checkout current branch
+        if: github.event_name != 'pull_request_target' && inputs.target_ref == ''
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.ref_name }}
           submodules: recursive
 
       - name: Install Nix


### PR DESCRIPTION
## Summary
- fix the reusable refresh flake hash workflow to check out `inputs.target_ref` whenever a target ref is provided, instead of only on `workflow_call`
- preserve pull request branch checkout for `pull_request_target` and fall back to the current ref only when no explicit target ref is set
- add a changeset describing the scheduled TypeScript Go update failure this fixes

## Why
Scheduled `Update TypeScript-Go` runs invoke the reusable refresh workflow with `event_name == schedule`, so the previous checkout conditions skipped every checkout step. That left the job without a repository checkout and caused `./_tools/update-flake-vendor-hash.sh` to fail with `No such file or directory`.