### PR TITLE
refactor: use direct property type lookup in typeparser

### DIFF
--- a/.changeset/slow-schools-add.md
+++ b/.changeset/slow-schools-add.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Reduce typeparser property lookup overhead by using direct property type access for Effect-related type detection, and add a regression test covering the plugin-only TS2589 failure path in `effectInFailure`.

--- a/internal/effecttest/effect_in_failure_ts2589_test.go
+++ b/internal/effecttest/effect_in_failure_ts2589_test.go
@@ -1,0 +1,216 @@
+package effecttest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	_ "github.com/effect-ts/tsgo/etscheckerhooks"
+	"github.com/effect-ts/tsgo/internal/bundledeffect"
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/parser"
+	"github.com/microsoft/typescript-go/shim/tsoptions"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/vfstest"
+)
+
+func TestEffectInFailureCanTriggerPluginOnlyTS2589(t *testing.T) {
+	t.Parallel()
+
+	withRule := collectDiagnosticStringsFromContent(t, buildEffectInFailureTS2589Case("enabled"))
+	withoutRule := collectDiagnosticStringsFromContent(t, buildEffectInFailureTS2589Case("rule-off"))
+	withoutPlugin := collectDiagnosticStringsFromContent(t, buildEffectInFailureTS2589Case("plugin-off"))
+
+	if !hasDiagnosticCode(withRule, "TS2589:") {
+		t.Fatalf("expected TS2589 with effectInFailure enabled, got %v", withRule)
+	}
+	if !hasDiagnosticCode(withRule, "TS377054:") {
+		t.Fatalf("expected effectInFailure diagnostic with rule enabled, got %v", withRule)
+	}
+	if hasDiagnosticCode(withoutRule, "TS2589:") {
+		t.Fatalf("did not expect TS2589 with effectInFailure disabled, got %v", withoutRule)
+	}
+	if hasDiagnosticCode(withoutPlugin, "TS2589:") {
+		t.Fatalf("did not expect TS2589 with plugin disabled, got %v", withoutPlugin)
+	}
+}
+
+func buildEffectInFailureTS2589Case(mode string) string {
+	pluginConfig := "{}"
+	switch mode {
+	case "enabled":
+		pluginConfig = `{
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
+  }
+}`
+	case "rule-off":
+		pluginConfig = `{
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnosticSeverity": {
+          "effectInFailure": "off"
+        }
+      }
+    ]
+  }
+}`
+	}
+
+	deep := "string"
+	for range 25 {
+		deep = "Wrap<" + deep + ">"
+	}
+
+	var sb strings.Builder
+	sb.WriteString("// @filename: tsconfig.json\n")
+	sb.WriteString(pluginConfig)
+	sb.WriteString("\n\n// @filename: test.ts\n")
+	sb.WriteString("import { Data, Effect } from \"effect\"\n\n")
+	sb.WriteString("type TE<T> = Data.TaggedEnum<{\n")
+	sb.WriteString("  A: { a: T }\n")
+	sb.WriteString("  B: { b?: T }\n")
+	sb.WriteString("}>\n\n")
+	sb.WriteString("interface TEDefinition extends Data.TaggedEnum.WithGenerics<1> {\n")
+	sb.WriteString("  readonly taggedEnum: TE<this[\"A\"]>\n")
+	sb.WriteString("}\n\n")
+	sb.WriteString("type Wrap<T> = Data.TaggedEnum.Kind<TEDefinition, T>\n\n")
+	sb.WriteString("export const program = Effect.try({\n")
+	sb.WriteString("  try: () => 1,\n")
+	fmt.Fprintf(&sb, "  catch: () => Effect.fail<%s>(undefined as any)\n", deep)
+	sb.WriteString("})\n")
+	return sb.String()
+}
+
+func hasDiagnosticCode(diags []string, prefix string) bool {
+	for _, diag := range diags {
+		if strings.Contains(diag, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func collectDiagnosticStringsFromContent(t testing.TB, content string) []string {
+	t.Helper()
+	AcquireProgram()
+	defer ReleaseProgram()
+
+	units := parseTestUnits(content, "test.ts")
+	currentDirectory := "/.src"
+	testfs := make(map[string]any)
+	if err := bundledeffect.MountEffect(bundledeffect.EffectV4, testfs); err != nil {
+		t.Fatal(err)
+	}
+
+	var programFileNames []string
+	var tsConfigFile *tsoptions.TsConfigSourceFile
+	var tsConfigUnit *testUnit
+	for _, unit := range units {
+		unitName := tspath.GetNormalizedAbsolutePath(unit.name, currentDirectory)
+		testfs[unitName] = &fstest.MapFile{Data: []byte(unit.content)}
+		if isHarnessConfigFile(unit.name) {
+			path := tspath.ToPath(unitName, currentDirectory, true)
+			configJSON := parser.ParseSourceFile(ast.SourceFileParseOptions{FileName: unitName, Path: path}, unit.content, core.ScriptKindJSON)
+			tsConfigFile = &tsoptions.TsConfigSourceFile{SourceFile: configJSON}
+			tsConfigUnit = unit
+			continue
+		}
+		programFileNames = append(programFileNames, unitName)
+	}
+
+	fs := vfstest.FromMap(testfs, true)
+	fs = bundled.WrapFS(fs)
+
+	compilerOptions := &core.CompilerOptions{
+		NewLine:                      core.NewLineKindLF,
+		SkipDefaultLibCheck:          core.TSTrue,
+		NoErrorTruncation:            core.TSTrue,
+		Target:                       core.ScriptTargetESNext,
+		Module:                       core.ModuleKindNodeNext,
+		ModuleResolution:             core.ModuleResolutionKindNodeNext,
+		ESModuleInterop:              core.TSTrue,
+		AllowSyntheticDefaultImports: core.TSTrue,
+	}
+
+	var parsedConfig *tsoptions.ParsedCommandLine
+	if tsConfigFile != nil {
+		configDir := tspath.GetNormalizedAbsolutePath(tspath.GetDirectoryPath(tsConfigUnit.name), currentDirectory)
+		parseHost := &vfsParseConfigHost{fs: fs, currentDirectory: currentDirectory}
+		parsedConfig = tsoptions.ParseJsonSourceFileConfigFileContent(
+			tsConfigFile,
+			parseHost,
+			configDir,
+			nil,
+			nil,
+			tsConfigFile.SourceFile.FileName(),
+			nil,
+			nil,
+			nil,
+		)
+		if parsedConfig.CompilerOptions() != nil {
+			parsedConfig.CompilerOptions().NewLine = core.NewLineKindLF
+			parsedConfig.CompilerOptions().SkipDefaultLibCheck = core.TSTrue
+			parsedConfig.CompilerOptions().NoErrorTruncation = core.TSTrue
+			if parsedConfig.CompilerOptions().Target == core.ScriptTargetNone {
+				parsedConfig.CompilerOptions().Target = core.ScriptTargetESNext
+			}
+			if parsedConfig.CompilerOptions().Module == core.ModuleKindNone {
+				parsedConfig.CompilerOptions().Module = core.ModuleKindNodeNext
+			}
+			if parsedConfig.CompilerOptions().ModuleResolution == core.ModuleResolutionKindUnknown {
+				parsedConfig.CompilerOptions().ModuleResolution = core.ModuleResolutionKindNodeNext
+			}
+			compilerOptions = parsedConfig.CompilerOptions()
+		}
+	}
+
+	host := &cachingCompilerHost{
+		CompilerHost: compiler.NewCompilerHost(currentDirectory, fs, bundled.LibPath(), nil, nil),
+		version:      bundledeffect.EffectV4,
+	}
+
+	var configFile *tsoptions.TsConfigSourceFile
+	if parsedConfig != nil {
+		configFile = parsedConfig.ConfigFile
+	}
+	program := compiler.NewProgram(compiler.ProgramOptions{
+		Config: &tsoptions.ParsedCommandLine{
+			ParsedConfig: &core.ParsedOptions{
+				CompilerOptions: compilerOptions,
+				FileNames:       programFileNames,
+			},
+			ConfigFile: configFile,
+		},
+		Host:           host,
+		SingleThreaded: core.TSTrue,
+	})
+
+	ctx := context.Background()
+	var diagnostics []*ast.Diagnostic
+	diagnostics = append(diagnostics, program.GetProgramDiagnostics()...)
+	diagnostics = append(diagnostics, program.GetSyntacticDiagnostics(ctx, nil)...)
+	diagnostics = append(diagnostics, program.GetSemanticDiagnostics(ctx, nil)...)
+	diagnostics = append(diagnostics, program.GetGlobalDiagnostics(ctx)...)
+
+	results := make([]string, 0, len(diagnostics))
+	for _, diag := range diagnostics {
+		results = append(results, fmt.Sprintf("TS%d: %s", diag.Code(), diag.String()))
+	}
+	return results
+}
+
+func isHarnessConfigFile(fileName string) bool {
+	return strings.HasSuffix(fileName, "/tsconfig.json") || fileName == "tsconfig.json"
+}

--- a/internal/fixables/missing_effect_error_catch.go
+++ b/internal/fixables/missing_effect_error_catch.go
@@ -6,13 +6,13 @@ import (
 	"strings"
 
 	"github.com/effect-ts/tsgo/internal/fixable"
+	"github.com/effect-ts/tsgo/internal/rewriter"
 	"github.com/effect-ts/tsgo/internal/rules"
 	"github.com/effect-ts/tsgo/internal/typeparser"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	tsdiag "github.com/microsoft/typescript-go/shim/diagnostics"
 	"github.com/microsoft/typescript-go/shim/ls"
-	"github.com/effect-ts/tsgo/internal/rewriter"
 	"github.com/microsoft/typescript-go/shim/scanner"
 )
 
@@ -63,7 +63,7 @@ func runMissingEffectErrorCatchFix(ctx *fixable.Context) []ls.CodeAction {
 		}
 
 		// Offer catchTags only when all missing error members have a literal _tag.
-		if tags, ok := collectLiteralMissingErrorTags(ctx.TypeParser, c, errorExpr, match.UnhandledErrors); ok {
+		if tags, ok := collectLiteralMissingErrorTags(ctx.TypeParser, c, match.UnhandledErrors); ok {
 			if taggedCandidate == nil || nodeStartPos < taggedCandidate.start || (nodeStartPos == taggedCandidate.start && nodeEndPos < taggedCandidate.end) {
 				taggedCandidate = &fixCandidate{
 					start: nodeStartPos,
@@ -111,7 +111,7 @@ func runMissingEffectErrorCatchFix(ctx *fixable.Context) []ls.CodeAction {
 	return actions
 }
 
-func collectLiteralMissingErrorTags(tp *typeparser.TypeParser, c *checker.Checker, atLocation *ast.Node, missing []*checker.Type) ([]string, bool) {
+func collectLiteralMissingErrorTags(tp *typeparser.TypeParser, c *checker.Checker, missing []*checker.Type) ([]string, bool) {
 	if len(missing) == 0 {
 		return nil, false
 	}
@@ -119,14 +119,13 @@ func collectLiteralMissingErrorTags(tp *typeparser.TypeParser, c *checker.Checke
 	seen := make(map[string]bool)
 	tags := make([]string, 0, len(missing))
 	for _, missingType := range missing {
-		tagProp := c.GetPropertyOfType(missingType, "_tag")
-		if tagProp == nil {
-			tagProp = tp.GetPropertyOfTypeByName(missingType, "_tag")
+		tagType := c.GetTypeOfPropertyOfType(missingType, "_tag")
+		if tagType == nil {
+			tagType = tp.GetTypeOfPropertyByName(missingType, "_tag")
 		}
-		if tagProp == nil {
+		if tagType == nil {
 			return nil, false
 		}
-		tagType := c.GetTypeOfSymbolAtLocation(tagProp, atLocation)
 		if tagType == nil || tagType.Flags()&checker.TypeFlagsStringLiteral == 0 {
 			return nil, false
 		}

--- a/internal/typeparser/context_tag.go
+++ b/internal/typeparser/context_tag.go
@@ -57,7 +57,7 @@ func (tp *TypeParser) ContextTag(t *checker.Type, atLocation *ast.Node) *Service
 
 		for _, prop := range candidates {
 			propType := tp.checker.GetTypeOfSymbolAtLocation(prop, atLocation)
-			if result := tp.parseServiceVarianceStruct(propType, atLocation); result != nil {
+			if result := tp.parseServiceVarianceStruct(propType); result != nil {
 				return result
 			}
 		}

--- a/internal/typeparser/effect_type.go
+++ b/internal/typeparser/effect_type.go
@@ -45,7 +45,7 @@ func (tp *TypeParser) EffectType(t *checker.Type, atLocation *ast.Node) *Effect 
 			}
 
 			// Parse the variance struct to extract A, E, R
-			return tp.parseVarianceStruct(varianceStructType, atLocation)
+			return tp.parseVarianceStruct(varianceStructType)
 		}
 
 		// v3 / unknown: iterate properties looking for a variance struct
@@ -86,7 +86,7 @@ func (tp *TypeParser) EffectType(t *checker.Type, atLocation *ast.Node) *Effect 
 		// Try each candidate as a variance struct
 		for _, prop := range candidates {
 			propType := tp.checker.GetTypeOfSymbolAtLocation(prop, atLocation)
-			if result := tp.parseVarianceStruct(propType, atLocation); result != nil {
+			if result := tp.parseVarianceStruct(propType); result != nil {
 				return result
 			}
 		}
@@ -96,18 +96,18 @@ func (tp *TypeParser) EffectType(t *checker.Type, atLocation *ast.Node) *Effect 
 }
 
 // parseVarianceStruct extracts A, E, R from a variance struct type.
-func (tp *TypeParser) parseVarianceStruct(t *checker.Type, atLocation *ast.Node) *Effect {
-	a := tp.extractCovariantType(t, atLocation, "_A")
+func (tp *TypeParser) parseVarianceStruct(t *checker.Type) *Effect {
+	a := tp.extractCovariantType(t, "_A")
 	if a == nil {
 		return nil
 	}
 
-	e := tp.extractCovariantType(t, atLocation, "_E")
+	e := tp.extractCovariantType(t, "_E")
 	if e == nil {
 		return nil
 	}
 
-	r := tp.extractCovariantType(t, atLocation, "_R")
+	r := tp.extractCovariantType(t, "_R")
 	if r == nil {
 		return nil
 	}

--- a/internal/typeparser/effect_type.go
+++ b/internal/typeparser/effect_type.go
@@ -39,14 +39,10 @@ func (tp *TypeParser) EffectType(t *checker.Type, atLocation *ast.Node) *Effect 
 	return Cached(&tp.links.EffectType, t, func() *Effect {
 		version := tp.DetectEffectVersion()
 		if version == EffectMajorV4 {
-			// Direct property access using the known Effect v4 type ID
-			propSymbol := tp.GetPropertyOfTypeByName(t, EffectTypeId)
-			if propSymbol == nil {
+			varianceStructType := tp.GetTypeOfPropertyByName(t, EffectTypeId)
+			if varianceStructType == nil {
 				return nil
 			}
-
-			// Get the variance struct type
-			varianceStructType := tp.checker.GetTypeOfSymbolAtLocation(propSymbol, atLocation)
 
 			// Parse the variance struct to extract A, E, R
 			return tp.parseVarianceStruct(varianceStructType, atLocation)
@@ -210,7 +206,7 @@ func (tp *TypeParser) HasEffectTypeId(t *checker.Type, atLocation *ast.Node) boo
 	return Cached(&tp.links.HasEffectTypeId, t, func() bool {
 		version := tp.DetectEffectVersion()
 		if version == EffectMajorV4 {
-			return tp.GetPropertyOfTypeByName(t, EffectTypeId) != nil
+			return tp.GetTypeOfPropertyByName(t, EffectTypeId) != nil
 		}
 		// For v3/unknown, the quick check is not available; defer to full detection.
 		return tp.IsEffectType(t, atLocation)

--- a/internal/typeparser/effect_yieldable_type.go
+++ b/internal/typeparser/effect_yieldable_type.go
@@ -30,12 +30,7 @@ func (tp *TypeParser) EffectYieldableType(t *checker.Type, atLocation *ast.Node)
 		}
 
 		// v4: look for asEffect() protocol
-		asEffectSymbol := tp.GetPropertyOfTypeByName(t, "asEffect")
-		if asEffectSymbol == nil {
-			return nil
-		}
-
-		asEffectType := tp.checker.GetTypeOfSymbolAtLocation(asEffectSymbol, atLocation)
+		asEffectType := tp.GetTypeOfPropertyByName(t, "asEffect")
 		if asEffectType == nil {
 			return nil
 		}

--- a/internal/typeparser/helpers.go
+++ b/internal/typeparser/helpers.go
@@ -7,14 +7,12 @@ import (
 
 // extractCovariantType gets the type argument from a covariant property.
 // Covariant<A> is encoded as () => A, so we get the return type.
-func (tp *TypeParser) extractCovariantType(t *checker.Type, atLocation *ast.Node, propName string) *checker.Type {
+func (tp *TypeParser) extractCovariantType(t *checker.Type, _ *ast.Node, propName string) *checker.Type {
 	c := tp.checker
-	propSymbol := c.GetPropertyOfType(t, propName)
-	if propSymbol == nil {
+	propType := tp.GetTypeOfPropertyByName(t, propName)
+	if propType == nil {
 		return nil
 	}
-
-	propType := c.GetTypeOfSymbolAtLocation(propSymbol, atLocation)
 	signatures := c.GetSignaturesOfType(propType, checker.SignatureKindCall)
 
 	if len(signatures) != 1 {
@@ -30,14 +28,12 @@ func (tp *TypeParser) extractCovariantType(t *checker.Type, atLocation *ast.Node
 
 // extractContravariantType gets the type argument from a contravariant property.
 // Contravariant<A> is encoded as (_: A) => void, so we get the first parameter type.
-func (tp *TypeParser) extractContravariantType(t *checker.Type, atLocation *ast.Node, propName string) *checker.Type {
+func (tp *TypeParser) extractContravariantType(t *checker.Type, _ *ast.Node, propName string) *checker.Type {
 	c := tp.checker
-	propSymbol := c.GetPropertyOfType(t, propName)
-	if propSymbol == nil {
+	propType := tp.GetTypeOfPropertyByName(t, propName)
+	if propType == nil {
 		return nil
 	}
-
-	propType := c.GetTypeOfSymbolAtLocation(propSymbol, atLocation)
 	signatures := c.GetSignaturesOfType(propType, checker.SignatureKindCall)
 
 	if len(signatures) != 1 {
@@ -62,28 +58,13 @@ func (tp *TypeParser) extractInvariantType(t *checker.Type, atLocation *ast.Node
 	return tp.extractCovariantType(t, atLocation, propName)
 }
 
-// GetPropertyOfTypeByName returns a property symbol by name, including computed properties backed by string literals.
-func (tp *TypeParser) GetPropertyOfTypeByName(t *checker.Type, name string) *ast.Symbol {
+// GetTypeOfPropertyByName returns the type of a property by name.
+// Prefer this when only the property type is needed.
+func (tp *TypeParser) GetTypeOfPropertyByName(t *checker.Type, name string) *checker.Type {
 	if tp == nil || tp.checker == nil || t == nil {
 		return nil
 	}
-	c := tp.checker
-	if sym := c.GetPropertyOfType(t, name); sym != nil {
-		return sym
-	}
-	for _, prop := range c.GetPropertiesOfType(t) {
-		if prop == nil {
-			continue
-		}
-		nameType := checker.Checker_getLiteralTypeFromProperty(c, prop, checker.TypeFlagsStringOrNumberLiteralOrUnique, true)
-		if nameType == nil || !nameType.IsStringLiteral() {
-			continue
-		}
-		if lit, ok := nameType.AsLiteralType().Value().(string); ok && lit == name {
-			return prop
-		}
-	}
-	return nil
+	return tp.checker.GetTypeOfPropertyOfType(t, name)
 }
 
 func (tp *TypeParser) resolveAliasedSymbol(sym *ast.Symbol) *ast.Symbol {

--- a/internal/typeparser/helpers.go
+++ b/internal/typeparser/helpers.go
@@ -7,7 +7,7 @@ import (
 
 // extractCovariantType gets the type argument from a covariant property.
 // Covariant<A> is encoded as () => A, so we get the return type.
-func (tp *TypeParser) extractCovariantType(t *checker.Type, _ *ast.Node, propName string) *checker.Type {
+func (tp *TypeParser) extractCovariantType(t *checker.Type, propName string) *checker.Type {
 	c := tp.checker
 	propType := tp.GetTypeOfPropertyByName(t, propName)
 	if propType == nil {
@@ -28,7 +28,7 @@ func (tp *TypeParser) extractCovariantType(t *checker.Type, _ *ast.Node, propNam
 
 // extractContravariantType gets the type argument from a contravariant property.
 // Contravariant<A> is encoded as (_: A) => void, so we get the first parameter type.
-func (tp *TypeParser) extractContravariantType(t *checker.Type, _ *ast.Node, propName string) *checker.Type {
+func (tp *TypeParser) extractContravariantType(t *checker.Type, propName string) *checker.Type {
 	c := tp.checker
 	propType := tp.GetTypeOfPropertyByName(t, propName)
 	if propType == nil {
@@ -54,8 +54,8 @@ func (tp *TypeParser) extractContravariantType(t *checker.Type, _ *ast.Node, pro
 
 // extractInvariantType gets the type argument from an invariant property.
 // Invariant<A> is encoded as (_: A) => A, so we extract the return type (same as covariant).
-func (tp *TypeParser) extractInvariantType(t *checker.Type, atLocation *ast.Node, propName string) *checker.Type {
-	return tp.extractCovariantType(t, atLocation, propName)
+func (tp *TypeParser) extractInvariantType(t *checker.Type, propName string) *checker.Type {
+	return tp.extractCovariantType(t, propName)
 }
 
 // GetTypeOfPropertyByName returns the type of a property by name.

--- a/internal/typeparser/helpers_test.go
+++ b/internal/typeparser/helpers_test.go
@@ -240,9 +240,9 @@ func TestExtractCovariantType_RejectsGenericSignature(t *testing.T) {
 	c, tp, sf, done := compileAndGetCheckerAndSourceFileInternal(t, source)
 	defer done()
 
-	typ, decl := getFirstVariableDeclarationType(t, tp, sf)
+	typ, _ := getFirstVariableDeclarationType(t, tp, sf)
 
-	result := tp.extractCovariantType(typ, decl, "prop")
+	result := tp.extractCovariantType(typ, "prop")
 	if result != nil {
 		t.Errorf("expected nil for generic covariant signature, got %s", c.TypeToString(result))
 	}
@@ -256,9 +256,9 @@ func TestExtractContravariantType_RejectsGenericSignature(t *testing.T) {
 	c, tp, sf, done := compileAndGetCheckerAndSourceFileInternal(t, source)
 	defer done()
 
-	typ, decl := getFirstVariableDeclarationType(t, tp, sf)
+	typ, _ := getFirstVariableDeclarationType(t, tp, sf)
 
-	result := tp.extractContravariantType(typ, decl, "prop")
+	result := tp.extractContravariantType(typ, "prop")
 	if result != nil {
 		t.Errorf("expected nil for generic contravariant signature, got %s", c.TypeToString(result))
 	}
@@ -272,9 +272,9 @@ func TestExtractCovariantType_AcceptsNonGenericSignature(t *testing.T) {
 	c, tp, sf, done := compileAndGetCheckerAndSourceFileInternal(t, source)
 	defer done()
 
-	typ, decl := getFirstVariableDeclarationType(t, tp, sf)
+	typ, _ := getFirstVariableDeclarationType(t, tp, sf)
 
-	result := tp.extractCovariantType(typ, decl, "prop")
+	result := tp.extractCovariantType(typ, "prop")
 	if result == nil {
 		t.Fatal("expected non-nil result for non-generic covariant signature")
 	}
@@ -293,9 +293,9 @@ func TestExtractInvariantType_RejectsGenericSignature(t *testing.T) {
 	c, tp, sf, done := compileAndGetCheckerAndSourceFileInternal(t, source)
 	defer done()
 
-	typ, decl := getFirstVariableDeclarationType(t, tp, sf)
+	typ, _ := getFirstVariableDeclarationType(t, tp, sf)
 
-	result := tp.extractInvariantType(typ, decl, "prop")
+	result := tp.extractInvariantType(typ, "prop")
 	if result != nil {
 		t.Errorf("expected nil for generic invariant signature, got %s", c.TypeToString(result))
 	}
@@ -309,9 +309,9 @@ func TestExtractInvariantType_AcceptsNonGenericSignature(t *testing.T) {
 	c, tp, sf, done := compileAndGetCheckerAndSourceFileInternal(t, source)
 	defer done()
 
-	typ, decl := getFirstVariableDeclarationType(t, tp, sf)
+	typ, _ := getFirstVariableDeclarationType(t, tp, sf)
 
-	result := tp.extractInvariantType(typ, decl, "prop")
+	result := tp.extractInvariantType(typ, "prop")
 	if result == nil {
 		t.Fatal("expected non-nil result for non-generic invariant signature")
 	}
@@ -330,9 +330,9 @@ func TestExtractContravariantType_AcceptsNonGenericSignature(t *testing.T) {
 	c, tp, sf, done := compileAndGetCheckerAndSourceFileInternal(t, source)
 	defer done()
 
-	typ, decl := getFirstVariableDeclarationType(t, tp, sf)
+	typ, _ := getFirstVariableDeclarationType(t, tp, sf)
 
-	result := tp.extractContravariantType(typ, decl, "prop")
+	result := tp.extractContravariantType(typ, "prop")
 	if result == nil {
 		t.Fatal("expected non-nil result for non-generic contravariant signature")
 	}

--- a/internal/typeparser/layer_type.go
+++ b/internal/typeparser/layer_type.go
@@ -24,18 +24,18 @@ type Layer struct {
 }
 
 // parseLayerVarianceStruct extracts ROut, E, RIn from a Layer variance struct type.
-func (tp *TypeParser) parseLayerVarianceStruct(t *checker.Type, atLocation *ast.Node) *Layer {
-	rOut := tp.extractContravariantType(t, atLocation, "_ROut")
+func (tp *TypeParser) parseLayerVarianceStruct(t *checker.Type) *Layer {
+	rOut := tp.extractContravariantType(t, "_ROut")
 	if rOut == nil {
 		return nil
 	}
 
-	e := tp.extractCovariantType(t, atLocation, "_E")
+	e := tp.extractCovariantType(t, "_E")
 	if e == nil {
 		return nil
 	}
 
-	rIn := tp.extractCovariantType(t, atLocation, "_RIn")
+	rIn := tp.extractCovariantType(t, "_RIn")
 	if rIn == nil {
 		return nil
 	}
@@ -60,7 +60,7 @@ func (tp *TypeParser) LayerType(t *checker.Type, atLocation *ast.Node) *Layer {
 				return nil
 			}
 
-			return tp.parseLayerVarianceStruct(varianceStructType, atLocation)
+			return tp.parseLayerVarianceStruct(varianceStructType)
 		}
 
 		// v3 / unknown: iterate properties looking for a layer variance struct
@@ -101,7 +101,7 @@ func (tp *TypeParser) LayerType(t *checker.Type, atLocation *ast.Node) *Layer {
 		// Try each candidate as a layer variance struct
 		for _, prop := range candidates {
 			propType := c.GetTypeOfSymbolAtLocation(prop, atLocation)
-			if result := tp.parseLayerVarianceStruct(propType, atLocation); result != nil {
+			if result := tp.parseLayerVarianceStruct(propType); result != nil {
 				return result
 			}
 		}

--- a/internal/typeparser/layer_type.go
+++ b/internal/typeparser/layer_type.go
@@ -55,13 +55,10 @@ func (tp *TypeParser) LayerType(t *checker.Type, atLocation *ast.Node) *Layer {
 	return Cached(&tp.links.LayerType, t, func() *Layer {
 		version := tp.DetectEffectVersion()
 		if version == EffectMajorV4 {
-			// Direct property access using the known Layer v4 type ID
-			propSymbol := tp.GetPropertyOfTypeByName(t, LayerTypeId)
-			if propSymbol == nil {
+			varianceStructType := tp.GetTypeOfPropertyByName(t, LayerTypeId)
+			if varianceStructType == nil {
 				return nil
 			}
-
-			varianceStructType := c.GetTypeOfSymbolAtLocation(propSymbol, atLocation)
 
 			return tp.parseLayerVarianceStruct(varianceStructType, atLocation)
 		}

--- a/internal/typeparser/schema_type.go
+++ b/internal/typeparser/schema_type.go
@@ -1,9 +1,6 @@
 package typeparser
 
 import (
-	"sort"
-	"strings"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 )
@@ -40,72 +37,12 @@ func (tp *TypeParser) parseSchemaVarianceStruct(t *checker.Type) bool {
 	return r != nil
 }
 
-// isSchemaType checks if a type is a Schema type (v4 or v3).
-func (tp *TypeParser) isSchemaType(t *checker.Type, atLocation *ast.Node) bool {
-	c := tp.checker
-	if c == nil || t == nil {
-		return false
-	}
-	return Cached(&tp.links.IsSchemaType, t, func() bool {
-		version := tp.DetectEffectVersion()
-		if version == EffectMajorV4 {
-			return tp.GetTypeOfPropertyByName(t, SchemaTypeId) != nil
-		}
-
-		// v3 / unknown: check for 'ast' property first
-		if c.GetPropertyOfType(t, "ast") == nil {
-			return false
-		}
-
-		props := c.GetPropertiesOfType(t)
-		var candidates []*ast.Symbol
-		for _, prop := range props {
-			if prop == nil {
-				continue
-			}
-			if prop.Flags&ast.SymbolFlagsProperty == 0 {
-				continue
-			}
-			if prop.Flags&ast.SymbolFlagsOptional != 0 {
-				continue
-			}
-			if prop.ValueDeclaration == nil {
-				continue
-			}
-			candidates = append(candidates, prop)
-		}
-
-		if len(candidates) == 0 {
-			return false
-		}
-
-		// Sort so properties containing "TypeId" come first (optimization heuristic)
-		sort.SliceStable(candidates, func(i, j int) bool {
-			iHas := strings.Contains(candidates[i].Name, "TypeId")
-			jHas := strings.Contains(candidates[j].Name, "TypeId")
-			if iHas && !jHas {
-				return true
-			}
-			return false
-		})
-
-		for _, prop := range candidates {
-			propType := c.GetTypeOfSymbolAtLocation(prop, atLocation)
-			if tp.parseSchemaVarianceStruct(propType) {
-				return true
-			}
-		}
-
-		return false
-	})
-}
-
 // IsSchemaType returns true if the type is a Schema type (v4 or v3).
 func (tp *TypeParser) IsSchemaType(t *checker.Type, atLocation *ast.Node) bool {
 	if tp == nil {
 		return false
 	}
-	return tp.isSchemaType(t, atLocation)
+	return tp.EffectSchemaTypes(t, atLocation) != nil
 }
 
 // SchemaTypes holds the A (Type) and E (Encoded) types extracted from a Schema type.
@@ -197,7 +134,7 @@ func isSchemaTypeSourceFile(tp *TypeParser, c *checker.Checker, sf *ast.SourceFi
 		return false
 	}
 
-	return tp.isSchemaType(schemaType, sf.AsNode())
+	return tp.IsSchemaType(schemaType, sf.AsNode())
 }
 
 // IsNodeReferenceToEffectSchemaModuleApi reports whether node resolves to a member

--- a/internal/typeparser/schema_type.go
+++ b/internal/typeparser/schema_type.go
@@ -27,16 +27,16 @@ var effectSchemaParserModuleDescriptor = PackageSourceFileDescriptor{
 const SchemaTypeId = "~effect/Schema/Schema"
 
 // parseSchemaVarianceStruct checks if a type is a Schema variance struct (has _A, _I, _R).
-func (tp *TypeParser) parseSchemaVarianceStruct(t *checker.Type, atLocation *ast.Node) bool {
-	a := tp.extractInvariantType(t, atLocation, "_A")
+func (tp *TypeParser) parseSchemaVarianceStruct(t *checker.Type) bool {
+	a := tp.extractInvariantType(t, "_A")
 	if a == nil {
 		return false
 	}
-	i := tp.extractInvariantType(t, atLocation, "_I")
+	i := tp.extractInvariantType(t, "_I")
 	if i == nil {
 		return false
 	}
-	r := tp.extractCovariantType(t, atLocation, "_R")
+	r := tp.extractCovariantType(t, "_R")
 	return r != nil
 }
 
@@ -91,7 +91,7 @@ func (tp *TypeParser) isSchemaType(t *checker.Type, atLocation *ast.Node) bool {
 
 		for _, prop := range candidates {
 			propType := c.GetTypeOfSymbolAtLocation(prop, atLocation)
-			if tp.parseSchemaVarianceStruct(propType, atLocation) {
+			if tp.parseSchemaVarianceStruct(propType) {
 				return true
 			}
 		}
@@ -148,15 +148,15 @@ func (tp *TypeParser) EffectSchemaTypes(t *checker.Type, atLocation *ast.Node) *
 				continue
 			}
 			propType := c.GetTypeOfSymbolAtLocation(prop, atLocation)
-			a := tp.extractInvariantType(propType, atLocation, "_A")
+			a := tp.extractInvariantType(propType, "_A")
 			if a == nil {
 				continue
 			}
-			i := tp.extractInvariantType(propType, atLocation, "_I")
+			i := tp.extractInvariantType(propType, "_I")
 			if i == nil {
 				continue
 			}
-			r := tp.extractCovariantType(propType, atLocation, "_R")
+			r := tp.extractCovariantType(propType, "_R")
 			if r == nil {
 				continue
 			}

--- a/internal/typeparser/schema_type.go
+++ b/internal/typeparser/schema_type.go
@@ -49,7 +49,7 @@ func (tp *TypeParser) isSchemaType(t *checker.Type, atLocation *ast.Node) bool {
 	return Cached(&tp.links.IsSchemaType, t, func() bool {
 		version := tp.DetectEffectVersion()
 		if version == EffectMajorV4 {
-			return tp.GetPropertyOfTypeByName(t, SchemaTypeId) != nil
+			return tp.GetTypeOfPropertyByName(t, SchemaTypeId) != nil
 		}
 
 		// v3 / unknown: check for 'ast' property first
@@ -124,7 +124,7 @@ func (tp *TypeParser) EffectSchemaTypes(t *checker.Type, atLocation *ast.Node) *
 	return Cached(&tp.links.EffectSchemaTypes, t, func() *SchemaTypes {
 		version := tp.DetectEffectVersion()
 		if version == EffectMajorV4 {
-			if tp.GetPropertyOfTypeByName(t, SchemaTypeId) == nil {
+			if tp.GetTypeOfPropertyByName(t, SchemaTypeId) == nil {
 				return nil
 			}
 			// V4: get Type and Encoded properties directly

--- a/internal/typeparser/scope_type.go
+++ b/internal/typeparser/scope_type.go
@@ -21,7 +21,7 @@ func (tp *TypeParser) IsScopeType(t *checker.Type, atLocation *ast.Node) bool {
 	return Cached(&tp.links.IsScopeType, t, func() bool {
 		version := tp.DetectEffectVersion()
 		if version == EffectMajorV4 {
-			return tp.GetPropertyOfTypeByName(t, ScopeTypeId) != nil
+			return tp.GetTypeOfPropertyByName(t, ScopeTypeId) != nil
 		}
 
 		// v3 / unknown: check that the type is "pipeable"

--- a/internal/typeparser/service_type.go
+++ b/internal/typeparser/service_type.go
@@ -43,22 +43,16 @@ func (tp *TypeParser) ServiceType(t *checker.Type, atLocation *ast.Node) *Servic
 			return nil
 		}
 
-		serviceKeyTypeIDSymbol := tp.GetPropertyOfTypeByName(t, ServiceTypeId)
-		if serviceKeyTypeIDSymbol == nil {
+		serviceKeyTypeIDType := tp.GetTypeOfPropertyByName(t, ServiceTypeId)
+		if serviceKeyTypeIDType == nil {
 			return nil
 		}
-		identifierSymbol := tp.GetPropertyOfTypeByName(t, "Identifier")
-		if identifierSymbol == nil {
+		identifier := tp.GetTypeOfPropertyByName(t, "Identifier")
+		if identifier == nil {
 			return nil
 		}
-		serviceSymbol := tp.GetPropertyOfTypeByName(t, "Service")
-		if serviceSymbol == nil {
-			return nil
-		}
-
-		identifier := tp.checker.GetTypeOfSymbolAtLocation(identifierSymbol, atLocation)
-		shape := tp.checker.GetTypeOfSymbolAtLocation(serviceSymbol, atLocation)
-		if identifier == nil || shape == nil {
+		shape := tp.GetTypeOfPropertyByName(t, "Service")
+		if shape == nil {
 			return nil
 		}
 

--- a/internal/typeparser/service_type.go
+++ b/internal/typeparser/service_type.go
@@ -15,13 +15,13 @@ type Service struct {
 }
 
 // parseServiceVarianceStruct extracts Identifier and Shape from a Service variance struct type.
-func (tp *TypeParser) parseServiceVarianceStruct(t *checker.Type, atLocation *ast.Node) *Service {
-	identifier := tp.extractInvariantType(t, atLocation, "_Identifier")
+func (tp *TypeParser) parseServiceVarianceStruct(t *checker.Type) *Service {
+	identifier := tp.extractInvariantType(t, "_Identifier")
 	if identifier == nil {
 		return nil
 	}
 
-	shape := tp.extractInvariantType(t, atLocation, "_Service")
+	shape := tp.extractInvariantType(t, "_Service")
 	if shape == nil {
 		return nil
 	}

--- a/internal/typeparser/stream_type.go
+++ b/internal/typeparser/stream_type.go
@@ -23,6 +23,6 @@ func (tp *TypeParser) StreamType(t *checker.Type, atLocation *ast.Node) *Effect 
 		if varianceStructType == nil {
 			return nil
 		}
-		return tp.parseVarianceStruct(varianceStructType, atLocation)
+		return tp.parseVarianceStruct(varianceStructType)
 	})
 }

--- a/internal/typeparser/stream_type.go
+++ b/internal/typeparser/stream_type.go
@@ -19,12 +19,10 @@ func (tp *TypeParser) StreamType(t *checker.Type, atLocation *ast.Node) *Effect 
 			return tp.EffectType(t, atLocation)
 		}
 
-		propSymbol := tp.GetPropertyOfTypeByName(t, StreamTypeId)
-		if propSymbol == nil {
+		varianceStructType := tp.GetTypeOfPropertyByName(t, StreamTypeId)
+		if varianceStructType == nil {
 			return nil
 		}
-
-		varianceStructType := tp.checker.GetTypeOfSymbolAtLocation(propSymbol, atLocation)
 		return tp.parseVarianceStruct(varianceStructType, atLocation)
 	})
 }

--- a/internal/typeparser/type_parser.go
+++ b/internal/typeparser/type_parser.go
@@ -29,7 +29,6 @@ type EffectLinks struct {
 	LayerType            core.LinkStore[*checker.Type, *Layer]
 	ServiceType          core.LinkStore[*checker.Type, *Service]
 	ContextTag           core.LinkStore[*checker.Type, *Service]
-	IsSchemaType         core.LinkStore[*checker.Type, bool]
 	EffectSchemaTypes    core.LinkStore[*checker.Type, *SchemaTypes]
 	IsScopeType          core.LinkStore[*checker.Type, bool]
 	IsPipeableType       core.LinkStore[*checker.Type, bool]


### PR DESCRIPTION
## Summary
- replace symbol lookup plus `GetTypeOfSymbolAtLocation` with direct property type lookups in the typeparser and related fixable paths
- remove the old `GetPropertyOfTypeByName` helper and switch remaining property existence checks to `GetTypeOfPropertyByName(...) != nil`
- add a regression test covering the plugin-only `TS2589` path triggered by `effectInFailure`

## Validation
- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`