### PR TITLE
fix inherited Effect plugin config through extends

### DIFF
--- a/.changeset/fix-multi-hop-plugin-extends.md
+++ b/.changeset/fix-multi-hop-plugin-extends.md
@@ -1,0 +1,7 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix `@effect/language-service` activation when the plugin is inherited through multiple `tsconfig` `extends` hops.
+
+Effect diagnostics now continue to work for config chains like `tsconfig.json -> worker.json -> base.json` without duplicating the plugin stanza in intermediate configs.

--- a/internal/effectconfigraw/hooks.go
+++ b/internal/effectconfigraw/hooks.go
@@ -21,15 +21,19 @@ func MergeEffectCompilerOptions(targetOptions, sourceOptions *core.CompilerOptio
 	if targetOptions == nil || sourceOptions == nil {
 		return
 	}
-	sourcePluginRaw := getEffectPluginRaw(rawSource)
-	if sourcePluginRaw == nil {
-		return
-	}
 	sourceEffect := cloneEffectOptions(sourceOptions.Effect)
 	if sourceEffect == nil {
 		return
 	}
 	rewriteEffectOptionsOverrides(sourceEffect, sourceConfigPath, basePath)
+	sourcePluginRaw := getEffectPluginRaw(rawSource)
+	if sourcePluginRaw == nil {
+		// No local plugin stanza means sourceEffect already represents the fully
+		// merged config for this branch. Carry it forward so pass-through extends
+		// hops do not drop inherited Effect settings.
+		targetOptions.Effect = sourceEffect
+		return
+	}
 
 	if targetOptions.Effect == nil {
 		targetOptions.Effect = sourceEffect

--- a/internal/effecttest/feature_flags_test.go
+++ b/internal/effecttest/feature_flags_test.go
@@ -217,3 +217,50 @@ Effect.succeed(1)`
 
 	f.VerifyDiagnostics(t, nil)
 }
+
+func TestEffectDiagnosticsWorkThroughMultiHopExtends(t *testing.T) {
+	t.Parallel()
+
+	const content = `// @Filename: /base.json
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnosticSeverity": {
+          "floatingEffect": "error"
+        }
+      }
+    ]
+  }
+}
+// @Filename: /worker.json
+{
+  "extends": "./base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}
+// @Filename: /tsconfig.json
+{
+  "extends": "./worker.json",
+  "include": ["./index.ts"]
+}
+// @Filename: /index.ts
+import { Effect } from "effect"
+
+[|Effect.succeed(1)|]`
+
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	ranges := f.Ranges()
+	if len(ranges) != 1 {
+		t.Fatalf("expected exactly one range, got %d", len(ranges))
+	}
+	f.VerifyErrorExistsAtRange(t, ranges[0], 377001, "")
+}


### PR DESCRIPTION
## Summary
- preserve merged `@effect/language-service` options through intermediate `tsconfig` files that only pass through `extends`
- add a regression test covering `base.json -> worker.json -> tsconfig.json` inheritance so floating Effect diagnostics still appear
- add a patch changeset describing the fix for multi-hop plugin inheritance

## Testing
- pnpm setup-repo
- pnpm lint
- pnpm check
- pnpm test

Closes #169