### PR TITLE
fix TS2683 false positive in Effect.gen

### DIFF
--- a/.changeset/fix-issue-173-this-signature-help.md
+++ b/.changeset/fix-issue-173-this-signature-help.md
@@ -1,0 +1,7 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix a false-positive `TS2683` when using `this` inside directly yielded expressions in `Effect.gen({ self: this })`.
+
+This avoids losing contextual `this` typing during data-first call analysis for Effect generator code such as `yield* Scope.close(this.#scope, Exit.void)`.

--- a/internal/effecttest/issue_173_test.go
+++ b/internal/effecttest/issue_173_test.go
@@ -1,0 +1,84 @@
+package effecttest_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/fourslash"
+
+	_ "github.com/effect-ts/tsgo/etscheckerhooks"
+	_ "github.com/effect-ts/tsgo/etslshooks"
+	_ "github.com/effect-ts/tsgo/etstesthooks"
+)
+
+func TestIssue173_DirectYieldedThisDoesNotReportFalsePositiveTS2683(t *testing.T) {
+	t.Parallel()
+
+	const content = `// @Filename: /tsconfig.json
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
+  }
+}
+// @Filename: /repro.ts
+import { Effect, Exit, Scope } from "effect"
+
+class Repro {
+  readonly #scope: Scope.Closeable = Scope.makeUnsafe()
+
+  run(): Effect.Effect<void> {
+    return Effect.gen({ self: this }, function* () {
+      yield* Scope.close([|this|].#scope, Exit.void)
+    })
+  }
+}`
+
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.VerifyNonSuggestionDiagnostics(t, nil)
+}
+
+func TestIssue173_HoistedThisScopeDoesNotReportTS2683(t *testing.T) {
+	t.Parallel()
+
+	const content = `// @Filename: /tsconfig.json
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
+  }
+}
+// @Filename: /repro.ts
+import { Effect, Exit, Scope } from "effect"
+
+class Repro {
+  readonly #scope: Scope.Closeable = Scope.makeUnsafe()
+
+  run(): Effect.Effect<void> {
+    return Effect.gen({ self: this }, function* () {
+      const scope = this.#scope
+      yield* Scope.close(scope, Exit.void)
+    })
+  }
+}`
+
+	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
+	defer done()
+
+	f.VerifyNonSuggestionDiagnostics(t, nil)
+}

--- a/internal/typeparser/data_first_signature.go
+++ b/internal/typeparser/data_first_signature.go
@@ -39,6 +39,9 @@ func (tp *TypeParser) DataFirstOrLastCall(node *ast.Node) *ParsedDataFirstOrLast
 	if len(resolved.Parameters()) != len(call.Arguments.Nodes) {
 		return nil
 	}
+	if tp.GetEffectContextFlags(node)&EffectContextFlagCanYieldEffect != 0 && callHasNonBareThisArgument(call.Arguments.Nodes) {
+		return nil
+	}
 
 	resolvedSymbol := checker.Checker_getSymbolOfDeclaration(c, resolved.Declaration())
 	if resolvedSymbol == nil {
@@ -104,6 +107,36 @@ func (tp *TypeParser) DataFirstOrLastCall(node *ast.Node) *ParsedDataFirstOrLast
 	}
 
 	return nil
+}
+
+func callHasNonBareThisArgument(args []*ast.Node) bool {
+	for _, arg := range args {
+		if arg == nil || arg.Kind == ast.KindThisKeyword {
+			continue
+		}
+		if containsThisKeyword(arg) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsThisKeyword(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == ast.KindThisKeyword {
+		return true
+	}
+	contains := false
+	node.ForEachChild(func(child *ast.Node) bool {
+		if containsThisKeyword(child) {
+			contains = true
+			return true
+		}
+		return false
+	})
+	return contains
 }
 
 func derivePipeableSignatureFromDataFirst(c *checker.Checker, sig *checker.Signature, subjectIndex int) *checker.Signature {


### PR DESCRIPTION
## Summary
- avoid the signature-help resolution path for data-first analysis only in Effect generator yield scopes where a call argument contains a non-bare `this` expression
- add a regression test covering `yield* Scope.close(this.#scope, Exit.void)` inside `Effect.gen({ self: this }, ...)`
- add a patch changeset for the `TS2683` false-positive fix

## Testing
- pnpm setup-repo
- pnpm lint
- pnpm check
- pnpm test

Closes #173