### PR TITLE
fix: restore update-typescript-go workflow

### DIFF
--- a/.changeset/fix-update-typescript-go-workflow.md
+++ b/.changeset/fix-update-typescript-go-workflow.md
@@ -1,0 +1,7 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix automatic `typescript-go` update workflow compatibility with the latest upstream `tsgo` entrypoint changes.
+
+The workflow now updates to the newer upstream submodule revision, keeps the `cmd/tsgo/main.go` hook patch applying cleanly, and refreshes generated shims and flake metadata accordingly.

--- a/_patches/001-cmd-tsgo-main.patch
+++ b/_patches/001-cmd-tsgo-main.patch
@@ -1,8 +1,8 @@
 diff --git a/cmd/tsgo/main.go b/cmd/tsgo/main.go
-index 5eabc96df..82b7bf932 100644
+index aebcf70fd..6d43d0fe4 100644
 --- a/cmd/tsgo/main.go
 +++ b/cmd/tsgo/main.go
-@@ -3,6 +3,11 @@ package main
+@@ -3,7 +3,12 @@ package main
  import (
  	"os"
  
@@ -11,6 +11,7 @@ index 5eabc96df..82b7bf932 100644
 +	_ "github.com/effect-ts/tsgo/etscheckerhooks" // checker diagnostics hooks
 +	_ "github.com/effect-ts/tsgo/etslshooks"      // LS codefix hooks
 +
+ 	"github.com/microsoft/typescript-go/internal/core"
  	"github.com/microsoft/typescript-go/internal/execute"
  )
  

--- a/_tools/update-flake-vendor-hash.sh
+++ b/_tools/update-flake-vendor-hash.sh
@@ -22,8 +22,11 @@ if [[ -n "${NIX_BUILD_ARGS:-}" ]]; then
 fi
 
 # --- Step 1: Sync flake inputs with submodule commits ---
-
-tsgo_commit="$(git ls-tree HEAD typescript-go | awk '{print $3}')"
+#
+# Prefer the staged gitlink so local refreshes can be run before committing an
+# updated submodule pointer. In CI this matches HEAD once the update commit
+# exists.
+tsgo_commit="$(git ls-files --stage -- typescript-go | awk 'NR==1 {print $2}')"
 if [[ -z "$tsgo_commit" ]]; then
   echo "error: cannot determine typescript-go submodule commit" >&2
   exit 1
@@ -70,7 +73,7 @@ update_input_commit "typescript-src" "$ts_commit" "microsoft/TypeScript"
 # --- Step 2: Refresh vendor hash ---
 
 run_build() {
-  nix build "$flake_attr" --no-write-lock-file -L "${extra_args[@]}" >"$build_log" 2>&1
+  nix build "$flake_attr" --no-write-lock-file -L "${extra_args[@]+"${extra_args[@]}"}" >"$build_log" 2>&1
 }
 
 extract_new_hash() {

--- a/flake.lock
+++ b/flake.lock
@@ -43,17 +43,17 @@
     "typescript-go-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1777424922,
-        "narHash": "sha256-ebjX+1+9axEqsnZXCRZSumA38gPNdmoz98tMt2oftN4=",
+        "lastModified": 1778025409,
+        "narHash": "sha256-nDYJWb6ugFyNiwSB1t0Chq8PlFiHC3OEYat/t7OPqCw=",
         "owner": "microsoft",
         "repo": "typescript-go",
-        "rev": "56ab4af421576f5326e0c08be5ac67149c053618",
+        "rev": "ee4225a856389fc94c8ce4a5fd9af771dbbc2c0b",
         "type": "github"
       },
       "original": {
         "owner": "microsoft",
         "repo": "typescript-go",
-        "rev": "56ab4af421576f5326e0c08be5ac67149c053618",
+        "rev": "ee4225a856389fc94c8ce4a5fd9af771dbbc2c0b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     /* Source of truth: git submodule `typescript-go` commit.
        Keep in sync via `_tools/update-flake-vendor-hash.sh`. */
     typescript-go-src = {
-      url = "github:microsoft/typescript-go/56ab4af421576f5326e0c08be5ac67149c053618?submodules=1";
+      url = "github:microsoft/typescript-go/ee4225a856389fc94c8ce4a5fd9af771dbbc2c0b?submodules=1";
       flake = false;
     };
     /* Source of truth: typescript-go's `_submodules/TypeScript` commit.

--- a/shim/ast/shim.go
+++ b/shim/ast/shim.go
@@ -789,7 +789,7 @@ func IsEqualityOperatorOrHigher(kind ast.Kind) bool
 //go:linkname IsExclusivelyTypeOnlyImportOrExport github.com/microsoft/typescript-go/internal/ast.IsExclusivelyTypeOnlyImportOrExport
 func IsExclusivelyTypeOnlyImportOrExport(node *ast.Node) bool
 //go:linkname IsExpandoInitializer github.com/microsoft/typescript-go/internal/ast.IsExpandoInitializer
-func IsExpandoInitializer(initializer *ast.Node) bool
+func IsExpandoInitializer(declaration *ast.Node, initializer *ast.Node) bool
 //go:linkname IsExpandoPropertyDeclaration github.com/microsoft/typescript-go/internal/ast.IsExpandoPropertyDeclaration
 func IsExpandoPropertyDeclaration(node *ast.Node) bool
 //go:linkname IsExponentiationOperator github.com/microsoft/typescript-go/internal/ast.IsExponentiationOperator

--- a/shim/core/shim.go
+++ b/shim/core/shim.go
@@ -10,6 +10,8 @@ import _ "unsafe"
 
 //go:linkname ApplyBulkEdits github.com/microsoft/typescript-go/internal/core.ApplyBulkEdits
 func ApplyBulkEdits(text string, edits []core.TextChange) string
+//go:linkname ApplyDebugStackLimit github.com/microsoft/typescript-go/internal/core.ApplyDebugStackLimit
+func ApplyDebugStackLimit()
 type Arena[T any] = core.Arena[T]
 //go:linkname BoolToTristate github.com/microsoft/typescript-go/internal/core.BoolToTristate
 func BoolToTristate(b bool) core.Tristate


### PR DESCRIPTION
## Summary

Fix the automatic `update-typescript-go` workflow after the latest upstream `typescript-go` update.

This PR:
- refreshes `_patches/001-cmd-tsgo-main.patch` against the current upstream `cmd/tsgo/main.go`
- updates the `typescript-go` submodule to `ee4225a856389fc94c8ce4a5fd9af771dbbc2c0b`
- refreshes generated shim output for the upstream API changes
- syncs `flake.nix` / `flake.lock` with the updated upstream commit
- hardens `_tools/update-flake-vendor-hash.sh` for local/staged submodule refreshes and empty `NIX_BUILD_ARGS`

## Why

The scheduled workflow started failing in `pnpm setup-repo --ci` because `_patches/001-cmd-tsgo-main.patch` no longer applied after upstream added `internal/core` imports and `core.ApplyDebugStackLimit()` to `cmd/tsgo/main.go`.

## Validation

Ran locally:
- `pnpm setup-repo --ci`
- `pnpm check`
- `pnpm test`
- `nix build .#effect-tsgo`

`pnpm lint` still reports pre-existing `modernize` diagnostics unrelated to this change.
