### PR TITLE
chore: update typescript-go

### DIFF
--- a/.changeset/update-typescript-go-1e58c841.md
+++ b/.changeset/update-typescript-go-1e58c841.md
@@ -1,0 +1,7 @@
+---
+"@effect/tsgo": patch
+---
+
+Update the pinned `typescript-go` submodule to `1e58c8419142e35f338840dc50822c48dcc4ec1f` and refresh the local patch metadata needed to apply cleanly on that upstream revision.
+
+Regenerate shim bindings for upstream API changes introduced by the submodule update.

--- a/_patches/001-cmd-tsgo-main.patch
+++ b/_patches/001-cmd-tsgo-main.patch
@@ -1,8 +1,8 @@
 diff --git a/cmd/tsgo/main.go b/cmd/tsgo/main.go
-index 5eabc96df..82b7bf932 100644
+index a2fe02e8c..10044042c 100644
 --- a/cmd/tsgo/main.go
 +++ b/cmd/tsgo/main.go
-@@ -3,6 +3,11 @@ package main
+@@ -3,7 +3,12 @@ package main
  import (
  	"os"
  
@@ -11,6 +11,7 @@ index 5eabc96df..82b7bf932 100644
 +	_ "github.com/effect-ts/tsgo/etscheckerhooks" // checker diagnostics hooks
 +	_ "github.com/effect-ts/tsgo/etslshooks"      // LS codefix hooks
 +
+ 	"github.com/microsoft/typescript-go/internal/core"
  	"github.com/microsoft/typescript-go/internal/execute"
  )
  

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     /* Source of truth: git submodule `typescript-go` commit.
        Keep in sync via `_tools/update-flake-vendor-hash.sh`. */
     typescript-go-src = {
-      url = "github:microsoft/typescript-go/56ab4af421576f5326e0c08be5ac67149c053618?submodules=1";
+      url = "github:microsoft/typescript-go/1e58c8419142e35f338840dc50822c48dcc4ec1f?submodules=1";
       flake = false;
     };
     /* Source of truth: typescript-go's `_submodules/TypeScript` commit.

--- a/shim/ast/shim.go
+++ b/shim/ast/shim.go
@@ -789,7 +789,7 @@ func IsEqualityOperatorOrHigher(kind ast.Kind) bool
 //go:linkname IsExclusivelyTypeOnlyImportOrExport github.com/microsoft/typescript-go/internal/ast.IsExclusivelyTypeOnlyImportOrExport
 func IsExclusivelyTypeOnlyImportOrExport(node *ast.Node) bool
 //go:linkname IsExpandoInitializer github.com/microsoft/typescript-go/internal/ast.IsExpandoInitializer
-func IsExpandoInitializer(initializer *ast.Node) bool
+func IsExpandoInitializer(declaration *ast.Node, initializer *ast.Node) bool
 //go:linkname IsExpandoPropertyDeclaration github.com/microsoft/typescript-go/internal/ast.IsExpandoPropertyDeclaration
 func IsExpandoPropertyDeclaration(node *ast.Node) bool
 //go:linkname IsExponentiationOperator github.com/microsoft/typescript-go/internal/ast.IsExponentiationOperator

--- a/shim/collections/shim.go
+++ b/shim/collections/shim.go
@@ -5,6 +5,8 @@ package collections
 
 import "github.com/microsoft/typescript-go/internal/collections"
 
+type CopyOnWriteMap[K comparable, V any] = collections.CopyOnWriteMap[K,V]
+type CopyOnWriteSet[K comparable] = collections.CopyOnWriteSet[K]
 type MapEntry[K comparable, V any] = collections.MapEntry[K,V]
 type MultiMap[K, V comparable] = collections.MultiMap[K,V]
 type OrderedMap[K comparable, V any] = collections.OrderedMap[K,V]

--- a/shim/core/shim.go
+++ b/shim/core/shim.go
@@ -10,6 +10,8 @@ import _ "unsafe"
 
 //go:linkname ApplyBulkEdits github.com/microsoft/typescript-go/internal/core.ApplyBulkEdits
 func ApplyBulkEdits(text string, edits []core.TextChange) string
+//go:linkname ApplyDebugStackLimit github.com/microsoft/typescript-go/internal/core.ApplyDebugStackLimit
+func ApplyDebugStackLimit()
 type Arena[T any] = core.Arena[T]
 //go:linkname BoolToTristate github.com/microsoft/typescript-go/internal/core.BoolToTristate
 func BoolToTristate(b bool) core.Tristate


### PR DESCRIPTION
## Summary
- update the pinned `typescript-go` submodule to `1e58c8419142e35f338840dc50822c48dcc4ec1f`
- refresh `_patches/001-cmd-tsgo-main.patch` so the patch queue still applies on the new upstream import layout
- regenerate shim bindings for upstream API changes, including `core.ApplyDebugStackLimit`, `collections.CopyOnWrite{Map,Set}`, and the updated `ast.IsExpandoInitializer` signature

## Validation
- `pnpm setup-repo`
- `pnpm check`
- `pnpm test`