### PR TITLE
fix data-first signature diagnostics

### DIFF
--- a/.changeset/fix-data-first-signature-diagnostics.md
+++ b/.changeset/fix-data-first-signature-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Avoid triggering stray TypeScript diagnostics while detecting data-first and data-last Effect APIs during piping-flow analysis.

--- a/internal/typeparser/data_first_signature.go
+++ b/internal/typeparser/data_first_signature.go
@@ -53,6 +53,11 @@ func (tp *TypeParser) DataFirstOrLastCall(node *ast.Node) *ParsedDataFirstOrLast
 	if resolvedSymbol == nil {
 		return nil
 	}
+	calleeType := tp.GetTypeAtLocation(call.Expression)
+	if calleeType == nil {
+		return nil
+	}
+	candidates := c.GetSignaturesOfType(calleeType, checker.SignatureKindCall)
 
 	subjectIndexes := []int{0}
 	if len(call.Arguments.Nodes) == 2 {
@@ -68,7 +73,6 @@ func (tp *TypeParser) DataFirstOrLastCall(node *ast.Node) *ParsedDataFirstOrLast
 		}
 	}
 
-	_, candidates := checker.GetResolvedSignatureForSignatureHelp(node, len(call.Arguments.Nodes)-1, c)
 	for _, subjectIndex := range subjectIndexes {
 		derived := derivePipeableSignatureFromDataFirst(c, resolved, subjectIndex)
 		if derived == nil {

--- a/internal/typeparser/data_first_signature.go
+++ b/internal/typeparser/data_first_signature.go
@@ -31,15 +31,6 @@ func (tp *TypeParser) DataFirstOrLastCall(node *ast.Node) *ParsedDataFirstOrLast
 		}
 	}
 
-	if tp.GetEffectContextFlags(node) != 0 {
-		if callHasNonBareThisArgument(call.Arguments.Nodes) ||
-			containsThisKeyword(call.Expression) ||
-			callHasArrowFunctionArgument(call.Arguments.Nodes) ||
-			callHasGenericCallee(tp, call) {
-			return nil
-		}
-	}
-
 	c := tp.checker
 	resolved := c.GetResolvedSignature(node)
 	if resolved == nil || resolved.Declaration() == nil {
@@ -117,65 +108,6 @@ func (tp *TypeParser) DataFirstOrLastCall(node *ast.Node) *ParsedDataFirstOrLast
 	}
 
 	return nil
-}
-
-func callHasNonBareThisArgument(args []*ast.Node) bool {
-	for _, arg := range args {
-		if arg == nil || arg.Kind == ast.KindThisKeyword {
-			continue
-		}
-		if containsThisKeyword(arg) {
-			return true
-		}
-	}
-	return false
-}
-
-func callHasArrowFunctionArgument(args []*ast.Node) bool {
-	for _, arg := range args {
-		if arg != nil && arg.Kind == ast.KindArrowFunction {
-			return true
-		}
-	}
-	return false
-}
-
-func callHasGenericCallee(tp *TypeParser, call *ast.CallExpression) bool {
-	if call == nil || call.Expression == nil {
-		return false
-	}
-	sym := tp.ReferenceSymbolAtNode(call.Expression)
-	if sym == nil {
-		return false
-	}
-	for _, decl := range sym.Declarations {
-		if decl == nil {
-			continue
-		}
-		typeParams := GetFunctionLikeTypeParameters(decl)
-		if typeParams != nil && len(typeParams.Nodes) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
-func containsThisKeyword(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	if node.Kind == ast.KindThisKeyword {
-		return true
-	}
-	contains := false
-	node.ForEachChild(func(child *ast.Node) bool {
-		if containsThisKeyword(child) {
-			contains = true
-			return true
-		}
-		return false
-	})
-	return contains
 }
 
 func derivePipeableSignatureFromDataFirst(c *checker.Checker, sig *checker.Signature, subjectIndex int) *checker.Signature {

--- a/testdata/baselines/reference/effect-v4/outdatedApi.flows.outdatedApi.mermaid
+++ b/testdata/baselines/reference/effect-v4/outdatedApi.flows.outdatedApi.mermaid
@@ -111,21 +111,23 @@ flowchart TB
   109[/"type: #quot;err#quot;<br/>node: #quot;err#quot;"/]
   110["type: Effect#lt;never, string, never#gt;<br/>callee: Effect.fail<br/>args: #91;#93;"]
   111[/"type: #lt;E#gt;#40;error: E#41; =#gt; Effect#lt;never, E, never#gt;<br/>node: Effect.fail"/]
-  112[/"type: Effect#lt;unknown#91;#93;, never, never#gt;<br/>node: Effect.filterMap#40;#91;Effect.succeed#40;1#41;, Effect.succeed#40;2#41;#93;, #40;n#41; =#gt; n #gt; 1 ? Effect.succeed#40;n#41; : Effect.succeed#40;null#41;#41;"/]
+  112[/"type: Effect#lt;number, never, never#gt;#91;#93;<br/>node: #91;Effect.succeed#40;1#41;, Effect.succeed#40;2#41;#93;"/]
   113[/"type: 1<br/>node: 1"/]
   114["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
   115[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
   116[/"type: 2<br/>node: 2"/]
   117["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
   118[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  119[["type: #40;n: Effect#lt;number, never, never#gt;#41; =#gt; Effect#lt;null, never, never#gt; #124; Effect#lt;Effect#lt;number, never, never#gt;, never, never#gt;<br/>node: #40;n#41; =#gt; n #gt; 1 ? Effect.succeed#40;n#41; : Effect.succeed#40;null#41;"]]
-  120[/"type: Effect#lt;null, never, never#gt; #124; Effect#lt;Effect#lt;number, never, never#gt;, never, never#gt;<br/>node: n #gt; 1 ? Effect.succeed#40;n#41; : Effect.succeed#40;null#41;"/]
-  121[/"type: Effect#lt;number, never, never#gt;<br/>node: n"/]
-  122["type: Effect#lt;Effect#lt;number, never, never#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  123[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  124[/"type: null<br/>node: null"/]
-  125["type: Effect#lt;null, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  126[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  119["type: Effect#lt;unknown#91;#93;, never, never#gt;<br/>callee: <br/>args: #91;#93;"]
+  120[/"type: #123; #lt;A, B, X#gt;#40;filter: Filter#lt;NoInfer#lt;A#gt;, B, X#gt;#41;: #40;elements: Iterable#lt;A#gt;#41; =#gt; Effect#lt;B#91;#93;, never, never#gt;; #lt;A, B, X#gt;#40;elements: Iterable#lt;A#gt;, filter: Filter#lt;NoInfer#lt;A#gt;, B, X#gt;#41;: Effect#lt;B#91;#93;, never, never#gt;; #125;<br/>node: Effect.filterMap"/]
+  121[["type: #40;n: Effect#lt;number, never, never#gt;#41; =#gt; Effect#lt;null, never, never#gt; #124; Effect#lt;Effect#lt;number, never, never#gt;, never, never#gt;<br/>node: #40;n#41; =#gt; n #gt; 1 ? Effect.succeed#40;n#41; : Effect.succeed#40;null#41;"]]
+  122[/"type: Effect#lt;null, never, never#gt; #124; Effect#lt;Effect#lt;number, never, never#gt;, never, never#gt;<br/>node: n #gt; 1 ? Effect.succeed#40;n#41; : Effect.succeed#40;null#41;"/]
+  123[/"type: Effect#lt;number, never, never#gt;<br/>node: n"/]
+  124["type: Effect#lt;Effect#lt;number, never, never#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  125[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  126[/"type: null<br/>node: null"/]
+  127["type: Effect#lt;null, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  128[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
   1 -->|"kind: yieldable"| 0
   5 -->|"kind: potentialReturn"| 4
   4 -->|"kind: usedBy"| 3
@@ -222,11 +224,13 @@ flowchart TB
   116 -->|"kind: pipe"| 117
   118 -->|"kind: transformCallee"| 117
   117 -->|"kind: usedBy"| 112
-  121 -->|"kind: pipe"| 122
-  123 -->|"kind: transformCallee"| 122
-  122 -->|"kind: usedBy"| 120
-  124 -->|"kind: pipe"| 125
-  126 -->|"kind: transformCallee"| 125
-  125 -->|"kind: usedBy"| 120
-  120 -->|"kind: potentialReturn"| 119
-  119 -->|"kind: usedBy"| 112
+  112 -->|"kind: pipe"| 119
+  120 -->|"kind: transformCallee"| 112
+  123 -->|"kind: pipe"| 124
+  125 -->|"kind: transformCallee"| 124
+  124 -->|"kind: usedBy"| 122
+  126 -->|"kind: pipe"| 127
+  128 -->|"kind: transformCallee"| 127
+  127 -->|"kind: usedBy"| 122
+  122 -->|"kind: potentialReturn"| 121
+  121 -->|"kind: transformArg"| 112

--- a/testdata/baselines/reference/effect-v4/outdatedApi.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/outdatedApi.pipings.txt
@@ -1,4 +1,4 @@
-==== /.src/outdatedApi.ts (37 flows) ====
+==== /.src/outdatedApi.ts (38 flows) ====
 
 === Piping Flow ===
 Location: 6:25 - 8:3
@@ -485,6 +485,20 @@ Transformations (1):
       callee: Effect.fail
       args: (constant)
       outType: Effect<never, string, never>
+
+=== Piping Flow ===
+Location: 87:27 - 87:141
+Node: Effect.filterMap([Effect.succeed(1), Effect.succeed(2)], (n) => n > 1 ? Effect.succeed(n) : Effect.succeed(null))
+Node Kind: KindCallExpression
+
+Subject: [Effect.succeed(1), Effect.succeed(2)]
+Subject Type: Effect<number, never, never>[]
+
+Transformations (1):
+  [0] kind: dataFirst
+      callee: Effect.filterMap
+      args: [(n) => n > 1 ? Effect.succeed(n) : Effect.succeed(null)]
+      outType: Effect<unknown[], never, never>
 
 === Piping Flow ===
 Location: 87:46 - 87:63

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.errors.txt
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.errors.txt
@@ -1,0 +1,36 @@
+=== Metadata ===
+Effect version: 4.0.0
+
+
+
+==== /.src/schemaMutableKey_ts2322.ts (0 errors) ====
+    import { Schema, Struct as Struct_, SchemaAST  } from "effect"
+    
+    
+    interface optionalKeyLambda extends Struct_.Lambda {
+      <S extends Schema.Top>(self: S): Schema.optionalKey<S>
+      readonly "~lambda.out": this["~lambda.in"] extends Schema.Top ? Schema.optionalKey<this["~lambda.in"]> : never
+    }
+    
+    /**
+     * Creates an exact optional key schema for struct fields. Unlike `optional`,
+     * this creates exact optional properties (not `| undefined`) that can be
+     * completely omitted from the object.
+     *
+     * **Example** (Creating a struct with optional key)
+     *
+     * ```ts
+     * import { Schema } from "effect"
+     *
+     * const schema = Schema.Struct({
+     *   name: Schema.String,
+     *   age: Schema.optionalKey(Schema.Number)
+     * })
+     *
+     * // Type: { readonly name: string; readonly age?: number }
+     * type Person = typeof schema["Type"]
+     * ```
+     *
+     * @since 4.0.0
+     */
+    export const optionalKey = Struct_.lambda<optionalKeyLambda>((schema) => Schema.make(SchemaAST.optionalKey(schema.ast), { schema }))

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.flows.schemaMutableKey_ts2322.mermaid
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.flows.schemaMutableKey_ts2322.mermaid
@@ -1,0 +1,15 @@
+flowchart TB
+  0[/"type: <br/>node: Struct_.Lambda"/]
+  1[["type: #40;schema: Top#41; =#gt; optionalKey#lt;Top#gt;<br/>node: #40;schema#41; =#gt; Schema.make#40;SchemaAST.optionalKey#40;schema.ast#41;, #123; schema #125;#41;"]]
+  2[/"type: optionalKey#lt;Top#gt;<br/>node: Schema.make#40;SchemaAST.optionalKey#40;schema.ast#41;, #123; schema #125;#41;"/]
+  3[/"type: AST<br/>node: schema.ast"/]
+  4["type: AST<br/>callee: SchemaAST.optionalKey<br/>args: #91;#93;"]
+  5[/"type: #lt;A extends AST#gt;#40;ast: A#41; =#gt; A<br/>node: SchemaAST.optionalKey"/]
+  6["type: optionalKeyLambda<br/>callee: Struct_.lambda<br/>args: #91;#93;"]
+  7[/"type: #lt;L extends #40;a: any#41; =#gt; any#gt;#40;f: #40;a: Parameters#lt;L#gt;#91;0#93;#41; =#gt; ReturnType#lt;L#gt;#41; =#gt; L<br/>node: Struct_.lambda"/]
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  4 -->|"kind: usedBy"| 2
+  2 -->|"kind: potentialReturn"| 1
+  1 -->|"kind: pipe"| 6
+  7 -->|"kind: transformCallee"| 6

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.flows.txt
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.flows.txt
@@ -1,0 +1,1 @@
+/.src/schemaMutableKey_ts2322.ts -> schemaMutableKey_ts2322.flows.schemaMutableKey_ts2322.mermaid

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.layers.txt
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/schemaMutableKey_ts2322.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.pipings.txt
@@ -1,0 +1,29 @@
+==== /.src/schemaMutableKey_ts2322.ts (2 flows) ====
+
+=== Piping Flow ===
+Location: 30:27 - 30:133
+Node: Struct_.lambda<optionalKeyLambda>((schema) => Schema.make(SchemaAST.optionalKey(schema.ast), { schema }))
+Node Kind: KindCallExpression
+
+Subject: (schema) => Schema.make(SchemaAST.optionalKey(schema.ast), { schema })
+Subject Type: (schema: Top) => optionalKey<Top>
+
+Transformations (1):
+  [0] kind: call
+      callee: Struct_.lambda
+      args: (constant)
+      outType: optionalKeyLambda
+
+=== Piping Flow ===
+Location: 30:86 - 30:119
+Node: SchemaAST.optionalKey(schema.ast)
+Node Kind: KindCallExpression
+
+Subject: schema.ast
+Subject Type: AST
+
+Transformations (1):
+  [0] kind: call
+      callee: SchemaAST.optionalKey
+      args: (constant)
+      outType: AST

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.quickfixes.txt
@@ -1,0 +1,5 @@
+=== Quick Fix Inventory ===
+(no diagnostics)
+
+=== Quick Fix Application Results ===
+(no quick fixes to apply)

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.errors.txt
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.errors.txt
@@ -1,0 +1,48 @@
+=== Metadata ===
+Effect version: 4.0.0
+
+
+
+==== /.src/tsconfig.json (0 errors) ====
+    {
+      "compilerOptions": {
+        "strict": true,
+        "target": "ESNext",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext"
+      }
+    }
+    
+
+==== /.src/schemaMutableKey_ts2322_pluginDisabled.ts (0 errors) ====
+    import { Schema, Struct as Struct_, SchemaAST  } from "effect"
+    
+    
+    interface optionalKeyLambda extends Struct_.Lambda {
+      <S extends Schema.Top>(self: S): Schema.optionalKey<S>
+      readonly "~lambda.out": this["~lambda.in"] extends Schema.Top ? Schema.optionalKey<this["~lambda.in"]> : never
+    }
+    
+    /**
+     * Creates an exact optional key schema for struct fields. Unlike `optional`,
+     * this creates exact optional properties (not `| undefined`) that can be
+     * completely omitted from the object.
+     *
+     * **Example** (Creating a struct with optional key)
+     *
+     * ```ts
+     * import { Schema } from "effect"
+     *
+     * const schema = Schema.Struct({
+     *   name: Schema.String,
+     *   age: Schema.optionalKey(Schema.Number)
+     * })
+     *
+     * // Type: { readonly name: string; readonly age?: number }
+     * type Person = typeof schema["Type"]
+     * ```
+     *
+     * @since 4.0.0
+     */
+    export const optionalKey = Struct_.lambda<optionalKeyLambda>((schema) => Schema.make(SchemaAST.optionalKey(schema.ast), { schema }))
+    

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.flows.schemaMutableKey_ts2322_pluginDisabled.mermaid
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.flows.schemaMutableKey_ts2322_pluginDisabled.mermaid
@@ -1,0 +1,15 @@
+flowchart TB
+  0[/"type: <br/>node: Struct_.Lambda"/]
+  1[["type: #40;schema: Top#41; =#gt; optionalKey#lt;Top#gt;<br/>node: #40;schema#41; =#gt; Schema.make#40;SchemaAST.optionalKey#40;schema.ast#41;, #123; schema #125;#41;"]]
+  2[/"type: optionalKey#lt;Top#gt;<br/>node: Schema.make#40;SchemaAST.optionalKey#40;schema.ast#41;, #123; schema #125;#41;"/]
+  3[/"type: AST<br/>node: schema.ast"/]
+  4["type: AST<br/>callee: SchemaAST.optionalKey<br/>args: #91;#93;"]
+  5[/"type: #lt;A extends AST#gt;#40;ast: A#41; =#gt; A<br/>node: SchemaAST.optionalKey"/]
+  6["type: optionalKeyLambda<br/>callee: Struct_.lambda<br/>args: #91;#93;"]
+  7[/"type: #lt;L extends #40;a: any#41; =#gt; any#gt;#40;f: #40;a: Parameters#lt;L#gt;#91;0#93;#41; =#gt; ReturnType#lt;L#gt;#41; =#gt; L<br/>node: Struct_.lambda"/]
+  3 -->|"kind: pipe"| 4
+  5 -->|"kind: transformCallee"| 4
+  4 -->|"kind: usedBy"| 2
+  2 -->|"kind: potentialReturn"| 1
+  1 -->|"kind: pipe"| 6
+  7 -->|"kind: transformCallee"| 6

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.flows.txt
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.flows.txt
@@ -1,0 +1,1 @@
+/.src/schemaMutableKey_ts2322_pluginDisabled.ts -> schemaMutableKey_ts2322_pluginDisabled.flows.schemaMutableKey_ts2322_pluginDisabled.mermaid

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.layers.txt
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/schemaMutableKey_ts2322_pluginDisabled.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.pipings.txt
@@ -1,0 +1,29 @@
+==== /.src/schemaMutableKey_ts2322_pluginDisabled.ts (2 flows) ====
+
+=== Piping Flow ===
+Location: 30:27 - 30:133
+Node: Struct_.lambda<optionalKeyLambda>((schema) => Schema.make(SchemaAST.optionalKey(schema.ast), { schema }))
+Node Kind: KindCallExpression
+
+Subject: (schema) => Schema.make(SchemaAST.optionalKey(schema.ast), { schema })
+Subject Type: (schema: Top) => optionalKey<Top>
+
+Transformations (1):
+  [0] kind: call
+      callee: Struct_.lambda
+      args: (constant)
+      outType: optionalKeyLambda
+
+=== Piping Flow ===
+Location: 30:86 - 30:119
+Node: SchemaAST.optionalKey(schema.ast)
+Node Kind: KindCallExpression
+
+Subject: schema.ast
+Subject Type: AST
+
+Transformations (1):
+  [0] kind: call
+      callee: SchemaAST.optionalKey
+      args: (constant)
+      outType: AST

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.quickfixes.txt
@@ -1,0 +1,5 @@
+=== Quick Fix Inventory ===
+(no diagnostics)
+
+=== Quick Fix Application Results ===
+(no quick fixes to apply)

--- a/testdata/tests/effect-v4/schemaMutableKey_ts2322.ts
+++ b/testdata/tests/effect-v4/schemaMutableKey_ts2322.ts
@@ -1,0 +1,30 @@
+import { Schema, Struct as Struct_, SchemaAST  } from "effect"
+
+
+interface optionalKeyLambda extends Struct_.Lambda {
+  <S extends Schema.Top>(self: S): Schema.optionalKey<S>
+  readonly "~lambda.out": this["~lambda.in"] extends Schema.Top ? Schema.optionalKey<this["~lambda.in"]> : never
+}
+
+/**
+ * Creates an exact optional key schema for struct fields. Unlike `optional`,
+ * this creates exact optional properties (not `| undefined`) that can be
+ * completely omitted from the object.
+ *
+ * **Example** (Creating a struct with optional key)
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ *
+ * const schema = Schema.Struct({
+ *   name: Schema.String,
+ *   age: Schema.optionalKey(Schema.Number)
+ * })
+ *
+ * // Type: { readonly name: string; readonly age?: number }
+ * type Person = typeof schema["Type"]
+ * ```
+ *
+ * @since 4.0.0
+ */
+export const optionalKey = Struct_.lambda<optionalKeyLambda>((schema) => Schema.make(SchemaAST.optionalKey(schema.ast), { schema }))

--- a/testdata/tests/effect-v4/schemaMutableKey_ts2322_pluginDisabled.ts
+++ b/testdata/tests/effect-v4/schemaMutableKey_ts2322_pluginDisabled.ts
@@ -1,0 +1,41 @@
+// @filename: tsconfig.json
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  }
+}
+
+// @filename: schemaMutableKey_ts2322_pluginDisabled.ts
+import { Schema, Struct as Struct_, SchemaAST  } from "effect"
+
+
+interface optionalKeyLambda extends Struct_.Lambda {
+  <S extends Schema.Top>(self: S): Schema.optionalKey<S>
+  readonly "~lambda.out": this["~lambda.in"] extends Schema.Top ? Schema.optionalKey<this["~lambda.in"]> : never
+}
+
+/**
+ * Creates an exact optional key schema for struct fields. Unlike `optional`,
+ * this creates exact optional properties (not `| undefined`) that can be
+ * completely omitted from the object.
+ *
+ * **Example** (Creating a struct with optional key)
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ *
+ * const schema = Schema.Struct({
+ *   name: Schema.String,
+ *   age: Schema.optionalKey(Schema.Number)
+ * })
+ *
+ * // Type: { readonly name: string; readonly age?: number }
+ * type Person = typeof schema["Type"]
+ * ```
+ *
+ * @since 4.0.0
+ */
+export const optionalKey = Struct_.lambda<optionalKeyLambda>((schema) => Schema.make(SchemaAST.optionalKey(schema.ast), { schema }))


### PR DESCRIPTION
## Summary
- replace `DataFirstOrLastCall` signature-help candidate resolution with a structural sibling-overload scan so piping-flow analysis no longer triggers stray `TS2322` diagnostics
- add `schemaMutableKey_ts2322` regression coverage for plugin-enabled and plugin-disabled behavior, plus baseline updates for the refined data-first detection output
- include a changeset for the diagnostic leak fix

## Testing
- `go test ./internal/typeparser`
- `go test ./internal/effecttest`
- `pnpm setup-repo`
- `pnpm lint` *(fails in current repo state after setup-repo: generated shim/typecheck issues under `typescript-go/internal/...` unrelated to this patch)*
- `pnpm check` *(fails in current repo state after setup-repo: generated diagnostics/shim build issues unrelated to this patch)*
- `pnpm test` *(fails in current repo state after setup-repo for the same generated shim/diagnostics build issue)*