### PR TITLE
fix: track typescript-go submodule updates

### DIFF
--- a/.github/workflows/update-typescript-go.yml
+++ b/.github/workflows/update-typescript-go.yml
@@ -32,6 +32,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
 
+      - name: Track TypeScript-Go submodule updates in Git
+        run: git config submodule.typescript-go.ignore none
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -74,6 +77,9 @@ jobs:
       - name: Record updated TypeScript-Go commit
         id: after
         run: echo "sha=$(git -C typescript-go rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Stage TypeScript-Go submodule pointer
+        run: git add typescript-go
 
       - name: Build upstream changelog
         id: changelog


### PR DESCRIPTION
## Summary
Fix the automated TypeScript-Go update workflow so the generated PR commits the updated `typescript-go` gitlink instead of only updating the PR body.

## Root cause
The repo config sets `submodule.typescript-go.ignore = all`, so the workflow could read the updated nested checkout but Git would ignore the superproject gitlink change when building the generated commit.

## Changes
- set `submodule.typescript-go.ignore` to `none` inside the workflow job
- explicitly stage `typescript-go` after updating the submodule

This keeps the committed submodule pointer aligned with the PR description and changelog.