### PR TITLE
fix: track typescript-go submodule commits

### DIFF
--- a/.changeset/fix-typescript-go-submodule-tracking.md
+++ b/.changeset/fix-typescript-go-submodule-tracking.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix the automated TypeScript-Go update workflow so it tracks submodule commit changes while still ignoring local patched worktree noise inside the `typescript-go` submodule.

--- a/.github/workflows/update-typescript-go.yml
+++ b/.github/workflows/update-typescript-go.yml
@@ -33,7 +33,7 @@ jobs:
           submodules: recursive
 
       - name: Track TypeScript-Go submodule updates in Git
-        run: git config submodule.typescript-go.ignore none
+        run: git config submodule.typescript-go.ignore dirty
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "typescript-go"]
 	path = typescript-go
 	url = https://github.com/microsoft/typescript-go.git
-	ignore = all
+	ignore = dirty


### PR DESCRIPTION
## Summary
- change the `typescript-go` submodule ignore mode from `all` to `dirty`
- align the update workflow with the same ignore mode during automated TypeScript-Go refreshes
- add a changeset for the workflow fix

## Why
The update workflow intentionally patches files inside the `typescript-go` submodule during `setup-repo`, which makes the submodule worktree dirty. Using `ignore = all` hides both that expected dirty state and the superproject gitlink change, so automated PRs can record the new upstream SHA in text while still leaving the checked-in submodule pointer unchanged.

Using `ignore = dirty` keeps the expected patched worktree noise hidden while still allowing Git and the workflow to detect when the `typescript-go` submodule commit itself has changed.

## Validation
- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`