### PR TITLE
fix: handle unexported shim field types

### DIFF
--- a/.changeset/fix-shim-unexported-field-types.md
+++ b/.changeset/fix-shim-unexported-field-types.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix shim generation for mirrored struct fields that reference unexported named types.

--- a/_tools/gen_shims/main.go
+++ b/_tools/gen_shims/main.go
@@ -151,6 +151,25 @@ func main() {
 		var qualifierEmptyPackageName types.Qualifier = func(p *types.Package) string {
 			return ""
 		}
+		var fieldTypeString func(types.Type) string
+		fieldTypeString = func(t types.Type) string {
+			switch ty := t.(type) {
+			case *types.Named:
+				if !ty.Obj().Exported() {
+					return fieldTypeString(ty.Underlying())
+				}
+			case *types.Pointer:
+				return "*" + fieldTypeString(ty.Elem())
+			case *types.Slice:
+				return "[]" + fieldTypeString(ty.Elem())
+			case *types.Array:
+				return fmt.Sprintf("[%d]%s", ty.Len(), fieldTypeString(ty.Elem()))
+			case *types.Map:
+				return "map[" + fieldTypeString(ty.Key()) + "]" + fieldTypeString(ty.Elem())
+			}
+
+			return types.TypeString(t, qualifierOnlyPackageName)
+		}
 
 		emitGoLinknameDirective := func(localName string, fn *types.Func) {
 			// //go:linkname only allowed in Go files that import "unsafe"
@@ -353,10 +372,7 @@ func main() {
 								}
 							}
 
-							shimBuilder.WriteString(
-								// TODO: move to extra-shim.json
-								strings.ReplaceAll(types.TypeString(field.Type(), qualifierOnlyPackageName), "checker.thisAssignmentDeclarationKind", "int32"),
-							)
+							shimBuilder.WriteString(fieldTypeString(field.Type()))
 						}
 						shimBuilder.WriteString("\n}\n")
 

--- a/shim/checker/shim.go
+++ b/shim/checker/shim.go
@@ -179,7 +179,7 @@ type extra_Checker struct {
   errorTypes map[checker.CacheHashKey]*checker.Type
   moduleSymbols map[*ast.Node]*ast.Symbol
   globalThisSymbol *ast.Symbol
-  symbolTableAliasCache map[checker.symbolTableID][]*ast.Symbol
+  symbolTableAliasCache map[uint64][]*ast.Symbol
   resolveName func(location *ast.Node, name string, meaning ast.SymbolFlags, nameNotFoundMessage *diagnostics.Message, isUse bool, excludeGlobals bool) *ast.Symbol
   resolveNameForSymbolSuggestion func(location *ast.Node, name string, meaning ast.SymbolFlags, nameNotFoundMessage *diagnostics.Message, isUse bool, excludeGlobals bool) *ast.Symbol
   tupleTypes map[checker.CacheHashKey]*checker.Type


### PR DESCRIPTION
## Summary
- Update shim generation to print unexported named field types using their underlying type recursively.
- Regenerate the checker shim so symbolTableAliasCache no longer references the unexported checker.symbolTableID type.
- Add a patch changeset for @effect/tsgo.

## Validation
- pnpm setup-repo
- pnpm lint
- pnpm check
- pnpm test