### PR TITLE
fix: allow generic lazy effect functions

### DIFF
--- a/.changeset/fix-lazy-effect-generic-functions.md
+++ b/.changeset/fix-lazy-effect-generic-functions.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix the lazyEffect diagnostic to allow generic zero-argument functions returning Effect values.

--- a/internal/rules/lazy_effect.go
+++ b/internal/rules/lazy_effect.go
@@ -187,6 +187,9 @@ func lazyEffectLikeTypeName(c *checker.Checker, tp *typeparser.TypeParser, t *ch
 	}
 
 	sig := callSignatures[0]
+	if len(sig.TypeParameters()) != 0 {
+		return "", false
+	}
 	if len(sig.Parameters()) != 0 {
 		return "", false
 	}

--- a/testdata/baselines/reference/effect-v4/lazyEffect.errors.txt
+++ b/testdata/baselines/reference/effect-v4/lazyEffect.errors.txt
@@ -5,12 +5,12 @@ Effect version: 4.0.0
 /.src/lazyEffect.ts(12,14): warning TS377091: Exported declaration 'lazyStream' returns a lazy Stream. Stream is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
 /.src/lazyEffect.ts(15,14): warning TS377091: Exported declaration 'lazyLayer' returns a lazy Layer. Layer is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
 /.src/lazyEffect.ts(18,14): warning TS377091: Exported declaration 'lazyAnnotated' returns a lazy Effect. Effect is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
-/.src/lazyEffect.ts(51,3): warning TS377091: Interface 'RepoShape' member 'load' returns a lazy Effect. Effect is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
-/.src/lazyEffect.ts(54,3): warning TS377091: Interface 'RepoShape' member 'watch' returns a lazy Stream. Stream is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
-/.src/lazyEffect.ts(57,3): warning TS377091: Interface 'RepoShape' member 'live' returns a lazy Layer. Layer is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
-/.src/lazyEffect.ts(68,14): warning TS377091: Service 'Repo' member 'live' returns a lazy Layer. Layer is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
-/.src/lazyEffect.ts(68,14): warning TS377091: Service 'Repo' member 'load' returns a lazy Effect. Effect is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
-/.src/lazyEffect.ts(68,14): warning TS377091: Service 'Repo' member 'watch' returns a lazy Stream. Stream is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
+/.src/lazyEffect.ts(54,3): warning TS377091: Interface 'RepoShape' member 'load' returns a lazy Effect. Effect is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
+/.src/lazyEffect.ts(57,3): warning TS377091: Interface 'RepoShape' member 'watch' returns a lazy Stream. Stream is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
+/.src/lazyEffect.ts(60,3): warning TS377091: Interface 'RepoShape' member 'live' returns a lazy Layer. Layer is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
+/.src/lazyEffect.ts(74,14): warning TS377091: Service 'Repo' member 'live' returns a lazy Layer. Layer is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
+/.src/lazyEffect.ts(74,14): warning TS377091: Service 'Repo' member 'load' returns a lazy Effect. Effect is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
+/.src/lazyEffect.ts(74,14): warning TS377091: Service 'Repo' member 'watch' returns a lazy Stream. Stream is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
 
 
 ==== /.src/lazyEffect.ts (10 errors) ====
@@ -40,6 +40,9 @@ Effect version: 4.0.0
     export const lazyAnnotated: () => Effect.Effect<string> = () => Effect.succeed("ok")
                  ~~~~~~~~~~~~~
 !!! warning TS377091: Exported declaration 'lazyAnnotated' returns a lazy Effect. Effect is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
+    
+    // Should not trigger: generic lazy functions may need to construct type-dependent Effects
+    export const genericLazyEffect = <A>() => Effect.succeed(null as A)
     
     // Should not trigger: Effect values are already lazy
     export const directEffect = Effect.succeed(1)
@@ -86,6 +89,9 @@ Effect version: 4.0.0
       ~~~~
 !!! warning TS377091: Interface 'RepoShape' member 'live' returns a lazy Layer. Layer is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
     
+      // Should not trigger: generic lazy functions may need to construct type-dependent Effects
+      genericLoad: <A>() => Effect.Effect<A>
+    
       // Should not trigger: one optional argument is allowed
       maybeLoad(_?: void): Effect.Effect<string>
     
@@ -111,6 +117,9 @@ Effect version: 4.0.0
     
         // Should trigger: service member returns a zero-arg lazy Layer
         live: () => layerValue,
+    
+        // Should not trigger: generic lazy functions may need to construct type-dependent Effects
+        genericLoad: <A>() => Effect.succeed(null as A),
     
         // Should not trigger: direct Effect values are allowed
         program: Effect.void,

--- a/testdata/baselines/reference/effect-v4/lazyEffect.flows.lazyEffect.mermaid
+++ b/testdata/baselines/reference/effect-v4/lazyEffect.flows.lazyEffect.mermaid
@@ -9,89 +9,104 @@ flowchart TB
   7[/"type: #quot;ok#quot;<br/>node: #quot;ok#quot;"/]
   8["type: Effect#lt;string, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
   9[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  10[/"type: 1<br/>node: 1"/]
-  11["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  12[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  13[/"type: 1<br/>node: 1"/]
-  14["type: Stream#lt;number, never, never#gt;<br/>callee: Stream.succeed<br/>args: #91;#93;"]
-  15[/"type: #lt;A#gt;#40;value: A#41; =#gt; Stream#lt;A, never, never#gt;<br/>node: Stream.succeed"/]
-  16[["type: #40;_?: void #124; undefined#41; =#gt; Effect#lt;void, never, never#gt;<br/>node: #40;_?: void#41; =#gt; effectValue"]]
-  17[/"type: Effect#lt;void, never, never#gt;<br/>node: effectValue"/]
-  18[["type: #40;..._args: readonly unknown#91;#93;#41; =#gt; Effect#lt;void, never, never#gt;<br/>node: #40;..._args: ReadonlyArray#lt;unknown#gt;#41; =#gt; effectValue"]]
-  19[/"type: Effect#lt;void, never, never#gt;<br/>node: effectValue"/]
-  20[["type: #40;id: string#41; =#gt; Effect#lt;string, never, never#gt;<br/>node: #40;id: string#41; =#gt; Effect.succeed#40;id#41;"]]
-  21[/"type: string<br/>node: id"/]
-  22["type: Effect#lt;string, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  23[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  24[["type: #40;#41; =#gt; Effect#lt;void, never, never#gt;<br/>node: #40;#41; =#gt; effectValue"]]
-  25[/"type: Effect#lt;void, never, never#gt;<br/>node: effectValue"/]
-  26[["type: #123; #40;#41;: Effect#lt;void, never, never#gt;; #40;_input: string#41;: Effect#lt;void, never, never#gt;; #125;<br/>node: export function overloaded#40;#41;: Effect.Effect#lt;void#gt;"]]
-  27[["type: #123; #40;#41;: Effect#lt;void, never, never#gt;; #40;_input: string#41;: Effect#lt;void, never, never#gt;; #125;<br/>node: export function overloaded#40;_input: string#41;: Effect.Effect#lt;void#gt;"]]
-  28[["type: #123; #40;#41;: Effect#lt;void, never, never#gt;; #40;_input: string#41;: Effect#lt;void, never, never#gt;; #125;<br/>node: export function overloaded#40;_input?: string#41; #123;#92;n  return Effect.void#92;n#125;"]]
-  29[/"type: Effect#lt;void, never, never#gt;<br/>node: Effect.void"/]
-  30[/"type: ServiceClass#lt;Repo, #quot;Repo#quot;, #123; load: #40;#41; =#gt; Effect#lt;string, never, never#gt;; watch: #40;#41; =#gt; Stream#lt;number, never, never#gt;; live: #40;#41; =#gt; Layer#lt;string, never, never#gt;; program: Effect#lt;void, never, never#gt;; maybeLoad: #40;_?: void #124; undefined#41; =#gt; Effect#lt;string, never, never#gt;; variadic: #40;..._args: readonly string#91;#93;#41; =#gt; Effect#lt;void, never, never#gt;; byId: #40;id: string#41; =#gt; Effect#lt;string, never, never#gt;; #125;#gt; #amp; #123; readonly make: Effect#lt;#123; load: #40;#41; =#gt; Effect#lt;string, never, never#gt;; watch: #40;#41; =#gt; Stream#lt;number, never, never#gt;; live: #40;#41; =#gt; Layer#lt;string, never, never#gt;; program: Effect#lt;void, never, never#gt;; maybeLoad: #40;_?: void #124; undefined#41; =#gt; Effect#lt;string, never, never#gt;; variadic: #40;..._args: readonly string#91;#93;#41; =#gt; Effect#lt;void, never, never#gt;; byId: #40;id: string#41; =#gt; Effect#lt;string, never, never#gt;; #125;, never, never#gt;; #125;<br/>node: Context.Service#lt;Repo#gt;#40;#41;#40;#quot;Repo#quot;, #123;#92;n  make: Effect.succeed#40;#123;#92;n    // Should trigger: service member returns a zero-arg lazy Effect#92;n    load: #40;#41; =#gt; Effect.succeed#40;#quot;value#quot;#41;,#92;n#92;n    // Should trigger: service member returns a zero-arg lazy Stream#92;n    watch: #40;#41; =#gt; Stream.succeed#40;1#41;,#92;n#92;n    // Should trigger: service member returns a zero-arg lazy Layer#92;n    live: #40;#41; =#gt; layerValue,#92;n#92;n    // Should not trigger: direct Effect values are allowed#92;n    program: Effect.void,#92;n#92;n    // Should not trigger: one optional argument is allowed#92;n    maybeLoad: #40;_?: void#41; =#gt; Effect.succeed#40;#quot;value#quot;#41;,#92;n#92;n    // Should not trigger: rest arguments are allowed#92;n    variadic: #40;..._args: ReadonlyArray#lt;string#gt;#41; =#gt; Effect.void,#92;n#92;n    // Should not trigger: required arguments are allowed#92;n    byId: #40;id: string#41; =#gt; Effect.succeed#40;id#41;#92;n  #125;#41;#92;n#125;#41;"/]
-  31[/"type: #123; load: #40;#41; =#gt; Effect#lt;string, never, never#gt;; watch: #40;#41; =#gt; Stream#lt;number, never, never#gt;; live: #40;#41; =#gt; Layer#lt;string, never, never#gt;; program: Effect#lt;void, never, never#gt;; maybeLoad: #40;_?: void #124; undefined#41; =#gt; Effect#lt;string, never, never#gt;; variadic: #40;..._args: readonly string#91;#93;#41; =#gt; Effect#lt;void, never, never#gt;; byId: #40;id: string#41; =#gt; Effect#lt;string, never, never#gt;; #125;<br/>node: #123;#92;n    // Should trigger: service member returns a zero-arg lazy Effect#92;n    load: #40;#41; =#gt; Effect.succeed#40;#quot;value#quot;#41;,#92;n#92;n    // Should trigger: service member returns a zero-arg lazy Stream#92;n    watch: #40;#41; =#gt; Stream.succeed#40;1#41;,#92;n#92;n    // Should trigger: service member returns a zero-arg lazy Layer#92;n    live: #40;#41; =#gt; layerValue,#92;n#92;n    // Should not trigger: direct Effect values are allowed#92;n    program: Effect.void,#92;n#92;n    // Should not trigger: one optional argument is allowed#92;n    maybeLoad: #40;_?: void#41; =#gt; Effect.succeed#40;#quot;value#quot;#41;,#92;n#92;n    // Should not trigger: rest arguments are allowed#92;n    variadic: #40;..._args: ReadonlyArray#lt;string#gt;#41; =#gt; Effect.void,#92;n#92;n    // Should not trigger: required arguments are allowed#92;n    byId: #40;id: string#41; =#gt; Effect.succeed#40;id#41;#92;n  #125;"/]
-  32[["type: #40;#41; =#gt; Effect#lt;string, never, never#gt;<br/>node: #40;#41; =#gt; Effect.succeed#40;#quot;value#quot;#41;"]]
-  33[/"type: #quot;value#quot;<br/>node: #quot;value#quot;"/]
-  34["type: Effect#lt;string, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  35[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  36[["type: #40;#41; =#gt; Stream#lt;number, never, never#gt;<br/>node: #40;#41; =#gt; Stream.succeed#40;1#41;"]]
-  37[/"type: 1<br/>node: 1"/]
-  38["type: Stream#lt;number, never, never#gt;<br/>callee: Stream.succeed<br/>args: #91;#93;"]
-  39[/"type: #lt;A#gt;#40;value: A#41; =#gt; Stream#lt;A, never, never#gt;<br/>node: Stream.succeed"/]
-  40[["type: #40;#41; =#gt; Layer#lt;string, never, never#gt;<br/>node: #40;#41; =#gt; layerValue"]]
-  41[/"type: Layer#lt;string, never, never#gt;<br/>node: layerValue"/]
-  42[["type: #40;_?: void #124; undefined#41; =#gt; Effect#lt;string, never, never#gt;<br/>node: #40;_?: void#41; =#gt; Effect.succeed#40;#quot;value#quot;#41;"]]
-  43[/"type: #quot;value#quot;<br/>node: #quot;value#quot;"/]
-  44["type: Effect#lt;string, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  45[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  46[["type: #40;..._args: readonly string#91;#93;#41; =#gt; Effect#lt;void, never, never#gt;<br/>node: #40;..._args: ReadonlyArray#lt;string#gt;#41; =#gt; Effect.void"]]
-  47[/"type: Effect#lt;void, never, never#gt;<br/>node: Effect.void"/]
-  48[["type: #40;id: string#41; =#gt; Effect#lt;string, never, never#gt;<br/>node: #40;id: string#41; =#gt; Effect.succeed#40;id#41;"]]
-  49[/"type: string<br/>node: id"/]
-  50["type: Effect#lt;string, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  51[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  52["type: Effect#lt;#123; load: #40;#41; =#gt; Effect#lt;string, never, never#gt;; watch: #40;#41; =#gt; Stream#lt;number, never, never#gt;; live: #40;#41; =#gt; Layer#lt;string, never, never#gt;; program: Effect#lt;void, never, never#gt;; maybeLoad: #40;_?: void #124; undefined#41; =#gt; Effect#lt;string, never, never#gt;; variadic: #40;..._args: readonly string#91;#93;#41; =#gt; Effect#lt;void, never, never#gt;; byId: #40;id: string#41; =#gt; Effect#lt;string, never, never#gt;; #125;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  10[["type: #lt;A#gt;#40;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: #lt;A#gt;#40;#41; =#gt; Effect.succeed#40;null as A#41;"]]
+  11[/"type: A<br/>node: null as A"/]
+  12["type: Effect#lt;A, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  13[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  14[/"type: 1<br/>node: 1"/]
+  15["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  16[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  17[/"type: 1<br/>node: 1"/]
+  18["type: Stream#lt;number, never, never#gt;<br/>callee: Stream.succeed<br/>args: #91;#93;"]
+  19[/"type: #lt;A#gt;#40;value: A#41; =#gt; Stream#lt;A, never, never#gt;<br/>node: Stream.succeed"/]
+  20[["type: #40;_?: void #124; undefined#41; =#gt; Effect#lt;void, never, never#gt;<br/>node: #40;_?: void#41; =#gt; effectValue"]]
+  21[/"type: Effect#lt;void, never, never#gt;<br/>node: effectValue"/]
+  22[["type: #40;..._args: readonly unknown#91;#93;#41; =#gt; Effect#lt;void, never, never#gt;<br/>node: #40;..._args: ReadonlyArray#lt;unknown#gt;#41; =#gt; effectValue"]]
+  23[/"type: Effect#lt;void, never, never#gt;<br/>node: effectValue"/]
+  24[["type: #40;id: string#41; =#gt; Effect#lt;string, never, never#gt;<br/>node: #40;id: string#41; =#gt; Effect.succeed#40;id#41;"]]
+  25[/"type: string<br/>node: id"/]
+  26["type: Effect#lt;string, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  27[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  28[["type: #40;#41; =#gt; Effect#lt;void, never, never#gt;<br/>node: #40;#41; =#gt; effectValue"]]
+  29[/"type: Effect#lt;void, never, never#gt;<br/>node: effectValue"/]
+  30[["type: #123; #40;#41;: Effect#lt;void, never, never#gt;; #40;_input: string#41;: Effect#lt;void, never, never#gt;; #125;<br/>node: export function overloaded#40;#41;: Effect.Effect#lt;void#gt;"]]
+  31[["type: #123; #40;#41;: Effect#lt;void, never, never#gt;; #40;_input: string#41;: Effect#lt;void, never, never#gt;; #125;<br/>node: export function overloaded#40;_input: string#41;: Effect.Effect#lt;void#gt;"]]
+  32[["type: #123; #40;#41;: Effect#lt;void, never, never#gt;; #40;_input: string#41;: Effect#lt;void, never, never#gt;; #125;<br/>node: export function overloaded#40;_input?: string#41; #123;#92;n  return Effect.void#92;n#125;"]]
+  33[/"type: Effect#lt;void, never, never#gt;<br/>node: Effect.void"/]
+  34[/"type: ServiceClass#lt;Repo, #quot;Repo#quot;, #123; load: #40;#41; =#gt; Effect#lt;string, never, never#gt;; watch: #40;#41; =#gt; Stream#lt;number, never, never#gt;; live: #40;#41; =#gt; Layer#lt;string, never, never#gt;; genericLoad: #lt;A#gt;#40;#41; =#gt; Effect#lt;A, never, never#gt;; program: Effect#lt;void, never, never#gt;; maybeLoad: #40;_?: void #124; undefined#41; =#gt; Effect#lt;string, never, never#gt;; variadic: #40;..._args: readonly string#91;#93;#41; =#gt; Effect#lt;void, never, never#gt;; byId: #40;id: string#41; =#gt; Effect#lt;string, never, never#gt;; #125;#gt; #amp; #123; readonly make: Effect#lt;#123; load: #40;#41; =#gt; Effect#lt;string, never, never#gt;; watch: #40;#41; =#gt; Stream#lt;number, never, never#gt;; live: #40;#41; =#gt; Layer#lt;string, never, never#gt;; genericLoad: #lt;A#gt;#40;#41; =#gt; Effect#lt;A, never, never#gt;; program: Effect#lt;void, never, never#gt;; maybeLoad: #40;_?: void #124; undefined#41; =#gt; Effect#lt;string, never, never#gt;; variadic: #40;..._args: readonly string#91;#93;#41; =#gt; Effect#lt;void, never, never#gt;; byId: #40;id: string#41; =#gt; Effect#lt;string, never, never#gt;; #125;, never, never#gt;; #125;<br/>node: Context.Service#lt;Repo#gt;#40;#41;#40;#quot;Repo#quot;, #123;#92;n  make: Effect.succeed#40;#123;#92;n    // Should trigger: service member returns a zero-arg lazy Effect#92;n    load: #40;#41; =#gt; Effect.succeed#40;#quot;value#quot;#41;,#92;n#92;n    // Should trigger: service member returns a zero-arg lazy Stream#92;n    watch: #40;#41; =#gt; Stream.succeed#40;1#41;,#92;n#92;n    // Should trigger: service member returns a zero-arg lazy Layer#92;n    live: #40;#41; =#gt; layerValue,#92;n#92;n    // Should not trigger: generic lazy functions may need to construct type-dependent Effects#92;n    genericLoad: #lt;A#gt;#40;#41; =#gt; Effect.succeed#40;null as A#41;,#92;n#92;n    // Should not trigger: direct Effect values are allowed#92;n    program: Effect.void,#92;n#92;n    // Should not trigger: one optional argument is allowed#92;n    maybeLoad: #40;_?: void#41; =#gt; Effect.succeed#40;#quot;value#quot;#41;,#92;n#92;n    // Should not trigger: rest arguments are allowed#92;n    variadic: #40;..._args: ReadonlyArray#lt;string#gt;#41; =#gt; Effect.void,#92;n#92;n    // Should not trigger: required arguments are allowed#92;n    byId: #40;id: string#41; =#gt; Effect.succeed#40;id#41;#92;n  #125;#41;#92;n#125;#41;"/]
+  35[/"type: #123; load: #40;#41; =#gt; Effect#lt;string, never, never#gt;; watch: #40;#41; =#gt; Stream#lt;number, never, never#gt;; live: #40;#41; =#gt; Layer#lt;string, never, never#gt;; genericLoad: #lt;A#gt;#40;#41; =#gt; Effect#lt;A, never, never#gt;; program: Effect#lt;void, never, never#gt;; maybeLoad: #40;_?: void #124; undefined#41; =#gt; Effect#lt;string, never, never#gt;; variadic: #40;..._args: readonly string#91;#93;#41; =#gt; Effect#lt;void, never, never#gt;; byId: #40;id: string#41; =#gt; Effect#lt;string, never, never#gt;; #125;<br/>node: #123;#92;n    // Should trigger: service member returns a zero-arg lazy Effect#92;n    load: #40;#41; =#gt; Effect.succeed#40;#quot;value#quot;#41;,#92;n#92;n    // Should trigger: service member returns a zero-arg lazy Stream#92;n    watch: #40;#41; =#gt; Stream.succeed#40;1#41;,#92;n#92;n    // Should trigger: service member returns a zero-arg lazy Layer#92;n    live: #40;#41; =#gt; layerValue,#92;n#92;n    // Should not trigger: generic lazy functions may need to construct type-dependent Effects#92;n    genericLoad: #lt;A#gt;#40;#41; =#gt; Effect.succeed#40;null as A#41;,#92;n#92;n    // Should not trigger: direct Effect values are allowed#92;n    program: Effect.void,#92;n#92;n    // Should not trigger: one optional argument is allowed#92;n    maybeLoad: #40;_?: void#41; =#gt; Effect.succeed#40;#quot;value#quot;#41;,#92;n#92;n    // Should not trigger: rest arguments are allowed#92;n    variadic: #40;..._args: ReadonlyArray#lt;string#gt;#41; =#gt; Effect.void,#92;n#92;n    // Should not trigger: required arguments are allowed#92;n    byId: #40;id: string#41; =#gt; Effect.succeed#40;id#41;#92;n  #125;"/]
+  36[["type: #40;#41; =#gt; Effect#lt;string, never, never#gt;<br/>node: #40;#41; =#gt; Effect.succeed#40;#quot;value#quot;#41;"]]
+  37[/"type: #quot;value#quot;<br/>node: #quot;value#quot;"/]
+  38["type: Effect#lt;string, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  39[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  40[["type: #40;#41; =#gt; Stream#lt;number, never, never#gt;<br/>node: #40;#41; =#gt; Stream.succeed#40;1#41;"]]
+  41[/"type: 1<br/>node: 1"/]
+  42["type: Stream#lt;number, never, never#gt;<br/>callee: Stream.succeed<br/>args: #91;#93;"]
+  43[/"type: #lt;A#gt;#40;value: A#41; =#gt; Stream#lt;A, never, never#gt;<br/>node: Stream.succeed"/]
+  44[["type: #40;#41; =#gt; Layer#lt;string, never, never#gt;<br/>node: #40;#41; =#gt; layerValue"]]
+  45[/"type: Layer#lt;string, never, never#gt;<br/>node: layerValue"/]
+  46[["type: #lt;A#gt;#40;#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: #lt;A#gt;#40;#41; =#gt; Effect.succeed#40;null as A#41;"]]
+  47[/"type: A<br/>node: null as A"/]
+  48["type: Effect#lt;A, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  49[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  50[["type: #40;_?: void #124; undefined#41; =#gt; Effect#lt;string, never, never#gt;<br/>node: #40;_?: void#41; =#gt; Effect.succeed#40;#quot;value#quot;#41;"]]
+  51[/"type: #quot;value#quot;<br/>node: #quot;value#quot;"/]
+  52["type: Effect#lt;string, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
   53[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  54[/"type: undefined<br/>node: void localLazy"/]
+  54[["type: #40;..._args: readonly string#91;#93;#41; =#gt; Effect#lt;void, never, never#gt;<br/>node: #40;..._args: ReadonlyArray#lt;string#gt;#41; =#gt; Effect.void"]]
+  55[/"type: Effect#lt;void, never, never#gt;<br/>node: Effect.void"/]
+  56[["type: #40;id: string#41; =#gt; Effect#lt;string, never, never#gt;<br/>node: #40;id: string#41; =#gt; Effect.succeed#40;id#41;"]]
+  57[/"type: string<br/>node: id"/]
+  58["type: Effect#lt;string, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  59[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  60["type: Effect#lt;#123; load: #40;#41; =#gt; Effect#lt;string, never, never#gt;; watch: #40;#41; =#gt; Stream#lt;number, never, never#gt;; live: #40;#41; =#gt; Layer#lt;string, never, never#gt;; genericLoad: #lt;A#gt;#40;#41; =#gt; Effect#lt;A, never, never#gt;; program: Effect#lt;void, never, never#gt;; maybeLoad: #40;_?: void #124; undefined#41; =#gt; Effect#lt;string, never, never#gt;; variadic: #40;..._args: readonly string#91;#93;#41; =#gt; Effect#lt;void, never, never#gt;; byId: #40;id: string#41; =#gt; Effect#lt;string, never, never#gt;; #125;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  61[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  62[/"type: undefined<br/>node: void localLazy"/]
   1 -->|"kind: potentialReturn"| 0
   3 -->|"kind: potentialReturn"| 2
   5 -->|"kind: potentialReturn"| 4
   7 -->|"kind: pipe"| 8
   9 -->|"kind: transformCallee"| 8
   8 -->|"kind: potentialReturn"| 6
-  10 -->|"kind: pipe"| 11
-  12 -->|"kind: transformCallee"| 11
-  13 -->|"kind: pipe"| 14
-  15 -->|"kind: transformCallee"| 14
-  17 -->|"kind: potentialReturn"| 16
-  19 -->|"kind: potentialReturn"| 18
-  21 -->|"kind: pipe"| 22
-  23 -->|"kind: transformCallee"| 22
-  22 -->|"kind: potentialReturn"| 20
-  25 -->|"kind: potentialReturn"| 24
+  11 -->|"kind: pipe"| 12
+  13 -->|"kind: transformCallee"| 12
+  12 -->|"kind: potentialReturn"| 10
+  14 -->|"kind: pipe"| 15
+  16 -->|"kind: transformCallee"| 15
+  17 -->|"kind: pipe"| 18
+  19 -->|"kind: transformCallee"| 18
+  21 -->|"kind: potentialReturn"| 20
+  23 -->|"kind: potentialReturn"| 22
+  25 -->|"kind: pipe"| 26
+  27 -->|"kind: transformCallee"| 26
+  26 -->|"kind: potentialReturn"| 24
   29 -->|"kind: potentialReturn"| 28
-  29 -->|"kind: usedBy"| 28
-  33 -->|"kind: pipe"| 34
-  35 -->|"kind: transformCallee"| 34
-  34 -->|"kind: potentialReturn"| 32
-  32 -->|"kind: usedBy"| 31
+  33 -->|"kind: potentialReturn"| 32
+  33 -->|"kind: usedBy"| 32
   37 -->|"kind: pipe"| 38
   39 -->|"kind: transformCallee"| 38
   38 -->|"kind: potentialReturn"| 36
-  36 -->|"kind: usedBy"| 31
-  41 -->|"kind: potentialReturn"| 40
-  40 -->|"kind: usedBy"| 31
-  43 -->|"kind: pipe"| 44
-  45 -->|"kind: transformCallee"| 44
-  44 -->|"kind: potentialReturn"| 42
-  42 -->|"kind: usedBy"| 31
-  47 -->|"kind: potentialReturn"| 46
-  46 -->|"kind: usedBy"| 31
-  49 -->|"kind: pipe"| 50
-  51 -->|"kind: transformCallee"| 50
-  50 -->|"kind: potentialReturn"| 48
-  48 -->|"kind: usedBy"| 31
-  31 -->|"kind: pipe"| 52
+  36 -->|"kind: usedBy"| 35
+  41 -->|"kind: pipe"| 42
+  43 -->|"kind: transformCallee"| 42
+  42 -->|"kind: potentialReturn"| 40
+  40 -->|"kind: usedBy"| 35
+  45 -->|"kind: potentialReturn"| 44
+  44 -->|"kind: usedBy"| 35
+  47 -->|"kind: pipe"| 48
+  49 -->|"kind: transformCallee"| 48
+  48 -->|"kind: potentialReturn"| 46
+  46 -->|"kind: usedBy"| 35
+  51 -->|"kind: pipe"| 52
   53 -->|"kind: transformCallee"| 52
-  52 -->|"kind: usedBy"| 30
+  52 -->|"kind: potentialReturn"| 50
+  50 -->|"kind: usedBy"| 35
+  55 -->|"kind: potentialReturn"| 54
+  54 -->|"kind: usedBy"| 35
+  57 -->|"kind: pipe"| 58
+  59 -->|"kind: transformCallee"| 58
+  58 -->|"kind: potentialReturn"| 56
+  56 -->|"kind: usedBy"| 35
+  35 -->|"kind: pipe"| 60
+  61 -->|"kind: transformCallee"| 60
+  60 -->|"kind: usedBy"| 34

--- a/testdata/baselines/reference/effect-v4/lazyEffect.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/lazyEffect.pipings.txt
@@ -1,4 +1,4 @@
-==== /.src/lazyEffect.ts (9 flows) ====
+==== /.src/lazyEffect.ts (11 flows) ====
 
 === Piping Flow ===
 Location: 18:64 - 18:85
@@ -15,7 +15,21 @@ Transformations (1):
       outType: Effect<string, never, never>
 
 === Piping Flow ===
-Location: 21:28 - 21:46
+Location: 21:42 - 21:68
+Node: Effect.succeed(null as A)
+Node Kind: KindCallExpression
+
+Subject: null as A
+Subject Type: A
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<A, never, never>
+
+=== Piping Flow ===
+Location: 24:28 - 24:46
 Node: Effect.succeed(1)
 Node Kind: KindCallExpression
 
@@ -29,7 +43,7 @@ Transformations (1):
       outType: Effect<number, never, never>
 
 === Piping Flow ===
-Location: 24:28 - 24:46
+Location: 27:28 - 27:46
 Node: Stream.succeed(1)
 Node Kind: KindCallExpression
 
@@ -43,7 +57,7 @@ Transformations (1):
       outType: Stream<number, never, never>
 
 === Piping Flow ===
-Location: 33:39 - 33:58
+Location: 36:39 - 36:58
 Node: Effect.succeed(id)
 Node Kind: KindCallExpression
 
@@ -57,21 +71,21 @@ Transformations (1):
       outType: Effect<string, never, never>
 
 === Piping Flow ===
-Location: 69:8 - 90:5
-Node: Effect.succeed({\n    // Should trigger: service member returns a zero-arg lazy Effect\n    load: () => Effect.succeed("value"),\n\n    // Should trigger: service member returns a zero-arg lazy Stream\n    watch: () => Stream.succeed(1),\n\n    // Should trigger: service member returns a zero-arg lazy Layer\n    live: () => layerValue,\n\n    // Should not trigger: direct Effect values are allowed\n    program: Effect.void,\n\n    // Should not trigger: one optional argument is allowed\n    maybeLoad: (_?: void) => Effect.succeed("value"),\n\n    // Should not trigger: rest arguments are allowed\n    variadic: (..._args: ReadonlyArray<string>) => Effect.void,\n\n    // Should not trigger: required arguments are allowed\n    byId: (id: string) => Effect.succeed(id)\n  })
+Location: 75:8 - 99:5
+Node: Effect.succeed({\n    // Should trigger: service member returns a zero-arg lazy Effect\n    load: () => Effect.succeed("value"),\n\n    // Should trigger: service member returns a zero-arg lazy Stream\n    watch: () => Stream.succeed(1),\n\n    // Should trigger: service member returns a zero-arg lazy Layer\n    live: () => layerValue,\n\n    // Should not trigger: generic lazy functions may need to construct type-dependent Effects\n    genericLoad: <A>() => Effect.succeed(null as A),\n\n    // Should not trigger: direct Effect values are allowed\n    program: Effect.void,\n\n    // Should not trigger: one optional argument is allowed\n    maybeLoad: (_?: void) => Effect.succeed("value"),\n\n    // Should not trigger: rest arguments are allowed\n    variadic: (..._args: ReadonlyArray<string>) => Effect.void,\n\n    // Should not trigger: required arguments are allowed\n    byId: (id: string) => Effect.succeed(id)\n  })
 Node Kind: KindCallExpression
 
-Subject: {\n    // Should trigger: service member returns a zero-arg lazy Effect\n    load: () => Effect.succeed("value"),\n\n    // Should trigger: service member returns a zero-arg lazy Stream\n    watch: () => Stream.succeed(1),\n\n    // Should trigger: service member returns a zero-arg lazy Layer\n    live: () => layerValue,\n\n    // Should not trigger: direct Effect values are allowed\n    program: Effect.void,\n\n    // Should not trigger: one optional argument is allowed\n    maybeLoad: (_?: void) => Effect.succeed("value"),\n\n    // Should not trigger: rest arguments are allowed\n    variadic: (..._args: ReadonlyArray<string>) => Effect.void,\n\n    // Should not trigger: required arguments are allowed\n    byId: (id: string) => Effect.succeed(id)\n  }
-Subject Type: { load: () => Effect<string, never, never>; watch: () => Stream<number, never, never>; live: () => Layer<string, never, never>; program: Effect<void, never, never>; maybeLoad: (_?: void | undefined) => Effect<string, never, never>; variadic: (..._args: readonly string[]) => Effect<void, never, never>; byId: (id: string) => Effect<string, never, never>; }
+Subject: {\n    // Should trigger: service member returns a zero-arg lazy Effect\n    load: () => Effect.succeed("value"),\n\n    // Should trigger: service member returns a zero-arg lazy Stream\n    watch: () => Stream.succeed(1),\n\n    // Should trigger: service member returns a zero-arg lazy Layer\n    live: () => layerValue,\n\n    // Should not trigger: generic lazy functions may need to construct type-dependent Effects\n    genericLoad: <A>() => Effect.succeed(null as A),\n\n    // Should not trigger: direct Effect values are allowed\n    program: Effect.void,\n\n    // Should not trigger: one optional argument is allowed\n    maybeLoad: (_?: void) => Effect.succeed("value"),\n\n    // Should not trigger: rest arguments are allowed\n    variadic: (..._args: ReadonlyArray<string>) => Effect.void,\n\n    // Should not trigger: required arguments are allowed\n    byId: (id: string) => Effect.succeed(id)\n  }
+Subject Type: { load: () => Effect<string, never, never>; watch: () => Stream<number, never, never>; live: () => Layer<string, never, never>; genericLoad: <A>() => Effect<A, never, never>; program: Effect<void, never, never>; maybeLoad: (_?: void | undefined) => Effect<string, never, never>; variadic: (..._args: readonly string[]) => Effect<void, never, never>; byId: (id: string) => Effect<string, never, never>; }
 
 Transformations (1):
   [0] kind: call
       callee: Effect.succeed
       args: (constant)
-      outType: Effect<{ load: () => Effect<string, never, never>; watch: () => Stream<number, never, never>; live: () => Layer<string, never, never>; program: Effect<void, never, never>; maybeLoad: (_?: void | undefined) => Effect<string, never, never>; variadic: (..._args: readonly string[]) => Effect<void, never, never>; byId: (id: string) => Effect<string, never, never>; }, never, never>
+      outType: Effect<{ load: () => Effect<string, never, never>; watch: () => Stream<number, never, never>; live: () => Layer<string, never, never>; genericLoad: <A>() => Effect<A, never, never>; program: Effect<void, never, never>; maybeLoad: (_?: void | undefined) => Effect<string, never, never>; variadic: (..._args: readonly string[]) => Effect<void, never, never>; byId: (id: string) => Effect<string, never, never>; }, never, never>
 
 === Piping Flow ===
-Location: 71:16 - 71:40
+Location: 77:16 - 77:40
 Node: Effect.succeed("value")
 Node Kind: KindCallExpression
 
@@ -85,7 +99,7 @@ Transformations (1):
       outType: Effect<string, never, never>
 
 === Piping Flow ===
-Location: 74:17 - 74:35
+Location: 80:17 - 80:35
 Node: Stream.succeed(1)
 Node Kind: KindCallExpression
 
@@ -99,7 +113,21 @@ Transformations (1):
       outType: Stream<number, never, never>
 
 === Piping Flow ===
-Location: 83:29 - 83:53
+Location: 86:26 - 86:52
+Node: Effect.succeed(null as A)
+Node Kind: KindCallExpression
+
+Subject: null as A
+Subject Type: A
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<A, never, never>
+
+=== Piping Flow ===
+Location: 92:29 - 92:53
 Node: Effect.succeed("value")
 Node Kind: KindCallExpression
 
@@ -113,7 +141,7 @@ Transformations (1):
       outType: Effect<string, never, never>
 
 === Piping Flow ===
-Location: 89:26 - 89:45
+Location: 98:26 - 98:45
 Node: Effect.succeed(id)
 Node Kind: KindCallExpression
 

--- a/testdata/baselines/reference/effect-v4/lazyEffect.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/lazyEffect.quickfixes.txt
@@ -16,27 +16,27 @@
   Fix 0: "Disable lazyEffect for this line"
   Fix 1: "Disable lazyEffect for entire file"
 
-[D5] (51:3-51:7) TS377091: Interface 'RepoShape' member 'load' returns a lazy Effect. Effect is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
+[D5] (54:3-54:7) TS377091: Interface 'RepoShape' member 'load' returns a lazy Effect. Effect is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
   Fix 0: "Disable lazyEffect for this line"
   Fix 1: "Disable lazyEffect for entire file"
 
-[D6] (54:3-54:8) TS377091: Interface 'RepoShape' member 'watch' returns a lazy Stream. Stream is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
+[D6] (57:3-57:8) TS377091: Interface 'RepoShape' member 'watch' returns a lazy Stream. Stream is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
   Fix 0: "Disable lazyEffect for this line"
   Fix 1: "Disable lazyEffect for entire file"
 
-[D7] (57:3-57:7) TS377091: Interface 'RepoShape' member 'live' returns a lazy Layer. Layer is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
+[D7] (60:3-60:7) TS377091: Interface 'RepoShape' member 'live' returns a lazy Layer. Layer is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
   Fix 0: "Disable lazyEffect for this line"
   Fix 1: "Disable lazyEffect for entire file"
 
-[D8] (68:14-68:18) TS377091: Service 'Repo' member 'live' returns a lazy Layer. Layer is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
+[D8] (74:14-74:18) TS377091: Service 'Repo' member 'live' returns a lazy Layer. Layer is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
   Fix 0: "Disable lazyEffect for this line"
   Fix 1: "Disable lazyEffect for entire file"
 
-[D9] (68:14-68:18) TS377091: Service 'Repo' member 'load' returns a lazy Effect. Effect is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
+[D9] (74:14-74:18) TS377091: Service 'Repo' member 'load' returns a lazy Effect. Effect is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
   Fix 0: "Disable lazyEffect for this line"
   Fix 1: "Disable lazyEffect for entire file"
 
-[D10] (68:14-68:18) TS377091: Service 'Repo' member 'watch' returns a lazy Stream. Stream is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
+[D10] (74:14-74:18) TS377091: Service 'Repo' member 'watch' returns a lazy Stream. Stream is already lazy, so wrapping it in a zero-argument function adds unnecessary indirection. effect(lazyEffect)
   Fix 0: "Disable lazyEffect for this line"
   Fix 1: "Disable lazyEffect for entire file"
 

--- a/testdata/tests/effect-v4/lazyEffect.ts
+++ b/testdata/tests/effect-v4/lazyEffect.ts
@@ -17,6 +17,9 @@ export const lazyLayer = () => layerValue
 // Should trigger: exported explicit zero-arg function type returning Effect
 export const lazyAnnotated: () => Effect.Effect<string> = () => Effect.succeed("ok")
 
+// Should not trigger: generic lazy functions may need to construct type-dependent Effects
+export const genericLazyEffect = <A>() => Effect.succeed(null as A)
+
 // Should not trigger: Effect values are already lazy
 export const directEffect = Effect.succeed(1)
 
@@ -56,6 +59,9 @@ export interface RepoShape extends SharedShape {
   // Should trigger: interface property returning a zero-arg lazy Layer
   live: () => Layer.Layer<string>
 
+  // Should not trigger: generic lazy functions may need to construct type-dependent Effects
+  genericLoad: <A>() => Effect.Effect<A>
+
   // Should not trigger: one optional argument is allowed
   maybeLoad(_?: void): Effect.Effect<string>
 
@@ -75,6 +81,9 @@ export class Repo extends Context.Service<Repo>()("Repo", {
 
     // Should trigger: service member returns a zero-arg lazy Layer
     live: () => layerValue,
+
+    // Should not trigger: generic lazy functions may need to construct type-dependent Effects
+    genericLoad: <A>() => Effect.succeed(null as A),
 
     // Should not trigger: direct Effect values are allowed
     program: Effect.void,


### PR DESCRIPTION
## Summary
- Skip lazyEffect diagnostics for zero-argument call signatures with type parameters.
- Add fixture coverage for exported, interface, and service generic lazy functions returning Effect values.
- Refresh lazyEffect baselines and add a patch changeset.

## Validation
- pnpm setup-repo
- pnpm lint
- pnpm check
- pnpm test