### PR TITLE
chore: update TypeScript-Go

### DIFF
--- a/.changeset/update-typescript-go-551b02d.md
+++ b/.changeset/update-typescript-go-551b02d.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Update the pinned TypeScript-Go submodule to `551b02d6c10e78610fc5ca7c23b77c9d531ee59b` and refresh generated shims.

--- a/_patches/001-cmd-tsgo-main.patch
+++ b/_patches/001-cmd-tsgo-main.patch
@@ -1,10 +1,10 @@
 diff --git a/cmd/tsgo/main.go b/cmd/tsgo/main.go
-index a2fe02e8c..10044042c 100644
+index 8d6816fa3d..49c6cbecba 100644
 --- a/cmd/tsgo/main.go
 +++ b/cmd/tsgo/main.go
-@@ -3,6 +3,12 @@ package main
- import (
- 	"os"
+@@ -6,6 +6,12 @@ import (
+ 	"os/signal"
+ 	"syscall"
  
 +	// Import Effect hooks to register via init()
 +	_ "github.com/effect-ts/tsgo/etsapihooks"     // native API hooks
@@ -15,4 +15,3 @@ index a2fe02e8c..10044042c 100644
  	"github.com/microsoft/typescript-go/internal/core"
  	"github.com/microsoft/typescript-go/internal/execute"
  )
- 

--- a/_patches/009-execute-tsc-emit.patch
+++ b/_patches/009-execute-tsc-emit.patch
@@ -1,5 +1,5 @@
 diff --git a/internal/execute/tsc.go b/internal/execute/tsc.go
-index 385ceba18..72ee9639f 100644
+index 80a9bdac9..8ac89fa6d 100644
 --- a/internal/execute/tsc.go
 +++ b/internal/execute/tsc.go
 @@ -5,6 +5,7 @@ import (
@@ -10,10 +10,10 @@ index 385ceba18..72ee9639f 100644
  	"github.com/microsoft/typescript-go/internal/ast"
  	"github.com/microsoft/typescript-go/internal/collections"
  	"github.com/microsoft/typescript-go/internal/compiler"
-@@ -50,6 +51,9 @@ func stopTracing(sys tsc.System, tr *tracing.Tracing) {
+@@ -49,6 +50,9 @@ func stopTracing(sys tsc.System, tr *tracing.Tracing) {
  }
  
- func CommandLine(sys tsc.System, commandLineArgs []string, testing tsc.CommandLineTesting) tsc.CommandLineResult {
+ func CommandLine(ctx context.Context, sys tsc.System, commandLineArgs []string, testing tsc.CommandLineTesting) tsc.CommandLineResult {
 +	restore := etscore.EnterCommandLineMode()
 +	defer restore()
 +
@@ -21,7 +21,7 @@ index 385ceba18..72ee9639f 100644
  		switch strings.ToLower(commandLineArgs[0]) {
  		case "-b", "--b", "-build", "--build":
 diff --git a/internal/execute/tsc/emit.go b/internal/execute/tsc/emit.go
-index 16080d1f8..9286d1e95 100644
+index 3a1e3de69..8cb7c24c0 100644
 --- a/internal/execute/tsc/emit.go
 +++ b/internal/execute/tsc/emit.go
 @@ -10,6 +10,7 @@ import (

--- a/_patches/022-ls-completions.patch
+++ b/_patches/022-ls-completions.patch
@@ -1,5 +1,5 @@
 diff --git a/internal/ls/completions.go b/internal/ls/completions.go
-index 9c27bfe08..0f3d03446 100644
+index f7d1c9f84..23d100dbb 100644
 --- a/internal/ls/completions.go
 +++ b/internal/ls/completions.go
 @@ -31,13 +31,25 @@ import (
@@ -29,10 +29,12 @@ index 9c27bfe08..0f3d03446 100644
  	var triggerCharacter *string
  	if context != nil {
  		triggerCharacter = context.TriggerCharacter
-@@ -53,6 +65,21 @@ func (l *LanguageService) ProvideCompletion(
+@@ -54,6 +66,22 @@ func (l *LanguageService) ProvideCompletion(
  	if err != nil {
  		return lsproto.CompletionItemsOrListOrNull{}, err
  	}
+-	completionList := ensureItemData(file.FileName(), position, completionListInternal.toLSP())
++	completionList := completionListInternal.toLSP()
 +	// EFFECT HOOK: Allow Effect to add or modify completion items
 +	if AfterCompletionCallback != nil {
 +		var existingItems []*lsproto.CompletionItem
@@ -48,6 +50,6 @@ index 9c27bfe08..0f3d03446 100644
 +		}
 +	}
 +
- 	completionList = ensureItemData(file.FileName(), position, completionList)
++	completionList = ensureItemData(file.FileName(), position, completionList)
  	return lsproto.CompletionItemsOrListOrNull{List: completionList}, nil
  }

--- a/_patches/028-api-effect-diagnostics.patch
+++ b/_patches/028-api-effect-diagnostics.patch
@@ -77,7 +77,7 @@ diff --git a/internal/api/session.go b/internal/api/session.go
  	case string(MethodGetSuggestionDiagnostics):
  		return s.handleGetSuggestionDiagnostics(ctx, parsed.(*GetDiagnosticsParams))
  	case string(MethodGetDeclarationDiagnostics):
-@@ -2003,6 +2015,40 @@ func (s *Session) handleGetSemanticDiagnostics(ctx context.Context, params *GetD
+@@ -2169,4 +2181,38 @@ func (s *Session) handleGetSemanticDiagnostics(ctx context.Context, params *GetD
  	return NewDiagnosticResponses(diags), nil
  }
  
@@ -116,5 +116,3 @@ diff --git a/internal/api/session.go b/internal/api/session.go
 +}
 +
  // handleGetSuggestionDiagnostics returns suggestion diagnostics for a file or all files.
- func (s *Session) handleGetSuggestionDiagnostics(ctx context.Context, params *GetDiagnosticsParams) ([]*DiagnosticResponse, error) {
- 	sd, err := s.getSnapshotData(params.Snapshot)

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     /* Source of truth: git submodule `typescript-go` commit.
        Keep in sync via `_tools/update-flake-vendor-hash.sh`. */
     typescript-go-src = {
-      url = "github:microsoft/typescript-go/f20e9196e66c08fd0f752c6fca02c9b45df474eb?submodules=1";
+      url = "github:microsoft/typescript-go/551b02d6c10e78610fc5ca7c23b77c9d531ee59b?submodules=1";
       flake = false;
     };
     /* Source of truth: typescript-go's `_submodules/TypeScript` commit.

--- a/shim/api/shim.go
+++ b/shim/api/shim.go
@@ -18,6 +18,9 @@ type APIFileChanges = api.APIFileChanges
 type AsyncConn = api.AsyncConn
 type CheckerSignatureParams = api.CheckerSignatureParams
 type CheckerTypeParams = api.CheckerTypeParams
+type CompletionEntryLabelDetailsResponse = api.CompletionEntryLabelDetailsResponse
+type CompletionEntryResponse = api.CompletionEntryResponse
+type CompletionInfoResponse = api.CompletionInfoResponse
 type ConfigFileResponse = api.ConfigFileResponse
 type Conn = api.Conn
 type DiagnosticResponse = api.DiagnosticResponse
@@ -29,6 +32,7 @@ var ErrRequestTimeout = api.ErrRequestTimeout
 //go:linkname GeneratePipePath github.com/microsoft/typescript-go/internal/api.GeneratePipePath
 func GeneratePipePath(name string) string
 type GetBaseTypeOfLiteralTypeParams = api.GetBaseTypeOfLiteralTypeParams
+type GetCompletionsAtPositionParams = api.GetCompletionsAtPositionParams
 type GetContextualTypeParams = api.GetContextualTypeParams
 type GetDefaultProjectForFileParams = api.GetDefaultProjectForFileParams
 type GetDiagnosticsParams = api.GetDiagnosticsParams
@@ -89,6 +93,7 @@ const MethodGetBaseTypes = api.MethodGetBaseTypes
 const MethodGetBigIntType = api.MethodGetBigIntType
 const MethodGetBooleanType = api.MethodGetBooleanType
 const MethodGetCheckTypeOfType = api.MethodGetCheckTypeOfType
+const MethodGetCompletionsAtPosition = api.MethodGetCompletionsAtPosition
 const MethodGetConfigFileParsingDiagnostics = api.MethodGetConfigFileParsingDiagnostics
 const MethodGetConstraintOfType = api.MethodGetConstraintOfType
 const MethodGetConstraintOfTypeParameter = api.MethodGetConstraintOfTypeParameter

--- a/shim/ast/shim.go
+++ b/shim/ast/shim.go
@@ -2205,6 +2205,7 @@ const NodeFlagsPossiblyContainsImportMeta = ast.NodeFlagsPossiblyContainsImportM
 const NodeFlagsReachabilityAndEmitFlags = ast.NodeFlagsReachabilityAndEmitFlags
 const NodeFlagsReachabilityCheckFlags = ast.NodeFlagsReachabilityCheckFlags
 const NodeFlagsReparsed = ast.NodeFlagsReparsed
+const NodeFlagsReparserTransformedLiteral = ast.NodeFlagsReparserTransformedLiteral
 const NodeFlagsSynthesized = ast.NodeFlagsSynthesized
 const NodeFlagsThisNodeHasError = ast.NodeFlagsThisNodeHasError
 const NodeFlagsThisNodeOrAnySubNodesHasError = ast.NodeFlagsThisNodeOrAnySubNodesHasError

--- a/shim/core/shim.go
+++ b/shim/core/shim.go
@@ -19,6 +19,10 @@ type BreadthFirstSearchLevel[K comparable, N any] = core.BreadthFirstSearchLevel
 type BreadthFirstSearchOptions[K comparable, N any] = core.BreadthFirstSearchOptions[K,N]
 type BreadthFirstSearchResult[N any] = core.BreadthFirstSearchResult[N]
 type BuildOptions = core.BuildOptions
+type CheckerLifetime = core.CheckerLifetime
+const CheckerLifetimeAPI = core.CheckerLifetimeAPI
+const CheckerLifetimeDiagnostics = core.CheckerLifetimeDiagnostics
+const CheckerLifetimeTemporary = core.CheckerLifetimeTemporary
 //go:linkname CompareBooleans github.com/microsoft/typescript-go/internal/core.CompareBooleans
 func CompareBooleans(a bool, b bool) int
 //go:linkname CompareTextRanges github.com/microsoft/typescript-go/internal/core.CompareTextRanges
@@ -31,6 +35,8 @@ func ComputeECMALineStartsSeq(text string) iter.Seq[core.TextPos]
 type ECMALineStarts = core.ECMALineStarts
 var EmptyCompilerOptions = core.EmptyCompilerOptions
 var ExclusivelyPrefixedNodeCoreModules = core.ExclusivelyPrefixedNodeCoreModules
+//go:linkname GetCheckerLifetime github.com/microsoft/typescript-go/internal/core.GetCheckerLifetime
+func GetCheckerLifetime(ctx context.Context) core.CheckerLifetime
 //go:linkname GetNewLineKind github.com/microsoft/typescript-go/internal/core.GetNewLineKind
 func GetNewLineKind(s string) core.NewLineKind
 //go:linkname GetRequestID github.com/microsoft/typescript-go/internal/core.GetRequestID
@@ -187,6 +193,8 @@ const WatchFileKindPriorityPollingInterval = core.WatchFileKindPriorityPollingIn
 const WatchFileKindUseFsEvents = core.WatchFileKindUseFsEvents
 const WatchFileKindUseFsEventsOnParentDirectory = core.WatchFileKindUseFsEventsOnParentDirectory
 type WatchOptions = core.WatchOptions
+//go:linkname WithCheckerLifetime github.com/microsoft/typescript-go/internal/core.WithCheckerLifetime
+func WithCheckerLifetime(ctx context.Context, lifetime core.CheckerLifetime) context.Context
 //go:linkname WithRequestID github.com/microsoft/typescript-go/internal/core.WithRequestID
 func WithRequestID(ctx context.Context, id string) context.Context
 type WorkGroup = core.WorkGroup

--- a/shim/ls/shim.go
+++ b/shim/ls/shim.go
@@ -34,6 +34,7 @@ type CodeFixProvider = ls.CodeFixProvider
 type CombinedCodeActions = ls.CombinedCodeActions
 //go:linkname CompareCompletionEntries github.com/microsoft/typescript-go/internal/ls.CompareCompletionEntries
 func CompareCompletionEntries(a *lsproto.CompletionItem, b *lsproto.CompletionItem) int
+type CompletionItem = ls.CompletionItem
 type CompletionKind = ls.CompletionKind
 const CompletionKindGlobal = ls.CompletionKindGlobal
 const CompletionKindMemberLike = ls.CompletionKindMemberLike
@@ -41,6 +42,7 @@ const CompletionKindNone = ls.CompletionKindNone
 const CompletionKindObjectPropertyDeclaration = ls.CompletionKindObjectPropertyDeclaration
 const CompletionKindPropertyAccess = ls.CompletionKindPropertyAccess
 const CompletionKindString = ls.CompletionKindString
+type CompletionList = ls.CompletionList
 type CompletionsTriggerCharacter = ls.CompletionsTriggerCharacter
 type CrossProjectOrchestrator = ls.CrossProjectOrchestrator
 type DeclarationInfo = ls.DeclarationInfo

--- a/shim/lsp/lsproto/shim.go
+++ b/shim/lsp/lsproto/shim.go
@@ -439,6 +439,7 @@ const ImportKindDefault = lsproto.ImportKindDefault
 const ImportKindNamed = lsproto.ImportKindNamed
 const ImportKindNamespace = lsproto.ImportKindNamespace
 type InitializationOptions = lsproto.InitializationOptions
+type InitializationOptionsOrNull = lsproto.InitializationOptionsOrNull
 type InitializeAPISessionParams = lsproto.InitializeAPISessionParams
 type InitializeAPISessionResult = lsproto.InitializeAPISessionResult
 type InitializeError = lsproto.InitializeError

--- a/shim/project/logging/shim.go
+++ b/shim/project/logging/shim.go
@@ -14,5 +14,7 @@ type Logger = logging.Logger
 func NewLogTree(name string) *logging.LogTree
 //go:linkname NewLogger github.com/microsoft/typescript-go/internal/project/logging.NewLogger
 func NewLogger(output io.Writer) logging.Logger
+//go:linkname NewNopLogger github.com/microsoft/typescript-go/internal/project/logging.NewNopLogger
+func NewNopLogger() logging.Logger
 //go:linkname NewTestLogger github.com/microsoft/typescript-go/internal/project/logging.NewTestLogger
 func NewTestLogger() logging.LogCollector

--- a/shim/project/shim.go
+++ b/shim/project/shim.go
@@ -15,7 +15,7 @@ import _ "unsafe"
 
 type APISnapshotRequest = project.APISnapshotRequest
 type ATAStateChange = project.ATAStateChange
-type CheckerPool = project.CheckerPool
+type CheckerPoolOptions = project.CheckerPoolOptions
 type Client = project.Client
 type ConfigFileRegistry = project.ConfigFileRegistry
 type CreateProgramResult = project.CreateProgramResult


### PR DESCRIPTION
## Summary
- update the pinned TypeScript-Go submodule to microsoft/typescript-go@551b02d6c10e78610fc5ca7c23b77c9d531ee59b
- refresh patches for upstream API/signature changes
- regenerate shims from the updated TypeScript-Go sources

## Validation
- pnpm setup-repo
- pnpm lint
- pnpm check
- pnpm test