### PR TITLE
chore: update TypeScript-Go

### DIFF
--- a/.changeset/update-typescript-go-2fb5d4c.md
+++ b/.changeset/update-typescript-go-2fb5d4c.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Update TypeScript Go to microsoft/typescript-go@2fb5d4ce13935aef1f3c2896fad76d0ab4d43604.

--- a/_patches/018-ls-autoimport-stylepolicy.patch
+++ b/_patches/018-ls-autoimport-stylepolicy.patch
@@ -3,7 +3,7 @@ index e34b62822..b733cd122 100644
 --- a/internal/ls/autoimport/aliasresolver.go
 +++ b/internal/ls/autoimport/aliasresolver.go
 @@ -219,6 +219,11 @@ func (r *aliasResolver) IsSourceFileDefaultLibrary(path tspath.Path) bool {
- 	panic("unimplemented")
+ 	return false
  }
  
 +// IsSourceFileFromExternalLibrary implements checker.Program.

--- a/_patches/023-checker-effect-links.patch
+++ b/_patches/023-checker-effect-links.patch
@@ -1,9 +1,10 @@
 diff --git a/internal/checker/checker.go b/internal/checker/checker.go
 --- a/internal/checker/checker.go
 +++ b/internal/checker/checker.go
-@@ -612,6 +612,7 @@ type Checker struct {
+@@ -622,7 +622,8 @@ type Checker struct {
  	TypeCount                                   uint32
  	SymbolCount                                 uint32
+ 	SignatureCount                              uint32
  	TotalInstantiationCount                     uint32
 +	EffectLinks                                 any
  	instantiationCount                          uint32

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     /* Source of truth: git submodule `typescript-go` commit.
        Keep in sync via `_tools/update-flake-vendor-hash.sh`. */
     typescript-go-src = {
-      url = "github:microsoft/typescript-go/551b02d6c10e78610fc5ca7c23b77c9d531ee59b?submodules=1";
+      url = "github:microsoft/typescript-go/2fb5d4ce13935aef1f3c2896fad76d0ab4d43604?submodules=1";
       flake = false;
     };
     /* Source of truth: typescript-go's `_submodules/TypeScript` commit.

--- a/shim/api/shim.go
+++ b/shim/api/shim.go
@@ -38,23 +38,20 @@ type GetDefaultProjectForFileParams = api.GetDefaultProjectForFileParams
 type GetDiagnosticsParams = api.GetDiagnosticsParams
 var GetEffectDiagnosticsCallback = api.GetEffectDiagnosticsCallback
 type GetEffectDiagnosticsParams = api.GetEffectDiagnosticsParams
-type GetExportSymbolOfSymbolParams = api.GetExportSymbolOfSymbolParams
-type GetExportsOfSymbolParams = api.GetExportsOfSymbolParams
 type GetIntrinsicTypeParams = api.GetIntrinsicTypeParams
-type GetMembersOfSymbolParams = api.GetMembersOfSymbolParams
 type GetNonNullableTypeParams = api.GetNonNullableTypeParams
 type GetParameterTypeParams = api.GetParameterTypeParams
-type GetParentOfSymbolParams = api.GetParentOfSymbolParams
 type GetProjectDiagnosticsParams = api.GetProjectDiagnosticsParams
 type GetReferencedSymbolsForNodeParams = api.GetReferencedSymbolsForNodeParams
 type GetReferencesToSymbolInFileParams = api.GetReferencesToSymbolInFileParams
 type GetResolvedSignatureParams = api.GetResolvedSignatureParams
+type GetSignaturePropertyParams = api.GetSignaturePropertyParams
 type GetSignatureUsagesParams = api.GetSignatureUsagesParams
 type GetSignaturesOfTypeParams = api.GetSignaturesOfTypeParams
 type GetSourceFileParams = api.GetSourceFileParams
 type GetSymbolAtLocationParams = api.GetSymbolAtLocationParams
 type GetSymbolAtPositionParams = api.GetSymbolAtPositionParams
-type GetSymbolOfTypeParams = api.GetSymbolOfTypeParams
+type GetSymbolPropertyParams = api.GetSymbolPropertyParams
 type GetSymbolsAtLocationsParams = api.GetSymbolsAtLocationsParams
 type GetSymbolsAtPositionsParams = api.GetSymbolsAtPositionsParams
 type GetTypeAtLocationParams = api.GetTypeAtLocationParams
@@ -118,6 +115,7 @@ const MethodGetNumberType = api.MethodGetNumberType
 const MethodGetObjectTypeOfType = api.MethodGetObjectTypeOfType
 const MethodGetOuterTypeParametersOfType = api.MethodGetOuterTypeParametersOfType
 const MethodGetParameterType = api.MethodGetParameterType
+const MethodGetParametersOfSignature = api.MethodGetParametersOfSignature
 const MethodGetParentOfSymbol = api.MethodGetParentOfSymbol
 const MethodGetPropertiesOfType = api.MethodGetPropertiesOfType
 const MethodGetReferencedSymbolsForNode = api.MethodGetReferencedSymbolsForNode
@@ -139,7 +137,9 @@ const MethodGetSymbolOfType = api.MethodGetSymbolOfType
 const MethodGetSymbolsAtLocations = api.MethodGetSymbolsAtLocations
 const MethodGetSymbolsAtPositions = api.MethodGetSymbolsAtPositions
 const MethodGetSyntacticDiagnostics = api.MethodGetSyntacticDiagnostics
+const MethodGetTargetOfSignature = api.MethodGetTargetOfSignature
 const MethodGetTargetOfType = api.MethodGetTargetOfType
+const MethodGetThisParameterOfSignature = api.MethodGetThisParameterOfSignature
 const MethodGetTypeArguments = api.MethodGetTypeArguments
 const MethodGetTypeAtLocation = api.MethodGetTypeAtLocation
 const MethodGetTypeAtLocations = api.MethodGetTypeAtLocations
@@ -147,6 +147,7 @@ const MethodGetTypeAtPosition = api.MethodGetTypeAtPosition
 const MethodGetTypeFromTypeNode = api.MethodGetTypeFromTypeNode
 const MethodGetTypeOfSymbol = api.MethodGetTypeOfSymbol
 const MethodGetTypeOfSymbolAtLocation = api.MethodGetTypeOfSymbolAtLocation
+const MethodGetTypeParametersOfSignature = api.MethodGetTypeParametersOfSignature
 const MethodGetTypeParametersOfType = api.MethodGetTypeParametersOfType
 const MethodGetTypePredicateOfSignature = api.MethodGetTypePredicateOfSignature
 const MethodGetTypesAtPositions = api.MethodGetTypesAtPositions
@@ -193,8 +194,6 @@ func NewSession(projectSession *project.Session, options *api.SessionOptions) *a
 func NewStdioServer(options *api.StdioServerOptions) *api.StdioServer
 //go:linkname NewStdioTransport github.com/microsoft/typescript-go/internal/api.NewStdioTransport
 func NewStdioTransport(stdin io.ReadCloser, stdout io.WriteCloser) *api.StdioTransport
-//go:linkname NewSymbolResponse github.com/microsoft/typescript-go/internal/api.NewSymbolResponse
-func NewSymbolResponse(symbol *ast.Symbol) *api.SymbolResponse
 //go:linkname NewSyncConn github.com/microsoft/typescript-go/internal/api.NewSyncConn
 func NewSyncConn(rwc io.ReadWriteCloser, protocol api.Protocol, handler api.Handler) *api.SyncConn
 type NodeHandle = api.NodeHandle
@@ -218,7 +217,7 @@ type ResolveNameParams = api.ResolveNameParams
 type Session = api.Session
 type SessionOptions = api.SessionOptions
 //go:linkname SignatureHandle github.com/microsoft/typescript-go/internal/api.SignatureHandle
-func SignatureHandle(id uint64) api.SignatureID
+func SignatureHandle(sig *checker.Signature) api.SignatureID
 type SignatureID = api.SignatureID
 type SignatureResponse = api.SignatureResponse
 type SignatureToSignatureDeclarationParams = api.SignatureToSignatureDeclarationParams

--- a/shim/ast/shim.go
+++ b/shim/ast/shim.go
@@ -2410,6 +2410,7 @@ func SkipPartiallyEmittedExpressions(node *ast.Expression) *ast.Expression
 //go:linkname SkipTypeParentheses github.com/microsoft/typescript-go/internal/ast.SkipTypeParentheses
 func SkipTypeParentheses(node *ast.Node) *ast.Node
 type SourceFile = ast.SourceFile
+type SourceFileDataKey[T any] = ast.SourceFileDataKey[T]
 type SourceFileLike = ast.SourceFileLike
 type SourceFileMetaData = ast.SourceFileMetaData
 type SourceFileNode = ast.SourceFileNode

--- a/shim/checker/shim.go
+++ b/shim/checker/shim.go
@@ -118,6 +118,7 @@ type extra_Checker struct {
   compareSymbolChains func([]*ast.Symbol, []*ast.Symbol) int
   TypeCount uint32
   SymbolCount uint32
+  SignatureCount uint32
   TotalInstantiationCount uint32
   EffectLinks any
   instantiationCount uint32
@@ -181,6 +182,7 @@ type extra_Checker struct {
   moduleSymbols map[*ast.Node]*ast.Symbol
   globalThisSymbol *ast.Symbol
   symbolTableAliasCache map[uint64][]*ast.Symbol
+  classExpressionNameTables map[ast.NodeId]ast.SymbolTable
   resolveName func(location *ast.Node, name string, meaning ast.SymbolFlags, nameNotFoundMessage *diagnostics.Message, isUse bool, excludeGlobals bool) *ast.Symbol
   resolveNameForSymbolSuggestion func(location *ast.Node, name string, meaning ast.SymbolFlags, nameNotFoundMessage *diagnostics.Message, isUse bool, excludeGlobals bool) *ast.Symbol
   tupleTypes map[checker.CacheHashKey]*checker.Type
@@ -858,6 +860,7 @@ const SignatureFlagsIsSignatureCandidateForOverloadFailure = checker.SignatureFl
 const SignatureFlagsIsUntypedSignatureInJSFile = checker.SignatureFlagsIsUntypedSignatureInJSFile
 const SignatureFlagsNone = checker.SignatureFlagsNone
 const SignatureFlagsPropagatingFlags = checker.SignatureFlagsPropagatingFlags
+type SignatureId = checker.SignatureId
 var SignatureKeyBase = checker.SignatureKeyBase
 var SignatureKeyCanonical = checker.SignatureKeyCanonical
 var SignatureKeyErased = checker.SignatureKeyErased


### PR DESCRIPTION
## Summary
- update the TypeScript Go submodule to microsoft/typescript-go@2fb5d4ce13935aef1f3c2896fad76d0ab4d43604
- refresh patches affected by upstream context changes
- regenerate shims from the updated TypeScript Go APIs
- add a patch changeset for @effect/tsgo

## Validation
- pnpm setup-repo
- pnpm lint
- pnpm check
- pnpm test