### PR TITLE
chore: track native-preview gitHead in TypeScript-Go updates

### DIFF
--- a/.changeset/native-preview-githead.md
+++ b/.changeset/native-preview-githead.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix the automated TypeScript-Go update workflow to pin the submodule to the commit shipped by `@typescript/native-preview@latest`.

--- a/.github/workflows/update-typescript-go.yml
+++ b/.github/workflows/update-typescript-go.yml
@@ -68,8 +68,22 @@ jobs:
         id: before
         run: echo "sha=$(git -C typescript-go rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve native preview metadata
+        id: native_preview
+        run: |
+          metadata="$(npm view @typescript/native-preview@latest version gitHead --json)"
+          version="$(node -e 'const m = JSON.parse(process.argv[1]); if (!m.version) process.exit(1); process.stdout.write(m.version)' "$metadata")"
+          git_head="$(node -e 'const m = JSON.parse(process.argv[1]); if (!/^[0-9a-f]{40}$/.test(m.gitHead || "")) process.exit(1); process.stdout.write(m.gitHead)' "$metadata")"
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "git_head=${git_head}" >> "$GITHUB_OUTPUT"
+
       - name: Update TypeScript-Go submodule
-        run: git submodule update --init --remote typescript-go
+        run: |
+          git -C typescript-go fetch --depth 1 origin "${{ steps.native_preview.outputs.git_head }}"
+          git -C typescript-go checkout --detach "${{ steps.native_preview.outputs.git_head }}"
+          git -C typescript-go submodule sync --recursive
+          git -C typescript-go submodule update --init --recursive --force
 
       - name: Regenerate shims and generated files
         run: pnpm setup-repo --ci
@@ -124,9 +138,11 @@ jobs:
           "@effect/tsgo": patch
           ---
 
-          Update \
+          Update to \
+          [\`@typescript/native-preview@${{ steps.native_preview.outputs.version }}\`](https://www.npmjs.com/package/@typescript/native-preview/v/${{ steps.native_preview.outputs.version }}), \
+          which ships \
           [\`typescript-go\`](https://github.com/microsoft/typescript-go/commit/${{ steps.after.outputs.sha }}) \
-          to commit \`${{ steps.after.outputs.sha }}\`.
+          commit \`${{ steps.after.outputs.sha }}\`.
           EOF
 
       - name: Create Pull Request
@@ -144,6 +160,7 @@ jobs:
 
             ## TypeScript-Go
 
+            - Native preview version: `@typescript/native-preview@${{ steps.native_preview.outputs.version }}`
             - Previous commit: `${{ steps.before.outputs.sha }}`
             - Updated commit: `${{ steps.after.outputs.sha }}`
             - Compare: ${{ steps.changelog.outputs.compare_url }}


### PR DESCRIPTION
## Summary
- Resolve @typescript/native-preview@latest metadata in the update workflow
- Checkout the typescript-go submodule to the package gitHead instead of the remote branch tip
- Include the native-preview version in generated update PRs and changesets

## Validation
- git diff --check -- .github/workflows/update-typescript-go.yml
- Verified the npm metadata parsing snippet locally

Full workflow linting was not run locally because actionlint is not installed.