### PR TITLE
chore: loosen version suffix patch context

### DIFF
--- a/.changeset/version-suffix-patch-context.md
+++ b/.changeset/version-suffix-patch-context.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Make the TypeScript-Go version suffix patch apply across upstream TypeScript version literal changes.

--- a/_patches/021-core-version-suffix.patch
+++ b/_patches/021-core-version-suffix.patch
@@ -2,9 +2,7 @@ diff --git a/internal/core/version.go b/internal/core/version.go
 index 9e04cb52c..639d3ee9a 100644
 --- a/internal/core/version.go
 +++ b/internal/core/version.go
-@@ -7,8 +7,14 @@ import (
- // This is a var so it can be overridden by ldflags.
- var version = "7.0.0-dev"
+@@ -10,6 +10,12 @@
  
 +var versionSuffix string
 +


### PR DESCRIPTION
## Summary
- Loosen `_patches/021-core-version-suffix.patch` so it no longer anchors on the literal `7.0.0-dev` upstream version string
- Add a changeset for the patch maintenance change

## Validation
- `pnpm setup-repo`
- `git diff --check -- _patches/021-core-version-suffix.patch .changeset/version-suffix-patch-context.md`
- `pnpm exec prettier --check .changeset/version-suffix-patch-context.md`
- `git -C typescript-go apply --check --reverse ../_patches/021-core-version-suffix.patch`