### PR TITLE
chore: build stable tsc release binaries

### DIFF
--- a/.changeset/bright-geese-push.md
+++ b/.changeset/bright-geese-push.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Publish platform packages with both the `tsgo` binary built from `main` and the `tsc` binary built from `generated/stable`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,31 +21,29 @@ jobs:
       github.event.pull_request.merged == true &&
       github.event.pull_request.head.ref == 'changeset-release/main' &&
       github.repository_owner == 'Effect-TS'
-    name: Build ${{ matrix.npm_target }}
+    name: Build ${{ matrix.binary.name }} ${{ matrix.npm_target }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:
-        include:
-          - npm_target: darwin-arm64
-            artifact_name: tsgo-darwin-arm64
-          - npm_target: darwin-x64
-            artifact_name: tsgo-darwin-x64
-          - npm_target: win32-x64
-            artifact_name: tsgo-win32-x64
-          - npm_target: win32-arm64
-            artifact_name: tsgo-win32-arm64
-          - npm_target: linux-x64
-            artifact_name: tsgo-linux-x64
-          - npm_target: linux-arm64
-            artifact_name: tsgo-linux-arm64
-          - npm_target: linux-arm
-            artifact_name: tsgo-linux-arm
+        npm_target:
+          - darwin-arm64
+          - darwin-x64
+          - win32-x64
+          - win32-arm64
+          - linux-x64
+          - linux-arm64
+          - linux-arm
+        binary:
+          - name: tsgo
+            ref: main
+          - name: tsc
+            ref: generated/stable
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ matrix.binary.ref }}
           submodules: recursive
 
       - name: Setup Go
@@ -58,9 +56,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/go-build
-          key: go-build-release-${{ matrix.npm_target }}-${{ hashFiles('**/go.sum') }}
+          key: go-build-release-${{ matrix.binary.name }}-${{ matrix.npm_target }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            go-build-release-${{ matrix.npm_target }}-
+            go-build-release-${{ matrix.binary.name }}-${{ matrix.npm_target }}-
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -78,14 +76,14 @@ jobs:
       - name: Setup repo
         run: pnpm setup-repo --ci
 
-      - name: Build ${{ matrix.npm_target }}
-        run: pnpm release:prepare --target ${{ matrix.npm_target }} --skip-cli
+      - name: Build ${{ matrix.binary.name }} ${{ matrix.npm_target }}
+        run: pnpm release:prepare --target ${{ matrix.npm_target }} --binary-name ${{ matrix.binary.name }} --skip-cli
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact_name }}
-          path: _packages/${{ matrix.artifact_name }}
+          name: ${{ matrix.binary.name }}-${{ matrix.npm_target }}
+          path: _packages/tsgo-${{ matrix.npm_target }}/lib/${{ matrix.binary.name }}${{ startsWith(matrix.npm_target, 'win32-') && '.exe' || '' }}
 
   publish:
     if: >-
@@ -120,47 +118,26 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Download darwin-arm64
+      - name: Download platform binaries
         uses: actions/download-artifact@v4
         with:
-          name: tsgo-darwin-arm64
-          path: _packages/tsgo-darwin-arm64
+          path: _release-artifacts
 
-      - name: Download darwin-x64
-        uses: actions/download-artifact@v4
-        with:
-          name: tsgo-darwin-x64
-          path: _packages/tsgo-darwin-x64
+      - name: Copy binaries into platform packages
+        run: |
+          for artifact_dir in _release-artifacts/*-*; do
+            artifact_name="${artifact_dir##*/}"
+            binary_name="${artifact_name%%-*}"
+            npm_target="${artifact_name#*-}"
+            package_dir="_packages/tsgo-${npm_target}/lib"
 
-      - name: Download win32-x64
-        uses: actions/download-artifact@v4
-        with:
-          name: tsgo-win32-x64
-          path: _packages/tsgo-win32-x64
-
-      - name: Download win32-arm64
-        uses: actions/download-artifact@v4
-        with:
-          name: tsgo-win32-arm64
-          path: _packages/tsgo-win32-arm64
-
-      - name: Download linux-x64
-        uses: actions/download-artifact@v4
-        with:
-          name: tsgo-linux-x64
-          path: _packages/tsgo-linux-x64
-
-      - name: Download linux-arm64
-        uses: actions/download-artifact@v4
-        with:
-          name: tsgo-linux-arm64
-          path: _packages/tsgo-linux-arm64
-
-      - name: Download linux-arm
-        uses: actions/download-artifact@v4
-        with:
-          name: tsgo-linux-arm
-          path: _packages/tsgo-linux-arm
+            mkdir -p "${package_dir}"
+            if [ -f "${artifact_dir}/${binary_name}.exe" ]; then
+              cp "${artifact_dir}/${binary_name}.exe" "${package_dir}/${binary_name}.exe"
+            else
+              cp "${artifact_dir}/${binary_name}" "${package_dir}/${binary_name}"
+            fi
+          done
 
       - name: Build CLI bundle
         run: pnpm build:cli

--- a/_packages/tsgo-darwin-arm64/package.json
+++ b/_packages/tsgo-darwin-arm64/package.json
@@ -17,6 +17,7 @@
   "preferUnplugged": true,
   "files": [
     "lib/tsgo",
+    "lib/tsc",
     "README.md"
   ],
   "os": [

--- a/_packages/tsgo-darwin-x64/package.json
+++ b/_packages/tsgo-darwin-x64/package.json
@@ -17,6 +17,7 @@
   "preferUnplugged": true,
   "files": [
     "lib/tsgo",
+    "lib/tsc",
     "README.md"
   ],
   "os": [

--- a/_packages/tsgo-linux-arm/package.json
+++ b/_packages/tsgo-linux-arm/package.json
@@ -17,6 +17,7 @@
   "preferUnplugged": true,
   "files": [
     "lib/tsgo",
+    "lib/tsc",
     "README.md"
   ],
   "os": [

--- a/_packages/tsgo-linux-arm64/package.json
+++ b/_packages/tsgo-linux-arm64/package.json
@@ -17,6 +17,7 @@
   "preferUnplugged": true,
   "files": [
     "lib/tsgo",
+    "lib/tsc",
     "README.md"
   ],
   "os": [

--- a/_packages/tsgo-linux-x64/package.json
+++ b/_packages/tsgo-linux-x64/package.json
@@ -17,6 +17,7 @@
   "preferUnplugged": true,
   "files": [
     "lib/tsgo",
+    "lib/tsc",
     "README.md"
   ],
   "os": [

--- a/_packages/tsgo-win32-arm64/package.json
+++ b/_packages/tsgo-win32-arm64/package.json
@@ -17,6 +17,7 @@
   "preferUnplugged": true,
   "files": [
     "lib/tsgo.exe",
+    "lib/tsc.exe",
     "README.md"
   ],
   "os": [

--- a/_packages/tsgo-win32-x64/package.json
+++ b/_packages/tsgo-win32-x64/package.json
@@ -17,6 +17,7 @@
   "preferUnplugged": true,
   "files": [
     "lib/tsgo.exe",
+    "lib/tsc.exe",
     "README.md"
   ],
   "os": [

--- a/_tools/release-prepare.sh
+++ b/_tools/release-prepare.sh
@@ -3,39 +3,41 @@ set -euo pipefail
 
 # release-prepare.sh — Single entrypoint for preparing publish-ready workspace packages.
 #
-# Usage: release-prepare.sh [--target <platform-arch> ...] [--skip-cli]
-#   --target    Select specific platform targets (repeatable). Omit to build all.
-#   --skip-cli  Skip the CLI bundle build and its validation. Used by matrix build jobs.
+# Usage: release-prepare.sh [--target <platform-arch> ...] [--binary-name <name>] [--skip-cli]
+#   --target       Select specific platform targets (repeatable). Omit to build all.
+#   --binary-name  Set the output executable base name. Defaults to tsgo.
+#   --skip-cli     Skip the CLI bundle build and its validation. Used by matrix build jobs.
 #
 # Steps:
-#   1. Cross-compile tsgo binaries for selected platforms directly into _packages
+#   1. Cross-compile binaries for selected platforms directly into _packages
 #   2. Build CLI bundle
 #   Followed by artifact validation.
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PACKAGES_DIR="${REPO_ROOT}/_packages"
 
-# Unified target matrix: goos goarch goarm npm_platform npm_arch binary_name
+# Unified target matrix: goos goarch goarm npm_platform npm_arch
 # Build order: Darwin first, then Windows, then Linux
 ALL_TARGETS=(
-  "darwin  arm64 - darwin arm64 tsgo"
-  "darwin  amd64 - darwin x64   tsgo"
-  "windows amd64 - win32  x64   tsgo.exe"
-  "windows arm64 - win32  arm64 tsgo.exe"
-  "linux   amd64 - linux  x64   tsgo"
-  "linux   arm64 - linux  arm64 tsgo"
-  "linux   arm   6 linux  arm   tsgo"
+  "darwin  arm64 - darwin arm64"
+  "darwin  amd64 - darwin x64"
+  "windows amd64 - win32  x64"
+  "windows arm64 - win32  arm64"
+  "linux   amd64 - linux  x64"
+  "linux   arm64 - linux  arm64"
+  "linux   arm   6 linux  arm"
 )
 
 # Build list of valid target identifiers from the matrix
 valid_ids=()
 for target in "${ALL_TARGETS[@]}"; do
-  read -r _goos _goarch _goarm npm_platform npm_arch _binary <<< "$target"
+  read -r _goos _goarch _goarm npm_platform npm_arch <<< "$target"
   valid_ids+=("${npm_platform}-${npm_arch}")
 done
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 selected_ids=()
+binary_name="tsgo"
 skip_cli=false
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -48,18 +50,31 @@ while [ $# -gt 0 ]; do
       selected_ids+=("$2")
       shift 2
       ;;
+    --binary-name)
+      if [ $# -lt 2 ]; then
+        echo "ERROR: --binary-name requires a value (e.g., --binary-name tsgo)."
+        exit 1
+      fi
+      binary_name="$2"
+      shift 2
+      ;;
     --skip-cli)
       skip_cli=true
       shift 1
       ;;
     *)
       echo "ERROR: Unknown flag '$1'."
-      echo "Usage: release-prepare.sh [--target <platform-arch> ...] [--skip-cli]"
+      echo "Usage: release-prepare.sh [--target <platform-arch> ...] [--binary-name <name>] [--skip-cli]"
       echo "Valid targets: ${valid_ids[*]}"
       exit 1
       ;;
   esac
 done
+
+if [[ ! "${binary_name}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "ERROR: --binary-name must contain only letters, numbers, dots, underscores, and dashes."
+  exit 1
+fi
 
 # ── Target validation & filtering ─────────────────────────────────────────────
 if [ ${#selected_ids[@]} -gt 0 ]; then
@@ -81,7 +96,7 @@ if [ ${#selected_ids[@]} -gt 0 ]; then
   # Filter ALL_TARGETS to only selected entries
   TARGETS=()
   for target in "${ALL_TARGETS[@]}"; do
-    read -r _goos _goarch _goarm npm_platform npm_arch _binary <<< "$target"
+    read -r _goos _goarch _goarm npm_platform npm_arch <<< "$target"
     tid="${npm_platform}-${npm_arch}"
     for id in "${selected_ids[@]}"; do
       if [ "$tid" = "$id" ]; then
@@ -103,10 +118,15 @@ fi
 echo "==> Step 1/${total_steps}: Cross-compiling ${#TARGETS[@]} target(s) sequentially"
 
 for target in "${TARGETS[@]}"; do
-  read -r goos goarch goarm npm_platform npm_arch binary_name <<< "$target"
+  read -r goos goarch goarm npm_platform npm_arch <<< "$target"
+
+  output_name="${binary_name}"
+  if [ "$goos" = "windows" ]; then
+    output_name="${output_name}.exe"
+  fi
 
   dest_dir="${PACKAGES_DIR}/tsgo-${npm_platform}-${npm_arch}/lib"
-  dest="${dest_dir}/${binary_name}"
+  dest="${dest_dir}/${output_name}"
 
   echo "  Building ${goos}/${goarch} -> ${dest}"
   mkdir -p "${dest_dir}"
@@ -144,8 +164,14 @@ fi
 
 # Check platform binaries
 for target in "${TARGETS[@]}"; do
-  read -r _goos _goarch _goarm npm_platform npm_arch binary_name <<< "$target"
-  bin_path="${PACKAGES_DIR}/tsgo-${npm_platform}-${npm_arch}/lib/${binary_name}"
+  read -r goos _goarch _goarm npm_platform npm_arch <<< "$target"
+
+  output_name="${binary_name}"
+  if [ "$goos" = "windows" ]; then
+    output_name="${output_name}.exe"
+  fi
+
+  bin_path="${PACKAGES_DIR}/tsgo-${npm_platform}-${npm_arch}/lib/${output_name}"
   if [ ! -s "${bin_path}" ]; then
     errors+=("Missing or empty binary: ${bin_path}")
   fi


### PR DESCRIPTION
## Summary
- build release binaries from both main and generated/stable
- publish both tsgo and tsc executables in each platform package
- add a binary-name option to the release preparation script

## Validation
- bash -n _tools/release-prepare.sh
- git diff --check
- parsed changed package manifests with Node
- pnpm release:prepare --target linux-x64 --binary-name tsc --skip-cli

No issue reference.