### PR TITLE
fix generated stable branch push ref

### DIFF
--- a/.github/workflows/generate-stable-branch.yml
+++ b/.github/workflows/generate-stable-branch.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Push generated stable PR branch
         if: steps.changes.outputs.has_changes == 'true'
-        run: git push --force origin "${{ steps.changes.outputs.head_sha }}:chore/generate-stable-branch"
+        run: git push --force origin "${{ steps.changes.outputs.head_sha }}:refs/heads/chore/generate-stable-branch"
 
       - name: Create or update generated stable PR
         id: pr


### PR DESCRIPTION
## Summary
- fully qualify the generated stable PR branch ref when pushing a commit-tree SHA
- fixes Git rejecting the push because the destination was not a full refname

## Validation
- git diff --check
- git check-ref-format refs/heads/chore/generate-stable-branch