### PR TITLE
Add layer magic extraction API

### DIFF
--- a/.changeset/lazy-layers-extract.md
+++ b/.changeset/lazy-layers-extract.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": minor
+---
+
+Add an ETS API helper for extracting layer magic from caller-provided layer nodes, and allow layer graph extraction to start from multiple nodes without exploding expressions.

--- a/etsapi/layer_magic.go
+++ b/etsapi/layer_magic.go
@@ -1,0 +1,58 @@
+package etsapi
+
+import (
+	"github.com/effect-ts/tsgo/internal/layergraph"
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+)
+
+// LayerMagicNode represents a layer expression annotated with the combinator
+// choice needed to compose it.
+type LayerMagicNode struct {
+	Merges   bool
+	Provides bool
+	Node     *ast.Node
+}
+
+// LayerMagicResult holds the layer magic extraction result.
+type LayerMagicResult struct {
+	Nodes              []LayerMagicNode
+	MissingOutputTypes []*checker.Type
+}
+
+// ExtractLayerMagic extracts layer magic from nodes that already represent layers.
+// It does not decompose pipe/call/array expressions; callers are responsible for
+// passing the layer nodes they want included and the target output types.
+func (tp *TypeParser) ExtractLayerMagic(sourceFile *ast.SourceFile, nodes []*ast.Node, targetOutputTypes []*checker.Type) *LayerMagicResult {
+	if tp == nil || tp.inner == nil || tp.checker == nil || sourceFile == nil || len(nodes) == 0 {
+		return nil
+	}
+
+	fullGraph := layergraph.ExtractLayerGraph(tp.inner, tp.checker, nodes, sourceFile, layergraph.ExtractLayerGraphOptions{
+		SkipExplode: true,
+	})
+	outlineGraph := layergraph.ExtractOutlineGraph(tp.checker, fullGraph)
+	if outlineGraph == nil {
+		return nil
+	}
+
+	return layerMagicResultFromInternal(layergraph.ConvertOutlineGraphToLayerMagic(tp.inner, outlineGraph, targetOutputTypes))
+}
+
+func layerMagicResultFromInternal(result *layergraph.LayerMagicResult) *LayerMagicResult {
+	if result == nil {
+		return nil
+	}
+	nodes := make([]LayerMagicNode, 0, len(result.Nodes))
+	for _, node := range result.Nodes {
+		nodes = append(nodes, LayerMagicNode{
+			Merges:   node.Merges,
+			Provides: node.Provides,
+			Node:     node.Node,
+		})
+	}
+	return &LayerMagicResult{
+		Nodes:              nodes,
+		MissingOutputTypes: result.MissingOutputTypes,
+	}
+}

--- a/etsapi/layer_magic.go
+++ b/etsapi/layer_magic.go
@@ -9,9 +9,12 @@ import (
 // LayerMagicNode represents a layer expression annotated with the combinator
 // choice needed to compose it.
 type LayerMagicNode struct {
-	Merges   bool
-	Provides bool
-	Node     *ast.Node
+	Merges              bool
+	Provides            bool
+	Node                *ast.Node
+	ProvidedTypes       []*checker.Type
+	ActualProvidedTypes []*checker.Type
+	RequiredTypes       []*checker.Type
 }
 
 // LayerMagicResult holds the layer magic extraction result.
@@ -46,9 +49,12 @@ func layerMagicResultFromInternal(result *layergraph.LayerMagicResult) *LayerMag
 	nodes := make([]LayerMagicNode, 0, len(result.Nodes))
 	for _, node := range result.Nodes {
 		nodes = append(nodes, LayerMagicNode{
-			Merges:   node.Merges,
-			Provides: node.Provides,
-			Node:     node.Node,
+			Merges:              node.Merges,
+			Provides:            node.Provides,
+			Node:                node.Node,
+			ProvidedTypes:       node.ProvidedTypes,
+			ActualProvidedTypes: node.ActualProvidedTypes,
+			RequiredTypes:       node.RequiredTypes,
 		})
 	}
 	return &LayerMagicResult{

--- a/etsapi/type_parser.go
+++ b/etsapi/type_parser.go
@@ -10,7 +10,8 @@ import (
 
 // TypeParser wraps the internal type parser with a narrow public API.
 type TypeParser struct {
-	inner *typeparser.TypeParser
+	inner   *typeparser.TypeParser
+	checker *checker.Checker
 }
 
 // Effect represents parsed Effect<A, E, R> type parameters.
@@ -41,7 +42,7 @@ type SchemaTypes struct {
 
 // NewTypeParser builds a checker-backed TypeParser.
 func NewTypeParser(program checker.Program, checker *checker.Checker) *TypeParser {
-	return &TypeParser{inner: typeparser.NewTypeParser(program, checker)}
+	return &TypeParser{inner: typeparser.NewTypeParser(program, checker), checker: checker}
 }
 
 // GetTypeAtLocation returns the checker type for node using the parser's safety guards.

--- a/etslshooks/init.go
+++ b/etslshooks/init.go
@@ -243,7 +243,7 @@ func formatLayerHover(tp *typeparser.TypeParser, c *checker.Checker, sf *ast.Sou
 		opts := layergraph.ExtractLayerGraphOptions{
 			FollowSymbolsDepth: effectConfig.GetLayerGraphFollowDepth(),
 		}
-		fullGraph := layergraph.ExtractLayerGraph(tp, c, initializer, sf, opts)
+		fullGraph := layergraph.ExtractLayerGraph(tp, c, []*ast.Node{initializer}, sf, opts)
 		info := layergraph.ExtractProvidersAndRequirers(c, fullGraph)
 		quickInfoSummary = layergraph.FormatQuickInfo(c, info, sf)
 		hasGraph = true

--- a/internal/effecttest/baseline.go
+++ b/internal/effecttest/baseline.go
@@ -555,7 +555,7 @@ func generateLayerGraphBaseline(
 				ExplodeOnlyLayerCalls: false,
 			}
 
-			fullGraph := layergraph.ExtractLayerGraph(tp, c, export.initializer, sf, opts)
+			fullGraph := layergraph.ExtractLayerGraph(tp, c, []*ast.Node{export.initializer}, sf, opts)
 			outlineGraph := layergraph.ExtractOutlineGraph(c, fullGraph)
 			providersAndRequirers := layergraph.ExtractProvidersAndRequirers(c, fullGraph)
 

--- a/internal/layergraph/extract.go
+++ b/internal/layergraph/extract.go
@@ -16,14 +16,14 @@ type workItem struct {
 	depth int
 }
 
-// ExtractLayerGraph builds a directed graph of Layer composition from the given AST node.
+// ExtractLayerGraph builds a directed graph of Layer composition from the given AST nodes.
 // It performs a DFS with a two-pass approach using an explicit work stack:
 //   - First pass: push children for processing
 //   - Second pass: link processed children into the graph
 func ExtractLayerGraph(
 	tp *typeparser.TypeParser,
 	c *checker.Checker,
-	node *ast.Node,
+	nodes []*ast.Node,
 	sf *ast.SourceFile,
 	opts ExtractLayerGraphOptions,
 ) *graph.Graph[LayerGraphNodeInfo, LayerGraphEdgeInfo] {
@@ -34,15 +34,20 @@ func ExtractLayerGraph(
 	depthBudget := make(map[*ast.Node]int)
 
 	// Resolve the Layer module import name for ExplodeOnlyLayerCalls checks.
-	layerModuleName := findLayerModuleName(sf)
+	layerModuleName := ""
+	if !opts.SkipExplode {
+		layerModuleName = findLayerModuleName(sf)
+	}
 
-	// Initialize the work stack with the root node.
-	stack := []workItem{{node: node, depth: opts.FollowSymbolsDepth}}
-	depthBudget[node] = opts.FollowSymbolsDepth
+	// Initialize the work stack with the root nodes.
+	stack := []workItem{}
 
 	appendNodeToVisit := func(n *ast.Node, depth int) {
 		depthBudget[n] = depth
 		stack = append(stack, workItem{node: n, depth: depth})
+	}
+	for _, node := range nodes {
+		appendNodeToVisit(node, opts.FollowSymbolsDepth)
 	}
 
 	addNode := func(n *ast.Node, info LayerGraphNodeInfo) graph.NodeIndex {
@@ -59,50 +64,52 @@ func ExtractLayerGraph(
 		currentDepth := depthBudget[current]
 
 		// Case 1: Pipe detection
-		if pipeResult := tp.ParsePipeCall(current); pipeResult != nil {
-			if !visitedNodes[current] {
-				// First pass: push self back, then subject and args.
-				appendNodeToVisit(current, currentDepth)
-				appendNodeToVisit(pipeResult.Subject, currentDepth)
-				for _, arg := range pipeResult.Args {
-					appendNodeToVisit(arg, currentDepth)
-					nodeInPipeContext[arg] = true
-				}
-				visitedNodes[current] = true
-			} else {
-				// Second pass: collect child graph indices.
-				allChildren := make([]*ast.Node, 0, 1+len(pipeResult.Args))
-				allChildren = append(allChildren, pipeResult.Subject)
-				allChildren = append(allChildren, pipeResult.Args...)
-
-				childIndices := collectChildIndices(allChildren, nodeToGraphIndex, g)
-
-				if len(childIndices) == len(allChildren) {
-					// All members are graph nodes — link them sequentially.
-					var lastIdx graph.NodeIndex
-					for i, childIdx := range childIndices {
-						if i > 0 {
-							g.AddEdge(childIdx, lastIdx, LayerGraphEdgeInfo{Relationship: EdgeRelationshipPipe})
-						}
-						lastIdx = childIdx
+		if !opts.SkipExplode {
+			if pipeResult := tp.ParsePipeCall(current); pipeResult != nil {
+				if !visitedNodes[current] {
+					// First pass: push self back, then subject and args.
+					appendNodeToVisit(current, currentDepth)
+					appendNodeToVisit(pipeResult.Subject, currentDepth)
+					for _, arg := range pipeResult.Args {
+						appendNodeToVisit(arg, currentDepth)
+						nodeInPipeContext[arg] = true
 					}
-					// Add a node for the pipe call itself, linking to the last child.
-					pipeIdx := addNode(current, extractNodeInfo(tp, c, current, sf, nodeInPipeContext[current]))
-					g.AddEdge(pipeIdx, lastIdx, LayerGraphEdgeInfo{Relationship: EdgeRelationshipPipe})
+					visitedNodes[current] = true
 				} else {
-					// Not all children are graph nodes — remove partial children and try as leaf.
-					removePartialChildren(allChildren, nodeToGraphIndex, g)
-					info := extractNodeInfo(tp, c, current, sf, nodeInPipeContext[current])
-					if info.LayerType != nil {
-						addNode(current, info)
+					// Second pass: collect child graph indices.
+					allChildren := make([]*ast.Node, 0, 1+len(pipeResult.Args))
+					allChildren = append(allChildren, pipeResult.Subject)
+					allChildren = append(allChildren, pipeResult.Args...)
+
+					childIndices := collectChildIndices(allChildren, nodeToGraphIndex, g)
+
+					if len(childIndices) == len(allChildren) {
+						// All members are graph nodes — link them sequentially.
+						var lastIdx graph.NodeIndex
+						for i, childIdx := range childIndices {
+							if i > 0 {
+								g.AddEdge(childIdx, lastIdx, LayerGraphEdgeInfo{Relationship: EdgeRelationshipPipe})
+							}
+							lastIdx = childIdx
+						}
+						// Add a node for the pipe call itself, linking to the last child.
+						pipeIdx := addNode(current, extractNodeInfo(tp, c, current, sf, nodeInPipeContext[current]))
+						g.AddEdge(pipeIdx, lastIdx, LayerGraphEdgeInfo{Relationship: EdgeRelationshipPipe})
+					} else {
+						// Not all children are graph nodes — remove partial children and try as leaf.
+						removePartialChildren(allChildren, nodeToGraphIndex, g)
+						info := extractNodeInfo(tp, c, current, sf, nodeInPipeContext[current])
+						if info.LayerType != nil {
+							addNode(current, info)
+						}
 					}
 				}
+				continue
 			}
-			continue
 		}
 
 		// Case 2: Call expression
-		if current.Kind == ast.KindCallExpression {
+		if !opts.SkipExplode && current.Kind == ast.KindCallExpression {
 			callExpr := current.AsCallExpression()
 			shouldExplode := !opts.ExplodeOnlyLayerCalls
 			if opts.ExplodeOnlyLayerCalls {
@@ -149,7 +156,7 @@ func ExtractLayerGraph(
 		}
 
 		// Case 3: Array literal (when ArrayLiteralAsMerge is enabled)
-		if opts.ArrayLiteralAsMerge && current.Kind == ast.KindArrayLiteralExpression {
+		if !opts.SkipExplode && opts.ArrayLiteralAsMerge && current.Kind == ast.KindArrayLiteralExpression {
 			arrayExpr := current.AsArrayLiteralExpression()
 			var elements []*ast.Node
 			if arrayExpr.Elements != nil {

--- a/internal/layergraph/magic.go
+++ b/internal/layergraph/magic.go
@@ -71,9 +71,12 @@ func ConvertOutlineGraphToLayerMagic(
 		}
 
 		result = append(result, LayerMagicNode{
-			Merges:   shouldMerge,
-			Provides: true,
-			Node:     nodeInfo.Node,
+			Merges:              shouldMerge,
+			Provides:            true,
+			Node:                nodeInfo.Node,
+			ProvidedTypes:       nodeInfo.Provides,
+			ActualProvidedTypes: nodeInfo.ActualProvides,
+			RequiredTypes:       nodeInfo.Requires,
 		})
 	}
 

--- a/internal/layergraph/types.go
+++ b/internal/layergraph/types.go
@@ -109,4 +109,5 @@ type ExtractLayerGraphOptions struct {
 	ArrayLiteralAsMerge   bool // Treat array literals [l1, l2] as implicit Layer.mergeAll (default: false)
 	ExplodeOnlyLayerCalls bool // Only explode calls to Layer module APIs (default: false)
 	FollowSymbolsDepth    int  // How many levels deep to follow identifier references (default: 0)
+	SkipExplode           bool // Do not decompose pipe/call/array expressions (default: false)
 }

--- a/internal/layergraph/types.go
+++ b/internal/layergraph/types.go
@@ -77,9 +77,12 @@ type LayerOutlineGraphNodeInfo struct {
 // LayerMagicNode represents a single node in the layer magic result,
 // annotated with flags that determine which Layer.* combinator to use.
 type LayerMagicNode struct {
-	Merges   bool      // Whether this node should be merged (provides a target output type)
-	Provides bool      // Whether this node provides services
-	Node     *ast.Node // The layer expression AST node
+	Merges              bool            // Whether this node should be merged (provides a target output type)
+	Provides            bool            // Whether this node provides services
+	Node                *ast.Node       // The layer expression AST node
+	ProvidedTypes       []*checker.Type // Service types provided
+	ActualProvidedTypes []*checker.Type // Actual (non-pass-through) provides
+	RequiredTypes       []*checker.Type // Service types required
 }
 
 // LayerMagicResult holds the output of ConvertOutlineGraphToLayerMagic.

--- a/internal/refactors/layer_magic.go
+++ b/internal/refactors/layer_magic.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/effect-ts/tsgo/internal/layergraph"
 	"github.com/effect-ts/tsgo/internal/refactor"
+	"github.com/effect-ts/tsgo/internal/rewriter"
 	"github.com/effect-ts/tsgo/internal/typeparser"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/astnav"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/ls"
-	"github.com/effect-ts/tsgo/internal/rewriter"
 )
 
 var LayerMagic = refactor.Refactor{
@@ -113,7 +113,7 @@ func tryBuildRefactor(ctx *refactor.Context, tp *typeparser.TypeParser, c *check
 	castedStructure := innerAs.Expression
 
 	// Extract layer graph from the casted structure
-	layerGraph := layergraph.ExtractLayerGraph(ctx.TypeParser, c, castedStructure, ctx.SourceFile, layergraph.ExtractLayerGraphOptions{
+	layerGraph := layergraph.ExtractLayerGraph(ctx.TypeParser, c, []*ast.Node{castedStructure}, ctx.SourceFile, layergraph.ExtractLayerGraphOptions{
 		ArrayLiteralAsMerge:   true,
 		ExplodeOnlyLayerCalls: true,
 		FollowSymbolsDepth:    0,
@@ -234,7 +234,7 @@ func tryPrepareRefactor(ctx *refactor.Context, tp *typeparser.TypeParser, c *che
 	}
 
 	// Extract layer graph
-	layerGraph := layergraph.ExtractLayerGraph(ctx.TypeParser, c, atLocation, ctx.SourceFile, layergraph.ExtractLayerGraphOptions{
+	layerGraph := layergraph.ExtractLayerGraph(ctx.TypeParser, c, []*ast.Node{atLocation}, ctx.SourceFile, layergraph.ExtractLayerGraphOptions{
 		ArrayLiteralAsMerge:   true,
 		ExplodeOnlyLayerCalls: true,
 		FollowSymbolsDepth:    0,

--- a/internal/rules/missing_effect_context.go
+++ b/internal/rules/missing_effect_context.go
@@ -163,7 +163,7 @@ func findRelatedLayerProviderDiagnostics(
 		return nil
 	}
 	rootLayerProvides := rootLayerProvidesTypes(ctx.TypeParser, c, layerNode)
-	fullGraph := layergraph.ExtractLayerGraph(ctx.TypeParser, c, layerNode, ctx.SourceFile, layergraph.ExtractLayerGraphOptions{
+	fullGraph := layergraph.ExtractLayerGraph(ctx.TypeParser, c, []*ast.Node{layerNode}, ctx.SourceFile, layergraph.ExtractLayerGraphOptions{
 		FollowSymbolsDepth: 2,
 	})
 	outlineGraph := layergraph.ExtractOutlineGraph(c, fullGraph)


### PR DESCRIPTION
## What changed
- Added `etsapi.TypeParser.ExtractLayerMagic(sourceFile, nodes, targetOutputTypes)` for callers that already have layer nodes.
- Added public `etsapi.LayerMagicResult` and `etsapi.LayerMagicNode` wrappers.
- Updated `ExtractLayerGraph` to accept multiple root nodes and added `SkipExplode` to bypass pipe/call/array decomposition.
- Updated existing single-root call sites to pass a one-element node slice.

## Example
```go
result := tp.ExtractLayerMagic(sourceFile, layerNodes, targetOutputTypes)
```

The ETS API helper extracts the layer graph with `SkipExplode: true`, builds the outline graph, and converts it to layer magic using the caller-provided target output types.

## Validation
- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`