### PR TITLE
Fix unnecessaryEffectGen nested yield false positive

### DIFF
--- a/.changeset/quiet-generators-yield.md
+++ b/.changeset/quiet-generators-yield.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Avoid suggesting `unnecessaryEffectGen` when a single-return generator contains nested `yield*` expressions.

--- a/internal/rules/unnecessary_effect_gen.go
+++ b/internal/rules/unnecessary_effect_gen.go
@@ -116,6 +116,9 @@ func analyzeUnnecessaryEffectGenNode(tp *typeparser.TypeParser, _ *checker.Check
 	}
 
 	yieldedExpr := yield.Expression
+	if checker.ForEachYieldExpression(yieldedExpr, isYieldStarExpression) {
+		return nil
+	}
 
 	// Determine if the success type is void-like
 	successIsVoid := false
@@ -136,4 +139,8 @@ func analyzeUnnecessaryEffectGenNode(tp *typeparser.TypeParser, _ *checker.Check
 		SuccessIsVoid:     successIsVoid,
 		EffectModuleNode:  genResult.EffectModule,
 	}
+}
+
+func isYieldStarExpression(expr *ast.Node) bool {
+	return expr.AsYieldExpression().AsteriskToken != nil
 }

--- a/testdata/baselines/reference/effect-v3/unnecessaryEffectGen.errors.txt
+++ b/testdata/baselines/reference/effect-v3/unnecessaryEffectGen.errors.txt
@@ -1,7 +1,7 @@
 === Metadata ===
 Effect version: 3.19.19
 
-/.src/unnecessaryEffectGen.ts(13,37): suggestion TS377017: This Effect.gen contains a single return statement. effect(unnecessaryEffectGen)
+/.src/unnecessaryEffectGen.ts(20,37): suggestion TS377017: This Effect.gen contains a single return statement. effect(unnecessaryEffectGen)
 
 
 ==== /.src/unnecessaryEffectGen.ts (1 errors) ====
@@ -15,6 +15,13 @@ Effect version: 3.19.19
     
     export const shouldNotRaiseForNonEffect = Effect.gen(function*() {
       return 42
+    })
+    
+    const foo = () => Effect.succeed(100)
+    const bar = (x: number) => Effect.succeed(x + x)
+    
+    export const shouldNotRaiseForNestedYield = Effect.gen(function*() {
+      return yield* bar(yield* foo())
     })
     
     export const shouldRaiseForSingle = Effect.gen(function*() {

--- a/testdata/baselines/reference/effect-v3/unnecessaryEffectGen.flows.unnecessaryEffectGen.mermaid
+++ b/testdata/baselines/reference/effect-v3/unnecessaryEffectGen.flows.unnecessaryEffectGen.mermaid
@@ -9,11 +9,24 @@ flowchart TB
   7[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
   8((("type: Effect#lt;number, never, never#gt;<br/>node: Effect.gen#40;function*#40;#41; #123;#92;n  return 42#92;n#125;#41;")))
   9[/"type: 42<br/>node: 42"/]
-  10((("type: Effect#lt;number, never, never#gt;<br/>node: Effect.gen#40;function*#40;#41; #123;#92;n  return yield* Effect.succeed#40;42#41;#92;n#125;#41;")))
-  11[/"type: number<br/>node: yield* Effect.succeed#40;42#41;"/]
-  12[/"type: 42<br/>node: 42"/]
-  13["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  14[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  10[["type: #40;#41; =#gt; Effect#lt;number, never, never#gt;<br/>node: #40;#41; =#gt; Effect.succeed#40;100#41;"]]
+  11[/"type: 100<br/>node: 100"/]
+  12["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  13[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  14[["type: #40;x: number#41; =#gt; Effect#lt;number, never, never#gt;<br/>node: #40;x: number#41; =#gt; Effect.succeed#40;x + x#41;"]]
+  15[/"type: number<br/>node: x + x"/]
+  16["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  17[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  18((("type: Effect#lt;number, never, never#gt;<br/>node: Effect.gen#40;function*#40;#41; #123;#92;n  return yield* bar#40;yield* foo#40;#41;#41;#92;n#125;#41;")))
+  19[/"type: number<br/>node: yield* bar#40;yield* foo#40;#41;#41;"/]
+  20[/"type: number<br/>node: yield* foo#40;#41;"/]
+  21["type: Effect#lt;number, never, never#gt;<br/>callee: bar<br/>args: #91;#93;"]
+  22[/"type: #40;x: number#41; =#gt; Effect#lt;number, never, never#gt;<br/>node: bar"/]
+  23((("type: Effect#lt;number, never, never#gt;<br/>node: Effect.gen#40;function*#40;#41; #123;#92;n  return yield* Effect.succeed#40;42#41;#92;n#125;#41;")))
+  24[/"type: number<br/>node: yield* Effect.succeed#40;42#41;"/]
+  25[/"type: 42<br/>node: 42"/]
+  26["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  27[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
   2 -->|"kind: pipe"| 3
   4 -->|"kind: transformCallee"| 3
   3 -->|"kind: usedBy"| 1
@@ -24,8 +37,19 @@ flowchart TB
   3 -->|"kind: yieldable"| 0
   9 -->|"kind: potentialReturn"| 8
   9 -->|"kind: usedBy"| 8
-  12 -->|"kind: pipe"| 13
-  14 -->|"kind: transformCallee"| 13
-  13 -->|"kind: usedBy"| 11
-  11 -->|"kind: potentialReturn"| 10
-  13 -->|"kind: yieldable"| 10
+  11 -->|"kind: pipe"| 12
+  13 -->|"kind: transformCallee"| 12
+  12 -->|"kind: potentialReturn"| 10
+  15 -->|"kind: pipe"| 16
+  17 -->|"kind: transformCallee"| 16
+  16 -->|"kind: potentialReturn"| 14
+  20 -->|"kind: pipe"| 21
+  22 -->|"kind: transformCallee"| 21
+  21 -->|"kind: usedBy"| 19
+  19 -->|"kind: potentialReturn"| 18
+  21 -->|"kind: yieldable"| 18
+  25 -->|"kind: pipe"| 26
+  27 -->|"kind: transformCallee"| 26
+  26 -->|"kind: usedBy"| 24
+  24 -->|"kind: potentialReturn"| 23
+  26 -->|"kind: yieldable"| 23

--- a/testdata/baselines/reference/effect-v3/unnecessaryEffectGen.pipings.txt
+++ b/testdata/baselines/reference/effect-v3/unnecessaryEffectGen.pipings.txt
@@ -1,4 +1,4 @@
-==== /.src/unnecessaryEffectGen.ts (6 flows) ====
+==== /.src/unnecessaryEffectGen.ts (10 flows) ====
 
 === Piping Flow ===
 Location: 4:29 - 7:3
@@ -57,7 +57,63 @@ Transformations (1):
       outType: Effect<number, never, never>
 
 === Piping Flow ===
-Location: 13:36 - 15:3
+Location: 13:18 - 13:38
+Node: Effect.succeed(100)
+Node Kind: KindCallExpression
+
+Subject: 100
+Subject Type: 100
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 14:27 - 14:49
+Node: Effect.succeed(x + x)
+Node Kind: KindCallExpression
+
+Subject: x + x
+Subject Type: number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 16:44 - 18:3
+Node: Effect.gen(function*() {\n  return yield* bar(yield* foo())\n})
+Node Kind: KindCallExpression
+
+Subject: function*() {\n  return yield* bar(yield* foo())\n}
+Subject Type: () => Generator<YieldWrap<Effect<number, never, never>>, number, any>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.gen
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 17:16 - 17:34
+Node: bar(yield* foo())
+Node Kind: KindCallExpression
+
+Subject: yield* foo()
+Subject Type: number
+
+Transformations (1):
+  [0] kind: call
+      callee: bar
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 20:36 - 22:3
 Node: Effect.gen(function*() {\n  return yield* Effect.succeed(42)\n})
 Node Kind: KindCallExpression
 
@@ -71,7 +127,7 @@ Transformations (1):
       outType: Effect<number, never, never>
 
 === Piping Flow ===
-Location: 14:16 - 14:35
+Location: 21:16 - 21:35
 Node: Effect.succeed(42)
 Node Kind: KindCallExpression
 

--- a/testdata/baselines/reference/effect-v3/unnecessaryEffectGen.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/unnecessaryEffectGen.quickfixes.txt
@@ -1,6 +1,6 @@
 === Quick Fix Inventory ===
 
-[D1] (13:37-15:3) TS377017: This Effect.gen contains a single return statement. effect(unnecessaryEffectGen)
+[D1] (20:37-22:3) TS377017: This Effect.gen contains a single return statement. effect(unnecessaryEffectGen)
   Fix 0: "Disable unnecessaryEffectGen for this line"
   Fix 1: "Disable unnecessaryEffectGen for entire file"
   Fix 2: "Remove the Effect.gen, and keep the body"
@@ -26,6 +26,13 @@ export const shouldNotRant = Effect.gen(function*() {
 
 export const shouldNotRaiseForNonEffect = Effect.gen(function*() {
   return 42
+})
+
+const foo = () => Effect.succeed(100)
+const bar = (x: number) => Effect.succeed(x + x)
+
+export const shouldNotRaiseForNestedYield = Effect.gen(function*() {
+  return yield* bar(yield* foo())
 })
 
 export const shouldRaiseForSingle = Effect.succeed(42)

--- a/testdata/baselines/reference/effect-v4/unnecessaryEffectGen.errors.txt
+++ b/testdata/baselines/reference/effect-v4/unnecessaryEffectGen.errors.txt
@@ -1,7 +1,7 @@
 === Metadata ===
 Effect version: 4.0.0
 
-/.src/unnecessaryEffectGen.ts(12,37): suggestion TS377017: This Effect.gen contains a single return statement. effect(unnecessaryEffectGen)
+/.src/unnecessaryEffectGen.ts(19,37): suggestion TS377017: This Effect.gen contains a single return statement. effect(unnecessaryEffectGen)
 
 
 ==== /.src/unnecessaryEffectGen.ts (1 errors) ====
@@ -14,6 +14,13 @@ Effect version: 4.0.0
     
     export const shouldNotRaiseForNonEffect = Effect.gen(function*() {
       return 42
+    })
+    
+    const foo = () => Effect.succeed(100)
+    const bar = (x: number) => Effect.succeed(x + x)
+    
+    export const shouldNotRaiseForNestedYield = Effect.gen(function*() {
+      return yield* bar(yield* foo())
     })
     
     export const shouldRaiseForSingle = Effect.gen(function*() {

--- a/testdata/baselines/reference/effect-v4/unnecessaryEffectGen.flows.unnecessaryEffectGen.mermaid
+++ b/testdata/baselines/reference/effect-v4/unnecessaryEffectGen.flows.unnecessaryEffectGen.mermaid
@@ -9,11 +9,24 @@ flowchart TB
   7[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
   8((("type: Effect#lt;number, never, never#gt;<br/>node: Effect.gen#40;function*#40;#41; #123;#92;n  return 42#92;n#125;#41;")))
   9[/"type: 42<br/>node: 42"/]
-  10((("type: Effect#lt;number, never, never#gt;<br/>node: Effect.gen#40;function*#40;#41; #123;#92;n  return yield* Effect.succeed#40;42#41;#92;n#125;#41;")))
-  11[/"type: number<br/>node: yield* Effect.succeed#40;42#41;"/]
-  12[/"type: 42<br/>node: 42"/]
-  13["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  14[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  10[["type: #40;#41; =#gt; Effect#lt;number, never, never#gt;<br/>node: #40;#41; =#gt; Effect.succeed#40;100#41;"]]
+  11[/"type: 100<br/>node: 100"/]
+  12["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  13[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  14[["type: #40;x: number#41; =#gt; Effect#lt;number, never, never#gt;<br/>node: #40;x: number#41; =#gt; Effect.succeed#40;x + x#41;"]]
+  15[/"type: number<br/>node: x + x"/]
+  16["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  17[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  18((("type: Effect#lt;number, never, never#gt;<br/>node: Effect.gen#40;function*#40;#41; #123;#92;n  return yield* bar#40;yield* foo#40;#41;#41;#92;n#125;#41;")))
+  19[/"type: number<br/>node: yield* bar#40;yield* foo#40;#41;#41;"/]
+  20[/"type: number<br/>node: yield* foo#40;#41;"/]
+  21["type: Effect#lt;number, never, never#gt;<br/>callee: bar<br/>args: #91;#93;"]
+  22[/"type: #40;x: number#41; =#gt; Effect#lt;number, never, never#gt;<br/>node: bar"/]
+  23((("type: Effect#lt;number, never, never#gt;<br/>node: Effect.gen#40;function*#40;#41; #123;#92;n  return yield* Effect.succeed#40;42#41;#92;n#125;#41;")))
+  24[/"type: number<br/>node: yield* Effect.succeed#40;42#41;"/]
+  25[/"type: 42<br/>node: 42"/]
+  26["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  27[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
   2 -->|"kind: pipe"| 3
   4 -->|"kind: transformCallee"| 3
   3 -->|"kind: usedBy"| 1
@@ -24,8 +37,19 @@ flowchart TB
   3 -->|"kind: yieldable"| 0
   9 -->|"kind: potentialReturn"| 8
   9 -->|"kind: usedBy"| 8
-  12 -->|"kind: pipe"| 13
-  14 -->|"kind: transformCallee"| 13
-  13 -->|"kind: usedBy"| 11
-  11 -->|"kind: potentialReturn"| 10
-  13 -->|"kind: yieldable"| 10
+  11 -->|"kind: pipe"| 12
+  13 -->|"kind: transformCallee"| 12
+  12 -->|"kind: potentialReturn"| 10
+  15 -->|"kind: pipe"| 16
+  17 -->|"kind: transformCallee"| 16
+  16 -->|"kind: potentialReturn"| 14
+  20 -->|"kind: pipe"| 21
+  22 -->|"kind: transformCallee"| 21
+  21 -->|"kind: usedBy"| 19
+  19 -->|"kind: potentialReturn"| 18
+  21 -->|"kind: yieldable"| 18
+  25 -->|"kind: pipe"| 26
+  27 -->|"kind: transformCallee"| 26
+  26 -->|"kind: usedBy"| 24
+  24 -->|"kind: potentialReturn"| 23
+  26 -->|"kind: yieldable"| 23

--- a/testdata/baselines/reference/effect-v4/unnecessaryEffectGen.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/unnecessaryEffectGen.pipings.txt
@@ -1,4 +1,4 @@
-==== /.src/unnecessaryEffectGen.ts (6 flows) ====
+==== /.src/unnecessaryEffectGen.ts (10 flows) ====
 
 === Piping Flow ===
 Location: 3:29 - 6:3
@@ -57,7 +57,63 @@ Transformations (1):
       outType: Effect<number, never, never>
 
 === Piping Flow ===
-Location: 12:36 - 14:3
+Location: 12:18 - 12:38
+Node: Effect.succeed(100)
+Node Kind: KindCallExpression
+
+Subject: 100
+Subject Type: 100
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 13:27 - 13:49
+Node: Effect.succeed(x + x)
+Node Kind: KindCallExpression
+
+Subject: x + x
+Subject Type: number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 15:44 - 17:3
+Node: Effect.gen(function*() {\n  return yield* bar(yield* foo())\n})
+Node Kind: KindCallExpression
+
+Subject: function*() {\n  return yield* bar(yield* foo())\n}
+Subject Type: () => Generator<Effect<number, never, never>, number, any>
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.gen
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 16:16 - 16:34
+Node: bar(yield* foo())
+Node Kind: KindCallExpression
+
+Subject: yield* foo()
+Subject Type: number
+
+Transformations (1):
+  [0] kind: call
+      callee: bar
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 19:36 - 21:3
 Node: Effect.gen(function*() {\n  return yield* Effect.succeed(42)\n})
 Node Kind: KindCallExpression
 
@@ -71,7 +127,7 @@ Transformations (1):
       outType: Effect<number, never, never>
 
 === Piping Flow ===
-Location: 13:16 - 13:35
+Location: 20:16 - 20:35
 Node: Effect.succeed(42)
 Node Kind: KindCallExpression
 

--- a/testdata/baselines/reference/effect-v4/unnecessaryEffectGen.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/unnecessaryEffectGen.quickfixes.txt
@@ -1,6 +1,6 @@
 === Quick Fix Inventory ===
 
-[D1] (12:37-14:3) TS377017: This Effect.gen contains a single return statement. effect(unnecessaryEffectGen)
+[D1] (19:37-21:3) TS377017: This Effect.gen contains a single return statement. effect(unnecessaryEffectGen)
   Fix 0: "Disable unnecessaryEffectGen for this line"
   Fix 1: "Disable unnecessaryEffectGen for entire file"
   Fix 2: "Remove the Effect.gen, and keep the body"
@@ -25,6 +25,13 @@ export const shouldNotRant = Effect.gen(function*() {
 
 export const shouldNotRaiseForNonEffect = Effect.gen(function*() {
   return 42
+})
+
+const foo = () => Effect.succeed(100)
+const bar = (x: number) => Effect.succeed(x + x)
+
+export const shouldNotRaiseForNestedYield = Effect.gen(function*() {
+  return yield* bar(yield* foo())
 })
 
 export const shouldRaiseForSingle = Effect.succeed(42)

--- a/testdata/tests/effect-v3/unnecessaryEffectGen.ts
+++ b/testdata/tests/effect-v3/unnecessaryEffectGen.ts
@@ -10,6 +10,13 @@ export const shouldNotRaiseForNonEffect = Effect.gen(function*() {
   return 42
 })
 
+const foo = () => Effect.succeed(100)
+const bar = (x: number) => Effect.succeed(x + x)
+
+export const shouldNotRaiseForNestedYield = Effect.gen(function*() {
+  return yield* bar(yield* foo())
+})
+
 export const shouldRaiseForSingle = Effect.gen(function*() {
   return yield* Effect.succeed(42)
 })

--- a/testdata/tests/effect-v4/unnecessaryEffectGen.ts
+++ b/testdata/tests/effect-v4/unnecessaryEffectGen.ts
@@ -9,6 +9,13 @@ export const shouldNotRaiseForNonEffect = Effect.gen(function*() {
   return 42
 })
 
+const foo = () => Effect.succeed(100)
+const bar = (x: number) => Effect.succeed(x + x)
+
+export const shouldNotRaiseForNestedYield = Effect.gen(function*() {
+  return yield* bar(yield* foo())
+})
+
 export const shouldRaiseForSingle = Effect.gen(function*() {
   return yield* Effect.succeed(42)
 })


### PR DESCRIPTION
## Summary
- Skip the unnecessaryEffectGen diagnostic when a single-return generator contains nested yield* expressions.
- Add v3 and v4 regression coverage for `return yield* bar(yield* foo())`.
- Update diagnostic, quickfix, piping, and execution-flow baselines.

## Example
```ts
export const program = Effect.gen(function* () {
  return yield* bar(yield* foo())
})
```

This no longer gets an `effect(unnecessaryEffectGen)` suggestion, avoiding an invalid quick fix.

## Validation
- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`