### PR TITLE
Fix EffectLinks patch context

### DIFF
--- a/.changeset/fresh-patches-apply.md
+++ b/.changeset/fresh-patches-apply.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Make the EffectLinks checker patch apply across newer typescript-go commits by anchoring it to stable Checker fields.

--- a/_patches/023-checker-effect-links.patch
+++ b/_patches/023-checker-effect-links.patch
@@ -1,12 +1,11 @@
 diff --git a/internal/checker/checker.go b/internal/checker/checker.go
 --- a/internal/checker/checker.go
 +++ b/internal/checker/checker.go
-@@ -622,7 +622,8 @@ type Checker struct {
- 	TypeCount                                   uint32
- 	SymbolCount                                 uint32
- 	SignatureCount                              uint32
- 	TotalInstantiationCount                     uint32
+@@ -581,6 +581,7 @@ type Checker struct {
+ 	id                                          uint32
+ 	program                                     Program
+ 	compilerOptions                             *core.CompilerOptions
 +	EffectLinks                                 any
- 	instantiationCount                          uint32
- 	instantiationDepth                          uint32
- 	inlineLevel                                 int
+ 	files                                       []*ast.SourceFile
+ 	fileIndexMap                                map[*ast.SourceFile]int
+ 	compareSymbols                              func(*ast.Symbol, *ast.Symbol) int

--- a/shim/checker/shim.go
+++ b/shim/checker/shim.go
@@ -112,6 +112,7 @@ type extra_Checker struct {
   id uint32
   program checker.Program
   compilerOptions *core.CompilerOptions
+  EffectLinks any
   files []*ast.SourceFile
   fileIndexMap map[*ast.SourceFile]int
   compareSymbols func(*ast.Symbol, *ast.Symbol) int
@@ -120,7 +121,6 @@ type extra_Checker struct {
   SymbolCount uint32
   SignatureCount uint32
   TotalInstantiationCount uint32
-  EffectLinks any
   instantiationCount uint32
   instantiationDepth uint32
   inlineLevel int


### PR DESCRIPTION
## Summary
- Move the EffectLinks checker patch insertion to a stable location after compilerOptions
- Regenerate the checker shim to match the updated field order
- Add a patch changeset

## Verification
- pnpm setup-repo
- pnpm lint
- pnpm check
- pnpm test

Also verified the patch series applies to typescript-go commits acfaa5bcc8631d3c51ad65a8562a656c8d6a4bd5 and a093a851632f4704ec2a59857da1dccbe6d336a3.