### PR TITLE
Fix effecttest LSP helpers after typescript-go update

### DIFF
--- a/.changeset/effecttest-lsp-unmarshal.md
+++ b/.changeset/effecttest-lsp-unmarshal.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix `internal/effecttest` LSP test helpers broken by the `typescript-go` update: the untyped `SendRequestWorker` now returns the response result as a raw `json.Value`, so the inlay hint, diagnostic, and code action helpers decode it via `RequestInfo.UnmarshalResult` instead of type-asserting the typed response struct.

--- a/go.work.sum
+++ b/go.work.sum
@@ -6,6 +6,7 @@ golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVo
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
 golang.org/x/mod v0.32.0/go.mod h1:SgipZ/3h2Ci89DlEtEXWUk/HteuRin+HHhN+WbNhguU=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=

--- a/internal/effecttest/autoimport_style_consistency_test.go
+++ b/internal/effecttest/autoimport_style_consistency_test.go
@@ -130,9 +130,9 @@ func verifyImportFixContentsUnordered(t *testing.T, f *fourslash.FourslashTest, 
 	if !ok {
 		t.Fatal("diagnostic request failed")
 	}
-	diagResult, ok := diagResp.Result.(lsproto.DocumentDiagnosticResponse)
-	if !ok {
-		t.Fatal("unexpected diagnostic response type")
+	diagResult, err := lsproto.TextDocumentDiagnosticInfo.UnmarshalResult(diagResp.Result)
+	if err != nil {
+		t.Fatalf("failed to unmarshal diagnostic response: %v", err)
 	}
 
 	var diagnostics []*lsproto.Diagnostic
@@ -151,9 +151,9 @@ func verifyImportFixContentsUnordered(t *testing.T, f *fourslash.FourslashTest, 
 	if !ok {
 		t.Fatal("code action request failed")
 	}
-	actionResult, ok := actionResp.Result.(lsproto.CodeActionResponse)
-	if !ok {
-		t.Fatal("unexpected code action response type")
+	actionResult, err := lsproto.TextDocumentCodeActionInfo.UnmarshalResult(actionResp.Result)
+	if err != nil {
+		t.Fatalf("failed to unmarshal code action response: %v", err)
 	}
 
 	var actual []string

--- a/internal/effecttest/inlay_hints_baseline_test.go
+++ b/internal/effecttest/inlay_hints_baseline_test.go
@@ -56,9 +56,9 @@ func verifyLocalBaselineInlayHints(t *testing.T, f *fourslash.FourslashTest, tes
 		t.Fatalf("%s request returned error: %s", lsproto.MethodTextDocumentInlayHint, resp.Error.String())
 	}
 
-	result, ok := resp.Result.(lsproto.InlayHintResponse)
-	if !ok {
-		t.Fatalf("Unexpected %s response type: %T", lsproto.MethodTextDocumentInlayHint, resp.Result)
+	result, err := lsproto.TextDocumentInlayHintInfo.UnmarshalResult(resp.Result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal %s response: %v", lsproto.MethodTextDocumentInlayHint, err)
 	}
 
 	actual := formatInlayHintBaseline(t, fileContent, result)


### PR DESCRIPTION
## What changed

The typescript-go submodule bump in #299 changed the upstream LSP test client (`testutil/lsptestutil`): the untyped `SendRequestWorker` now leaves `resp.Result` as a raw `json.Value`, with typed decoding moved into the typed helpers via `RequestInfo.UnmarshalResult`.

Our `internal/effecttest` helpers still type-asserted the typed response structs on the raw result, so 6 tests failed on `main`:

- `TestEffectInlayHintsGenSuppression`, `TestEffectInlayHintsFnSuppression`, `TestEffectInlayHintsFnUntracedSuppression`, `TestEffectInlayHintsNonEffectNotSuppressed`, `TestEffectInlayHintsDisabledPassthrough` — `Unexpected textDocument/inlayHint response type: jsontext.Value`
- `TestAutoImportEffectStyleConsistency_barrel` — `unexpected diagnostic response type`

## Fix

Decode the raw results with the matching `RequestInfo.UnmarshalResult` (same pattern as upstream's typed helpers):

```go
// before
result, ok := resp.Result.(lsproto.InlayHintResponse)

// after
result, err := lsproto.TextDocumentInlayHintInfo.UnmarshalResult(resp.Result)
```

Applied to the inlay hint helper (`inlay_hints_baseline_test.go`) and the diagnostic + code action requests in `autoimport_style_consistency_test.go`. Also includes the `go.work.sum` refresh from the submodule dependency update.

## Validation

- `pnpm lint` — 0 issues
- `pnpm check` — clean
- `pnpm test` — full suite passes (previously failing 6 tests now green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)