### PR TITLE
Fix release workflow embedding stale EffectVersion in tsc binary

### DIFF
--- a/.changeset/release-version-sync.md
+++ b/.changeset/release-version-sync.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix the release workflow embedding a stale `EffectVersion` in the published `tsc` binary. The version bump from the changeset release PR only lands on `main`, while the `tsc` binary builds from `generated/stable`; the workflow now syncs `_packages/tsgo/package.json` from the release merge commit and re-runs `_tools/version-prepare.sh` before building. All release checkouts are also pinned to the merge commit SHA instead of the moving `main` ref so the release is deterministic.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           - linux-arm
         binary:
           - name: tsgo
-            ref: main
+            ref: ${{ github.event.pull_request.merge_commit_sha }}
           - name: tsc
             ref: generated/stable
     steps:
@@ -76,6 +76,13 @@ jobs:
       - name: Setup repo
         run: pnpm setup-repo --ci
 
+      - name: Sync Effect version from release commit
+        if: matrix.binary.ref != github.event.pull_request.merge_commit_sha
+        run: |
+          git fetch --depth=1 origin "${{ github.event.pull_request.merge_commit_sha }}"
+          git checkout "${{ github.event.pull_request.merge_commit_sha }}" -- _packages/tsgo/package.json
+          bash _tools/version-prepare.sh
+
       - name: Build ${{ matrix.binary.name }} ${{ matrix.npm_target }}
         run: pnpm release:prepare --target ${{ matrix.npm_target }} --binary-name ${{ matrix.binary.name }} --skip-cli
 
@@ -99,7 +106,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

The release workflow triggers when the `changeset-release/main` PR merges. That PR bumps `_packages/tsgo/package.json` and regenerates `etscore/version_generated.go` — but only on `main`. The `tsc` binary in the release matrix builds from `generated/stable`, which never has the bump at release time (the stable-branch generation workflow explicitly skips `Version Packages` commits, and its update PR would not be merged before the release runs anyway). As a result the published `tsc` binary embedded the **previous** release's `EffectVersion`.

## Fix

- New `Sync Effect version from release commit` step in the build job: for any matrix entry not building the release commit itself, it fetches the changeset PR's merge commit, checks out `_packages/tsgo/package.json` from it, and re-runs `_tools/version-prepare.sh` to regenerate `etscore/version_generated.go`. Syncing the source of truth and re-running the existing generator means the build can never drift from what the script produces.
- All checkouts previously pointing at the moving `main` ref (the `tsgo` build entry and the publish job) are now pinned to `github.event.pull_request.merge_commit_sha`, so the release builds and publishes exactly the commit that carried the version bump even if `main` advances mid-run. `merge_commit_sha` is used rather than `github.sha`, which on `pull_request` events can refer to the ephemeral test-merge ref.

## Example

Previous release: `tsgo --version` reported the new version while `tsc --version` (built from `generated/stable`) still reported the old `EffectVersion`. With this change both binaries embed the version from the merged release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)