### PR TITLE
Fix checker panics on import.defer calls and bindingless import clauses

### DIFF
--- a/.changeset/tidy-crabs-guard.md
+++ b/.changeset/tidy-crabs-guard.md
@@ -1,0 +1,15 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix checker panics on `import.defer(...)` calls and bindingless import clauses.
+
+`import.defer` parses as a meta property, and the checker debug-asserts (panics) when asked for its symbol or type while it is used as an import-call callee. Rules resolving arbitrary call callees (e.g. `catchUnfailableEffect`, `globalFetch`, `globalTimers`) crashed tsc and the LSP on files containing:
+
+```ts
+import.defer("./module")
+```
+
+Symbol resolution now goes through a guarded `TypeParser.GetSymbolAtLocation` wrapper that skips meta properties, and all rule/refactor/LSP call sites were audited to use it. `TypeParser.GetTypeAtLocation` gained the same meta-property guard, plus a guard for import clauses without a default binding (`import { A } from "x"`), which previously hit a nil-symbol panic that was silently recovered.
+
+Also adds rule sweep stress tests that run the every-node diagnostics (`anyUnknownInErrorContext`, `effectInFailure`) over the typescript-go compiler test corpus, the effect-v4 fixtures, and effect's own package sources under a watchdog, failing on panics or non-termination.

--- a/etsapi/layer_magic.go
+++ b/etsapi/layer_magic.go
@@ -34,7 +34,7 @@ func (tp *TypeParser) ExtractLayerMagic(sourceFile *ast.SourceFile, nodes []*ast
 	fullGraph := layergraph.ExtractLayerGraph(tp.inner, tp.checker, nodes, sourceFile, layergraph.ExtractLayerGraphOptions{
 		SkipExplode: true,
 	})
-	outlineGraph := layergraph.ExtractOutlineGraph(tp.checker, fullGraph)
+	outlineGraph := layergraph.ExtractOutlineGraph(tp.inner, tp.checker, fullGraph)
 	if outlineGraph == nil {
 		return nil
 	}

--- a/etslshooks/document_symbols.go
+++ b/etslshooks/document_symbols.go
@@ -395,7 +395,7 @@ func classificationTypes(tp *typeparser.TypeParser, c *checker.Checker, node *as
 	types := []*checker.Type{t}
 	if node.Kind == ast.KindClassDeclaration {
 		if className := node.Name(); className != nil {
-			if classSymbol := c.GetSymbolAtLocation(className); classSymbol != nil {
+			if classSymbol := tp.GetSymbolAtLocation(className); classSymbol != nil {
 				if classType := c.GetTypeOfSymbolAtLocation(classSymbol, node); classType != nil && classType != t {
 					types = append(types, classType)
 				}

--- a/etslshooks/init.go
+++ b/etslshooks/init.go
@@ -250,7 +250,7 @@ func formatLayerHover(tp *typeparser.TypeParser, c *checker.Checker, sf *ast.Sou
 
 		if !effectConfig.NoExternal {
 			nestedDiagram = layergraph.FormatNestedLayerGraph(c, fullGraph, sf)
-			outlineGraph := layergraph.ExtractOutlineGraph(c, fullGraph)
+			outlineGraph := layergraph.ExtractOutlineGraph(tp, c, fullGraph)
 			outlineDiagram = layergraph.FormatOutlineGraph(c, outlineGraph, sf)
 		}
 	}

--- a/internal/effecttest/baseline.go
+++ b/internal/effecttest/baseline.go
@@ -556,7 +556,7 @@ func generateLayerGraphBaseline(
 			}
 
 			fullGraph := layergraph.ExtractLayerGraph(tp, c, []*ast.Node{export.initializer}, sf, opts)
-			outlineGraph := layergraph.ExtractOutlineGraph(c, fullGraph)
+			outlineGraph := layergraph.ExtractOutlineGraph(tp, c, fullGraph)
 			providersAndRequirers := layergraph.ExtractProvidersAndRequirers(c, fullGraph)
 
 			sb.WriteString("\n--- output ---\n")

--- a/internal/effecttest/rule_sweep_test.go
+++ b/internal/effecttest/rule_sweep_test.go
@@ -1,0 +1,267 @@
+package effecttest
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/effect-ts/tsgo/internal/bundledeffect"
+)
+
+// Rule sweep stress tests (originally built while investigating
+// https://github.com/Effect-TS/tsgo/issues/301).
+//
+// anyUnknownInErrorContext and effectInFailure are the only rules that request
+// the type of every node in a file, which exercises checker paths regular
+// type checking never touches. These tests run both rules (plus all
+// default-enabled rules) over broad code corpora and fail if any input makes
+// diagnostics collection panic or fail to terminate within a generous
+// watchdog timeout.
+
+const ruleSweepPluginConfig = `{
+  "compilerOptions": {
+    "strict": true,
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnosticSeverity": {
+          "anyUnknownInErrorContext": "error",
+          "effectInFailure": "error"
+        }
+      }
+    ]
+  }
+}`
+
+const ruleSweepTimeout = 120 * time.Second
+
+// runRuleSweepCase collects diagnostics for the given test content under a
+// watchdog: it fails the test if collection panics or exceeds ruleSweepTimeout.
+func runRuleSweepCase(t *testing.T, content string) time.Duration {
+	t.Helper()
+
+	start := time.Now()
+	done := make(chan []string, 1)
+	panicked := make(chan any, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked <- r
+			}
+		}()
+		done <- collectDiagnosticStringsFromContent(t, content)
+	}()
+
+	select {
+	case diags := <-done:
+		elapsed := time.Since(start)
+		t.Logf("completed in %s with %d diagnostics", elapsed, len(diags))
+		return elapsed
+	case r := <-panicked:
+		t.Errorf("diagnostics collection panicked: %v", r)
+		return time.Since(start)
+	case <-time.After(ruleSweepTimeout):
+		t.Fatalf("diagnostics collection did not complete within %s", ruleSweepTimeout)
+		return 0
+	}
+}
+
+func buildRuleSweepContent(source string, overrideEffectPackageJSON string) string {
+	var sb strings.Builder
+	sb.WriteString("// @filename: tsconfig.json\n")
+	sb.WriteString(ruleSweepPluginConfig)
+	if overrideEffectPackageJSON != "" {
+		sb.WriteString("\n\n// @filename: /node_modules/effect/package.json\n")
+		sb.WriteString(overrideEffectPackageJSON)
+	}
+	sb.WriteString("\n\n// @filename: test.ts\n")
+	sb.WriteString(source)
+	return sb.String()
+}
+
+// TestRuleSweepImportDefer is a fast regression test: `import.defer(...)` used
+// to panic the checker via rules resolving the callee symbol or type
+// (checkMetaProperty debug assertion). See the typeparser GetSymbolAtLocation and
+// GetTypeAtLocation meta-property guards.
+func TestRuleSweepImportDefer(t *testing.T) {
+	t.Parallel()
+	content := "// @filename: tsconfig.json\n" + ruleSweepPluginConfig +
+		"\n\n// @filename: dep.ts\nexport {}\n" +
+		"\n\n// @filename: test.ts\nexport {}\nimport.defer(\"./dep.js\")\n"
+	runRuleSweepCase(t, content)
+}
+
+// TestRuleSweepTypeScriptCorpus sweeps the rules over typescript-go's own
+// compiler/conformance test corpus, covering exotic syntax shapes the Effect
+// fixtures never produce.
+func TestRuleSweepTypeScriptCorpus(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("corpus sweep is slow")
+	}
+
+	var files []string
+	for _, dir := range []string{"compiler", "conformance"} {
+		root := filepath.Join(bundledeffect.EffectTsGoRootPath(), "typescript-go", "testdata", "tests", "cases", dir)
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err == nil && !d.IsDir() && (strings.HasSuffix(path, ".ts") || strings.HasSuffix(path, ".tsx")) {
+				files = append(files, path)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("corpus size: %d files", len(files))
+
+	for _, path := range files {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		name := filepath.Base(path)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			elapsed := runRuleSweepCase(t, buildRuleSweepContent(string(raw), ""))
+			if elapsed > 5*time.Second {
+				t.Logf("SLOW corpus file (%s): %s", elapsed, path)
+			}
+		})
+	}
+}
+
+// TestRuleSweepEffectFixtures runs the sweep over this repo's own effect-v4
+// rule fixtures (realistic Effect code). anyUnknownInErrorContext is off by
+// default, so regular fixture runs never sweep these files with it.
+func TestRuleSweepEffectFixtures(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("fixture sweep is slow")
+	}
+
+	cases, err := DiscoverTestCases(bundledeffect.EffectV4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("fixture count: %d", len(cases))
+
+	for _, path := range cases {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		name := filepath.Base(path)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			elapsed := runRuleSweepCase(t, buildRuleSweepContent(string(raw), ""))
+			if elapsed > 5*time.Second {
+				t.Logf("SLOW fixture (%s): %s", elapsed, path)
+			}
+		})
+	}
+}
+
+// TestRuleSweepEffectPackageSources pulls effect's own shipped src/*.ts files
+// into the program as non-external, non-declaration files, so the sweep runs
+// over the library's full source complexity.
+func TestRuleSweepEffectPackageSources(t *testing.T) {
+	t.Parallel()
+	content := "// @filename: tsconfig.json\n" + ruleSweepPluginConfig +
+		"\n\n// @filename: /node_modules/effect/src/__sweep__.ts\nexport * from \"./index.js\"\n" +
+		"\n\n// @filename: test.ts\nimport * as E from \"/node_modules/effect/src/__sweep__.js\"\nexport const x = E\n"
+	runRuleSweepCase(t, content)
+}
+
+// TestRuleSweepUnknownEffectVersion runs the sweep with effect version
+// detection forced to Unknown (mangled package.json version), covering the
+// v3/unknown property-iteration fallback in EffectType/LayerType.
+func TestRuleSweepUnknownEffectVersion(t *testing.T) {
+	t.Parallel()
+	source := buildRuleSweepSource(20)
+
+	t.Run("v4_detected", func(t *testing.T) {
+		t.Parallel()
+		runRuleSweepCase(t, buildRuleSweepContent(source, ""))
+	})
+
+	t.Run("version_unknown", func(t *testing.T) {
+		t.Parallel()
+		runRuleSweepCase(t, buildRuleSweepContent(source, unknownVersionEffectPackageJSON(t)))
+	})
+}
+
+// unknownVersionEffectPackageJSON returns the bundled effect v4 package.json
+// with its version mangled so that DetectEffectVersion returns Unknown.
+func unknownVersionEffectPackageJSON(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(bundledeffect.EffectTsGoRootPath(), "testdata", "tests", "effect-v4", "node_modules", "effect", "package.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	patched := strings.Replace(string(raw), `"version": "4.`, `"version": "0.`, 1)
+	if patched == string(raw) {
+		t.Fatal("failed to patch effect package.json version")
+	}
+	return patched
+}
+
+// buildRuleSweepSource builds a file mixing recursive template-object types
+// and Effect v4 usage, scaled by n repeated sections.
+func buildRuleSweepSource(n int) string {
+	var sb strings.Builder
+	sb.WriteString(`import { Effect } from "effect"
+
+interface KeyboardEvent { triggeredByAccelerator: boolean }
+interface BrowserWindow { close(): void; isFocused(): boolean }
+interface Menu { items: MenuItem[]; append(item: MenuItem): void; popup(): void; closePopup(): void }
+interface MenuItem { label: string; enabled: boolean; visible: boolean; checked: boolean }
+type Role = "about" | "quit" | "undo" | "redo" | "cut" | "copy" | "paste" | "toggleDevTools" | "reload" | "minimize" | "close" | "help" | "window" | "services" | "zoomIn" | "zoomOut" | "togglefullscreen"
+interface MenuItemConstructorOptions {
+	label?: string
+	role?: Role
+	type?: "normal" | "separator" | "submenu" | "checkbox" | "radio"
+	accelerator?: string
+	enabled?: boolean
+	visible?: boolean
+	checked?: boolean
+	click?: (menuItem: MenuItem, browserWindow: BrowserWindow | undefined, event: KeyboardEvent) => void
+	submenu?: MenuItemConstructorOptions[] | Menu
+}
+declare const MenuStatic: {
+	buildFromTemplate(template: Array<MenuItemConstructorOptions | MenuItem>): Menu
+	setApplicationMenu(menu: Menu | null): void
+	getApplicationMenu(): Menu | null
+}
+`)
+	for i := range n {
+		fmt.Fprintf(&sb, `
+const template%[1]d: MenuItemConstructorOptions[] = [
+	{ label: "App%[1]d", submenu: [{ role: "about" }, { type: "separator" }, { role: "quit" }] },
+	{ label: "Edit%[1]d", submenu: [{ role: "undo" }, { role: "redo" }, { type: "separator" }, { role: "cut" }, { role: "copy" }, { role: "paste" }] },
+	{ label: "View%[1]d", submenu: [{ role: "reload" }, { role: "toggleDevTools" }, { label: "Custom%[1]d", click: (item, win, ev) => { if (win?.isFocused()) { win.close() } } }] },
+	{ label: "Window%[1]d", submenu: [{ role: "minimize" }, { role: "close" }] },
+]
+export const menu%[1]d = MenuStatic.buildFromTemplate(template%[1]d)
+
+export const program%[1]d = Effect.succeed(%[1]d).pipe(
+	Effect.map((v) => v + 1),
+	Effect.flatMap((v) => v > 0 ? Effect.succeed(v) : Effect.fail(new Error("neg"))),
+	Effect.map((v) => v * 2),
+	Effect.catchAll(() => Effect.succeed(0)),
+)
+
+export const gen%[1]d = Effect.gen(function*() {
+	const a = yield* program%[1]d
+	const m = MenuStatic.getApplicationMenu()
+	if (m) { m.append({ label: "x", enabled: true, visible: true, checked: false }) }
+	return a + template%[1]d.length
+})
+`, i)
+	}
+	return sb.String()
+}

--- a/internal/layergraph/extract.go
+++ b/internal/layergraph/extract.go
@@ -187,7 +187,7 @@ func ExtractLayerGraph(
 
 		// Case 4: Symbol following
 		if currentDepth > 0 && isSimpleIdentifier(current) {
-			sym := c.GetSymbolAtLocation(current)
+			sym := tp.GetSymbolAtLocation(current)
 			if sym != nil {
 				if sym.Flags&ast.SymbolFlagsAlias != 0 {
 					resolved := checker.SkipAlias(sym, c)

--- a/internal/layergraph/outline.go
+++ b/internal/layergraph/outline.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"github.com/effect-ts/tsgo/internal/graph"
+	"github.com/effect-ts/tsgo/internal/typeparser"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 )
@@ -12,6 +13,7 @@ import (
 // It keeps only leaf nodes (deduplicated by symbol) and connects them based on
 // type compatibility: if node A requires a service that node B provides, add an edge.
 func ExtractOutlineGraph(
+	tp *typeparser.TypeParser,
 	c *checker.Checker,
 	layerGraph *graph.Graph[LayerGraphNodeInfo, LayerGraphEdgeInfo],
 ) *graph.Graph[LayerOutlineGraphNodeInfo, struct{}] {
@@ -25,7 +27,7 @@ func ExtractOutlineGraph(
 	// Step 1: Get leaf nodes (nodes with no outgoing edges) and deduplicate by symbol.
 	var dedupedLeafNodes []LayerGraphNodeInfo
 	for _, leafNode := range layerGraph.Externals(graph.Outgoing) {
-		sym := c.GetSymbolAtLocation(leafNode.Node)
+		sym := tp.GetSymbolAtLocation(leafNode.Node)
 		if sym == nil {
 			dedupedLeafNodes = append(dedupedLeafNodes, leafNode)
 		} else if _, seen := knownSymbols[sym]; !seen {

--- a/internal/refactors/layer_magic.go
+++ b/internal/refactors/layer_magic.go
@@ -123,7 +123,7 @@ func tryBuildRefactor(ctx *refactor.Context, tp *typeparser.TypeParser, c *check
 	}
 
 	// Extract outline graph
-	outlineGraph := layergraph.ExtractOutlineGraph(c, layerGraph)
+	outlineGraph := layergraph.ExtractOutlineGraph(ctx.TypeParser, c, layerGraph)
 	if outlineGraph == nil || outlineGraph.NodeCount() <= 1 {
 		return nil
 	}
@@ -244,7 +244,7 @@ func tryPrepareRefactor(ctx *refactor.Context, tp *typeparser.TypeParser, c *che
 	}
 
 	// Extract outline graph
-	outlineGraph := layergraph.ExtractOutlineGraph(c, layerGraph)
+	outlineGraph := layergraph.ExtractOutlineGraph(ctx.TypeParser, c, layerGraph)
 	if outlineGraph == nil || outlineGraph.NodeCount() <= 1 {
 		return nil
 	}

--- a/internal/refactors/write_tag_class_accessors.go
+++ b/internal/refactors/write_tag_class_accessors.go
@@ -75,7 +75,7 @@ func runWriteTagClassAccessors(ctx *refactor.Context) []ls.CodeAction {
 	}
 
 	// Resolve the service shape type via the _Service variance struct
-	classSymbol := c.GetSymbolAtLocation(className)
+	classSymbol := ctx.TypeParser.GetSymbolAtLocation(className)
 	if classSymbol == nil {
 		return nil
 	}

--- a/internal/rules/crypto_random_uuid.go
+++ b/internal/rules/crypto_random_uuid.go
@@ -55,7 +55,7 @@ func runCryptoRandomUUID(ctx *rule.Context, checkInEffect bool) []*ast.Diagnosti
 			inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagInEffect != 0
 			if inEffect == checkInEffect {
 				if receiver := cryptoRandomUUIDReceiver(call); receiver != nil {
-					if ctx.TypeParser.ResolveToGlobalSymbol(ctx.Checker.GetSymbolAtLocation(receiver)) == cryptoSymbol {
+					if ctx.TypeParser.ResolveToGlobalSymbol(ctx.TypeParser.GetSymbolAtLocation(receiver)) == cryptoSymbol {
 						diags = append(diags, ctx.NewDiagnostic(
 							ctx.SourceFile,
 							scanner.GetErrorRangeForNode(ctx.SourceFile, node),

--- a/internal/rules/extends_native_error.go
+++ b/internal/rules/extends_native_error.go
@@ -76,7 +76,7 @@ func checkExtendsNativeError(tp *typeparser.TypeParser, c *checker.Checker, sf *
 		}
 		expr := elem.AsExpressionWithTypeArguments().Expression
 
-		exprSymbol := c.GetSymbolAtLocation(expr)
+		exprSymbol := tp.GetSymbolAtLocation(expr)
 		resolvedSymbol := exprSymbol
 		if resolvedSymbol != nil && resolvedSymbol.Flags&ast.SymbolFlagsAlias != 0 {
 			resolvedSymbol = c.GetAliasedSymbol(resolvedSymbol)

--- a/internal/rules/generic_effect_services.go
+++ b/internal/rules/generic_effect_services.go
@@ -41,7 +41,7 @@ var GenericEffectServices = rule.Rule{
 			if node.Kind == ast.KindClassDeclaration {
 				classDecl := node.AsClassDeclaration()
 				if node.Name() != nil && classDecl.TypeParameters != nil && classDecl.HeritageClauses != nil {
-					classSym := ctx.Checker.GetSymbolAtLocation(node.Name())
+					classSym := ctx.TypeParser.GetSymbolAtLocation(node.Name())
 					if classSym != nil {
 						classType := ctx.Checker.GetTypeOfSymbolAtLocation(classSym, node)
 						if classType != nil && ctx.TypeParser.IsContextTag(classType, node) {

--- a/internal/rules/global_console.go
+++ b/internal/rules/global_console.go
@@ -65,7 +65,7 @@ func runGlobalConsole(ctx *rule.Context, checkInEffect bool) []*ast.Diagnostic {
 				prop := node.AsCallExpression().Expression.AsPropertyAccessExpression()
 				method := prop.Name().Text()
 				alternative := globalConsoleMethodAlternatives[method]
-				if alternative != "" && ctx.TypeParser.ResolveToGlobalSymbol(ctx.Checker.GetSymbolAtLocation(prop.Expression)) == consoleSymbol {
+				if alternative != "" && ctx.TypeParser.ResolveToGlobalSymbol(ctx.TypeParser.GetSymbolAtLocation(prop.Expression)) == consoleSymbol {
 					diags = append(diags, ctx.NewDiagnostic(
 						ctx.SourceFile,
 						scanner.GetErrorRangeForNode(ctx.SourceFile, node),

--- a/internal/rules/global_date.go
+++ b/internal/rules/global_date.go
@@ -76,7 +76,7 @@ func runGlobalDate(ctx *rule.Context, checkInEffect bool) []*ast.Diagnostic {
 				}
 			}
 
-			if objectNode != nil && ctx.TypeParser.ResolveToGlobalSymbol(ctx.Checker.GetSymbolAtLocation(objectNode)) == dateSymbol {
+			if objectNode != nil && ctx.TypeParser.ResolveToGlobalSymbol(ctx.TypeParser.GetSymbolAtLocation(objectNode)) == dateSymbol {
 				diags = append(diags, ctx.NewDiagnostic(
 					ctx.SourceFile,
 					scanner.GetErrorRangeForNode(ctx.SourceFile, node),

--- a/internal/rules/global_fetch.go
+++ b/internal/rules/global_fetch.go
@@ -59,7 +59,7 @@ func runGlobalFetch(ctx *rule.Context, checkInEffect bool) []*ast.Diagnostic {
 			inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagInEffect != 0
 			if inEffect == checkInEffect {
 				call := node.AsCallExpression()
-				if ctx.TypeParser.ResolveToGlobalSymbol(ctx.Checker.GetSymbolAtLocation(call.Expression)) == fetchSymbol {
+				if ctx.TypeParser.ResolveToGlobalSymbol(ctx.TypeParser.GetSymbolAtLocation(call.Expression)) == fetchSymbol {
 					diags = append(diags, ctx.NewDiagnostic(
 						ctx.SourceFile,
 						scanner.GetErrorRangeForNode(ctx.SourceFile, call.Expression),

--- a/internal/rules/global_random.go
+++ b/internal/rules/global_random.go
@@ -54,7 +54,7 @@ func runGlobalRandom(ctx *rule.Context, checkInEffect bool) []*ast.Diagnostic {
 			inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagInEffect != 0
 			if inEffect == checkInEffect {
 				prop := node.AsCallExpression().Expression.AsPropertyAccessExpression()
-				if prop.Name().Text() == "random" && ctx.TypeParser.ResolveToGlobalSymbol(ctx.Checker.GetSymbolAtLocation(prop.Expression)) == mathSymbol {
+				if prop.Name().Text() == "random" && ctx.TypeParser.ResolveToGlobalSymbol(ctx.TypeParser.GetSymbolAtLocation(prop.Expression)) == mathSymbol {
 					diags = append(diags, ctx.NewDiagnostic(
 						ctx.SourceFile,
 						scanner.GetErrorRangeForNode(ctx.SourceFile, node),

--- a/internal/rules/global_timers.go
+++ b/internal/rules/global_timers.go
@@ -74,7 +74,7 @@ func runGlobalTimers(ctx *rule.Context, checkInEffect bool) []*ast.Diagnostic {
 		if node.Kind == ast.KindCallExpression {
 			inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagInEffect != 0
 			if inEffect == checkInEffect {
-				resolved := ctx.TypeParser.ResolveToGlobalSymbol(ctx.Checker.GetSymbolAtLocation(node.AsCallExpression().Expression))
+				resolved := ctx.TypeParser.ResolveToGlobalSymbol(ctx.TypeParser.GetSymbolAtLocation(node.AsCallExpression().Expression))
 				if resolved != nil {
 					for name, globalSymbol := range globalSymbols {
 						if resolved != globalSymbol {

--- a/internal/rules/lazy_effect.go
+++ b/internal/rules/lazy_effect.go
@@ -135,7 +135,7 @@ func checkLazyEffectService(ctx *rule.Context, stmt *ast.Node) []*ast.Diagnostic
 		return nil
 	}
 
-	classSym := ctx.Checker.GetSymbolAtLocation(stmt.Name())
+	classSym := ctx.TypeParser.GetSymbolAtLocation(stmt.Name())
 	if classSym == nil {
 		return nil
 	}

--- a/internal/rules/leaking_requirements.go
+++ b/internal/rules/leaking_requirements.go
@@ -66,7 +66,7 @@ var LeakingRequirements = rule.Rule{
 				}
 			case ast.KindClassDeclaration:
 				if node.Name() != nil && node.AsClassDeclaration().HeritageClauses != nil {
-					classSym := ctx.Checker.GetSymbolAtLocation(node.Name())
+					classSym := ctx.TypeParser.GetSymbolAtLocation(node.Name())
 					if classSym != nil {
 						classType := ctx.Checker.GetTypeOfSymbolAtLocation(classSym, node)
 						if classType != nil {

--- a/internal/rules/missing_effect_context.go
+++ b/internal/rules/missing_effect_context.go
@@ -166,7 +166,7 @@ func findRelatedLayerProviderDiagnostics(
 	fullGraph := layergraph.ExtractLayerGraph(ctx.TypeParser, c, []*ast.Node{layerNode}, ctx.SourceFile, layergraph.ExtractLayerGraphOptions{
 		FollowSymbolsDepth: 2,
 	})
-	outlineGraph := layergraph.ExtractOutlineGraph(c, fullGraph)
+	outlineGraph := layergraph.ExtractOutlineGraph(ctx.TypeParser, c, fullGraph)
 	if outlineGraph == nil {
 		return nil
 	}

--- a/internal/rules/missing_effect_service_dependency.go
+++ b/internal/rules/missing_effect_service_dependency.go
@@ -74,7 +74,7 @@ func checkServiceDependencies(ctx *rule.Context, node *ast.Node) []*ast.Diagnost
 	options := serviceResult.Options
 
 	// Get the class symbol and type
-	classSym := ctx.Checker.GetSymbolAtLocation(className)
+	classSym := ctx.TypeParser.GetSymbolAtLocation(className)
 	if classSym == nil {
 		return nil
 	}

--- a/internal/rules/new_promise.go
+++ b/internal/rules/new_promise.go
@@ -30,7 +30,7 @@ var NewPromise = rule.Rule{
 
 			if node.Kind == ast.KindNewExpression {
 				newExpr := node.AsNewExpression()
-				if ctx.TypeParser.ResolveToGlobalSymbol(ctx.Checker.GetSymbolAtLocation(newExpr.Expression)) == promiseSymbol {
+				if ctx.TypeParser.ResolveToGlobalSymbol(ctx.TypeParser.GetSymbolAtLocation(newExpr.Expression)) == promiseSymbol {
 					diags = append(diags, ctx.NewDiagnostic(
 						ctx.SourceFile,
 						scanner.GetErrorRangeForNode(ctx.SourceFile, node),

--- a/internal/rules/process_env.go
+++ b/internal/rules/process_env.go
@@ -54,7 +54,7 @@ func runProcessEnv(ctx *rule.Context, checkInEffect bool) []*ast.Diagnostic {
 		inEffect := ctx.TypeParser.GetEffectContextFlags(node)&typeparser.EffectContextFlagInEffect != 0
 		if inEffect == checkInEffect {
 			if processNode := processEnvRoot(node); processNode != nil {
-				if ctx.TypeParser.ResolveToGlobalSymbol(ctx.Checker.GetSymbolAtLocation(processNode)) == processSymbol {
+				if ctx.TypeParser.ResolveToGlobalSymbol(ctx.TypeParser.GetSymbolAtLocation(processNode)) == processSymbol {
 					diags = append(diags, ctx.NewDiagnostic(
 						ctx.SourceFile,
 						scanner.GetErrorRangeForNode(ctx.SourceFile, node),

--- a/internal/rules/redundant_map_error.go
+++ b/internal/rules/redundant_map_error.go
@@ -166,7 +166,7 @@ func analyzeRedundantGeneratorMapErrorCandidate(tp *typeparser.TypeParser, c *ch
 			validYieldCount = -1
 			return true
 		}
-		if !mapperCanBeHoisted(c, generatorFunction.AsNode(), generatorCallNode, candidate.mapperNode) {
+		if !mapperCanBeHoisted(tp, c, generatorFunction.AsNode(), generatorCallNode, candidate.mapperNode) {
 			validYieldCount = -1
 			return true
 		}
@@ -241,8 +241,8 @@ func enclosingGeneratorCall(node *ast.Node) *ast.Node {
 	return nil
 }
 
-func mapperCanBeHoisted(c *checker.Checker, generatorFunctionNode *ast.Node, hoistLocation *ast.Node, mapperNode *ast.Node) bool {
-	if c == nil || generatorFunctionNode == nil || hoistLocation == nil || mapperNode == nil {
+func mapperCanBeHoisted(tp *typeparser.TypeParser, c *checker.Checker, generatorFunctionNode *ast.Node, hoistLocation *ast.Node, mapperNode *ast.Node) bool {
+	if tp == nil || c == nil || generatorFunctionNode == nil || hoistLocation == nil || mapperNode == nil {
 		return false
 	}
 
@@ -253,7 +253,7 @@ func mapperCanBeHoisted(c *checker.Checker, generatorFunctionNode *ast.Node, hoi
 			return canHoist
 		}
 		if node.Kind == ast.KindIdentifier && isHoistSensitiveValueReference(node) {
-			symbol := hoistSensitiveReferenceSymbol(c, node)
+			symbol := hoistSensitiveReferenceSymbol(tp, c, node)
 			if symbol != nil {
 				if allSymbolDeclarationsInsideNode(symbol, mapperNode) {
 					node.ForEachChild(walk)
@@ -303,8 +303,8 @@ func allSymbolDeclarationsOutsideNode(symbol *ast.Symbol, node *ast.Node) bool {
 	return true
 }
 
-func hoistSensitiveReferenceSymbol(c *checker.Checker, node *ast.Node) *ast.Symbol {
-	if c == nil || node == nil {
+func hoistSensitiveReferenceSymbol(tp *typeparser.TypeParser, c *checker.Checker, node *ast.Node) *ast.Symbol {
+	if tp == nil || c == nil || node == nil {
 		return nil
 	}
 	if node.Parent != nil && node.Parent.Kind == ast.KindShorthandPropertyAssignment {
@@ -312,7 +312,7 @@ func hoistSensitiveReferenceSymbol(c *checker.Checker, node *ast.Node) *ast.Symb
 			return symbol
 		}
 	}
-	return c.GetSymbolAtLocation(node)
+	return tp.GetSymbolAtLocation(node)
 }
 
 func generatorFunctionKeywordRange(sf *ast.SourceFile, generatorFunction *ast.FunctionExpression) core.TextRange {

--- a/internal/rules/scope_in_layer_effect.go
+++ b/internal/rules/scope_in_layer_effect.go
@@ -148,7 +148,7 @@ func matchClassWithDefaultLayer(tp *typeparser.TypeParser, c *checker.Checker, s
 	}
 
 	// Get the class symbol
-	classSym := c.GetSymbolAtLocation(node.Name())
+	classSym := tp.GetSymbolAtLocation(node.Name())
 	if classSym == nil {
 		return nil
 	}

--- a/internal/typeparser/effect_fn_opportunity.go
+++ b/internal/typeparser/effect_fn_opportunity.go
@@ -433,7 +433,7 @@ func (tp *TypeParser) areParametersReferencedIn(fnNode *ast.Node, nodes []*ast.N
 
 		// Check identifiers
 		if current.Kind == ast.KindIdentifier {
-			sym := c.GetSymbolAtLocation(current)
+			sym := tp.GetSymbolAtLocation(current)
 			if sym != nil && isSymbolDeclaredInRange(sym, paramsStart, paramsEnd) {
 				return true
 			}

--- a/internal/typeparser/get_type_at_location.go
+++ b/internal/typeparser/get_type_at_location.go
@@ -7,8 +7,9 @@ import (
 
 // GetTypeAtLocation wraps checker.GetTypeAtLocation with node-kind and JSX safety guards.
 // It returns nil when the node is nil, not an expression/type-node/declaration,
-// a JSX tag name, or a JSX attribute name. It also recovers from checker panics
-// (e.g. nil symbol dereferences on certain declaration nodes) and returns nil.
+// an import clause, a JSX tag name, or a JSX attribute name. It also recovers
+// from checker panics (e.g. nil symbol dereferences on certain declaration
+// nodes) and returns nil.
 func (tp TypeParser) GetTypeAtLocation(node *ast.Node) (result *checker.Type) {
 	if tp.checker == nil || node == nil {
 		return nil
@@ -36,6 +37,22 @@ func (tp TypeParser) getTypeAtLocationUncached(node *ast.Node) (result *checker.
 	}
 
 	if !ast.IsExpression(node) && !ast.IsTypeNode(node) && !ast.IsDeclaration(node) {
+		return nil
+	}
+
+	// ImportClause passes the IsDeclaration check above, but a clause without a
+	// default binding (import { A } from "x", import * as ns from "x") declares
+	// no symbol itself, and checker.GetTypeAtLocation panics dereferencing the
+	// nil symbol. The clause type is never useful to rules: its bindings are
+	// visited as separate nodes and carry the actual types.
+	if node.Kind == ast.KindImportClause {
+		return nil
+	}
+
+	// A meta property used as a call callee (import.defer(...)) has no type of
+	// its own and the checker debug-asserts when asked (checkMetaProperty); the
+	// enclosing call expression carries the meaningful type.
+	if node.Kind == ast.KindMetaProperty && node.Parent != nil && ast.IsCallExpression(node.Parent) && node.Parent.Expression() == node {
 		return nil
 	}
 

--- a/internal/typeparser/get_type_at_location_test.go
+++ b/internal/typeparser/get_type_at_location_test.go
@@ -1,0 +1,54 @@
+package typeparser
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
+// Import clauses without a default binding declare no symbol; before the
+// KindImportClause guard, checker.GetTypeAtLocation panicked on them with a
+// nil symbol dereference (recovered silently, see issue #301 investigation).
+func TestGetTypeAtLocationImportClause(t *testing.T) {
+	t.Parallel()
+
+	sources := map[string]string{
+		"/.src/dep.ts": `
+export const A = 1
+export type T = string
+const d = { A }
+export default d
+`,
+		"/.src/main.ts": `
+import { A } from "./dep.js"
+import * as ns from "./dep.js"
+import type { T } from "./dep.js"
+import d from "./dep.js"
+export const use: T = String(A + ns.A + d.A)
+`,
+	}
+
+	_, tp, sourceFiles, done := compileAndGetCheckerAndSourceFilesInternal(t, sources)
+	defer done()
+
+	var clauses []*ast.Node
+	var visit func(node *ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindImportClause {
+			clauses = append(clauses, node)
+		}
+		node.ForEachChild(visit)
+		return false
+	}
+	sourceFiles["/.src/main.ts"].AsNode().ForEachChild(visit)
+
+	if len(clauses) != 4 {
+		t.Fatalf("expected 4 import clauses, got %d", len(clauses))
+	}
+
+	for _, clause := range clauses {
+		if got := tp.GetTypeAtLocation(clause); got != nil {
+			t.Errorf("expected nil type for import clause %q, got %v", clause.Parent.Text(), got)
+		}
+	}
+}

--- a/internal/typeparser/helpers.go
+++ b/internal/typeparser/helpers.go
@@ -67,6 +67,21 @@ func (tp *TypeParser) GetTypeOfPropertyByName(t *checker.Type, name string) *che
 	return tp.checker.GetTypeOfPropertyOfType(t, name)
 }
 
+// GetSymbolAtLocation wraps checker.GetSymbolAtLocation with a meta-property
+// guard. Meta properties (import.meta, import.defer, new.target) never
+// reference a symbol rules care about, and the checker debug-asserts (panics)
+// when asked for `import.defer` used as an import-call callee. Always use
+// this instead of the raw checker call.
+func (tp *TypeParser) GetSymbolAtLocation(node *ast.Node) *ast.Symbol {
+	if tp == nil || tp.checker == nil || node == nil {
+		return nil
+	}
+	if node.Kind == ast.KindMetaProperty {
+		return nil
+	}
+	return tp.checker.GetSymbolAtLocation(node)
+}
+
 func (tp *TypeParser) resolveAliasedSymbol(sym *ast.Symbol) *ast.Symbol {
 	if tp == nil || tp.checker == nil {
 		return sym
@@ -84,7 +99,6 @@ func (tp *TypeParser) ResolveToGlobalSymbol(sym *ast.Symbol) *ast.Symbol {
 	if tp == nil || tp.checker == nil || sym == nil {
 		return nil
 	}
-	c := tp.checker
 
 	sym = tp.resolveAliasedSymbol(sym)
 	depth := 0
@@ -94,7 +108,7 @@ func (tp *TypeParser) ResolveToGlobalSymbol(sym *ast.Symbol) *ast.Symbol {
 			break
 		}
 
-		next := c.GetSymbolAtLocation(decl.Initializer)
+		next := tp.GetSymbolAtLocation(decl.Initializer)
 		if next == nil {
 			break
 		}

--- a/internal/typeparser/module_export_reference.go
+++ b/internal/typeparser/module_export_reference.go
@@ -16,12 +16,11 @@ func (tp *TypeParser) ReferenceSymbolAtNode(node *ast.Node) *ast.Symbol {
 	if tp == nil || tp.checker == nil || node == nil {
 		return nil
 	}
-	c := tp.checker
 
-	sym := c.GetSymbolAtLocation(node)
+	sym := tp.GetSymbolAtLocation(node)
 	if sym == nil && node.Kind == ast.KindPropertyAccessExpression {
 		if prop := node.AsPropertyAccessExpression(); prop != nil && prop.Name() != nil {
-			sym = c.GetSymbolAtLocation(prop.Name())
+			sym = tp.GetSymbolAtLocation(prop.Name())
 		}
 	}
 

--- a/internal/typeparser/pipeable.go
+++ b/internal/typeparser/pipeable.go
@@ -29,7 +29,6 @@ func (tp *TypeParser) IsPipeableType(t *checker.Type, atLocation *ast.Node) bool
 // This is used by the missedPipeableOpportunity rule to determine which
 // call expressions can be converted to pipe style.
 func (tp *TypeParser) IsSafelyPipeableCallee(callee *ast.Node) bool {
-	c := tp.checker
 	if callee == nil {
 		return false
 	}
@@ -56,7 +55,7 @@ func (tp *TypeParser) IsSafelyPipeableCallee(callee *ast.Node) bool {
 
 	// Simple identifiers - check if it's a module/namespace or standalone function
 	if ast.IsIdentifier(callee) {
-		sym := c.GetSymbolAtLocation(callee)
+		sym := tp.GetSymbolAtLocation(callee)
 		if sym == nil {
 			return false
 		}
@@ -86,7 +85,7 @@ func (tp *TypeParser) IsSafelyPipeableCallee(callee *ast.Node) bool {
 	if ast.IsPropertyAccessExpression(callee) {
 		propAccess := callee.AsPropertyAccessExpression()
 		subject := propAccess.Expression
-		sym := c.GetSymbolAtLocation(subject)
+		sym := tp.GetSymbolAtLocation(subject)
 		if sym == nil {
 			return false
 		}


### PR DESCRIPTION
## What changed

Two latent checker-panic paths in the diagnostic rules are fixed at the typeparser boundary, and the symbol-resolution call sites are audited to go through the guarded wrapper.

### 1. `import.defer(...)` crashed tsc and the LSP

`import.defer` parses as a meta property, and typescript-go's checker intentionally debug-asserts when asked for its symbol or type while it is the callee of an import call (`checkMetaProperty`). Any rule that resolves arbitrary call callees — `catchUnfailableEffect` (via piping flows), `globalFetch`, `globalTimers` — panicked on files containing:

```ts
export {}
import.defer("./module")
```

In tsc mode this crashed the whole compile; in LSP mode it killed the server.

**Fix:** a new `TypeParser.GetSymbolAtLocation` wrapper skips `KindMetaProperty` nodes (`import.meta`, `import.defer`, `new.target` never reference a symbol rules care about) before delegating to the checker. All production call sites across rules, typeparser internals, layergraph, refactors, and LSP hooks now use it — `layergraph.ExtractOutlineGraph` and the `redundantMapError` hoisting helpers now receive the `TypeParser` to make that possible. `TypeParser.GetTypeAtLocation` gains the same guard for meta properties in call-callee position.

### 2. Bindingless import clauses hit a nil-symbol panic

For import clauses without a default binding (`import { A } from "x"`, `import * as ns from "x"`, `import type { T } from "x"`), the clause node passes `ast.IsDeclaration` but declares no symbol, so `checker.GetTypeAtLocation` panicked on a nil symbol dereference. The every-node sweep rules (`anyUnknownInErrorContext`, `effectInFailure`) hit this on virtually every file with imports; the panic was silently swallowed by the `recover()` in the wrapper. `GetTypeAtLocation` now skips `KindImportClause` explicitly — the clause's bindings are visited as separate nodes and carry the actual types.

### New stress tests

`internal/effecttest/rule_sweep_test.go` runs the every-node diagnostics over three corpora under a per-case watchdog (120s) that fails on panic or non-termination:

- `TestRuleSweepImportDefer` — fast regression for the crash above
- `TestRuleSweepTypeScriptCorpus` — 316 typescript-go compiler/conformance test files (exotic syntax; skipped with `-short`)
- `TestRuleSweepEffectFixtures` — all 248 effect-v4 fixtures with `anyUnknownInErrorContext` force-enabled, which regular fixture runs never do (skipped with `-short`)
- `TestRuleSweepEffectPackageSources` — effect's own shipped `src/*.ts` pulled into the program as checked files
- `TestRuleSweepUnknownEffectVersion` — the v3/unknown property-iteration fallback path

`internal/typeparser/get_type_at_location_test.go` covers the import-clause guard for all four clause shapes.

## Validation

- `pnpm lint` — 0 issues
- `pnpm check` — clean
- `pnpm test` — full Go + CLI suite green (the corpus sweep previously crashed the test binary on `importDeferCallCommonJS.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)