### PR TITLE
Fix layer magic ordering for unrelated layers

### DIFF
--- a/.changeset/layer-magic-unrelated-order.md
+++ b/.changeset/layer-magic-unrelated-order.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix layer magic ordering for unrelated layers so layers that only require services are composed after layers that provide no services.

--- a/internal/layergraph/magic.go
+++ b/internal/layergraph/magic.go
@@ -39,7 +39,7 @@ func ConvertOutlineGraphToLayerMagic(
 		rootIndices = append(rootIndices, idx)
 	}
 
-	// Sort roots by provides count descending, then requires count descending
+	// Sort roots by layer shape, then provides/requires count.
 	slices.SortFunc(rootIndices, func(a, b graph.NodeIndex) int {
 		return compareNodesByOrder(reversedGraph, a, b)
 	})
@@ -95,7 +95,7 @@ func ConvertOutlineGraphToLayerMagic(
 }
 
 // dfsPostOrderWithOrder performs an iterative post-order DFS with custom node ordering.
-// Neighbors are sorted by provides count descending, then requires count descending.
+// Neighbors are sorted by layer shape, then provides/requires count.
 func dfsPostOrderWithOrder(
 	g *graph.Graph[LayerOutlineGraphNodeInfo, struct{}],
 	start []graph.NodeIndex,
@@ -145,7 +145,7 @@ func dfsPostOrderWithOrder(
 }
 
 // neighborsOutgoingSorted returns outgoing neighbor indices sorted by the layer ordering:
-// provides count descending, then requires count descending.
+// layer shape, then provides/requires count.
 func neighborsOutgoingSorted(
 	g *graph.Graph[LayerOutlineGraphNodeInfo, struct{}],
 	nodeIndex graph.NodeIndex,
@@ -157,7 +157,8 @@ func neighborsOutgoingSorted(
 	return neighbors
 }
 
-// compareNodesByOrder compares two nodes by provides count descending, then requires count descending.
+// compareNodesByOrder compares two nodes by composition priority:
+// both provides/requires, only provides, neither, only requires.
 func compareNodesByOrder(
 	g *graph.Graph[LayerOutlineGraphNodeInfo, struct{}],
 	a, b graph.NodeIndex,
@@ -165,10 +166,31 @@ func compareNodesByOrder(
 	nodeA, _ := g.GetNode(a)
 	nodeB, _ := g.GetNode(b)
 
+	if rankDiff := layerOrderRank(nodeA) - layerOrderRank(nodeB); rankDiff != 0 {
+		return rankDiff
+	}
 	// Sort by provides count descending (reverse order)
 	if lenDiff := len(nodeB.Provides) - len(nodeA.Provides); lenDiff != 0 {
 		return lenDiff
 	}
 	// Tiebreak by requires count descending (reverse order)
-	return len(nodeB.Requires) - len(nodeA.Requires)
+	if lenDiff := len(nodeB.Requires) - len(nodeA.Requires); lenDiff != 0 {
+		return lenDiff
+	}
+	return a - b
+}
+
+func layerOrderRank(node LayerOutlineGraphNodeInfo) int {
+	hasProvides := len(node.Provides) > 0
+	hasRequires := len(node.Requires) > 0
+	switch {
+	case hasProvides && hasRequires:
+		return 0
+	case hasProvides:
+		return 1
+	case !hasRequires:
+		return 2
+	default:
+		return 3
+	}
 }

--- a/internal/layergraph/magic_test.go
+++ b/internal/layergraph/magic_test.go
@@ -44,6 +44,28 @@ func TestCompareNodesByOrder(t *testing.T) {
 	}
 }
 
+func TestCompareNodesByOrderLayerShapes(t *testing.T) {
+	t.Parallel()
+	g := graph.New[LayerOutlineGraphNodeInfo, struct{}]()
+
+	bothProvidesAndRequires := g.AddNode(makeOutlineNode(1, 1))
+	onlyProvides := g.AddNode(makeOutlineNode(1, 0))
+	noProvidesOrRequires := g.AddNode(makeOutlineNode(0, 0))
+	onlyRequires := g.AddNode(makeOutlineNode(0, 1))
+
+	ordered := []graph.NodeIndex{
+		bothProvidesAndRequires,
+		onlyProvides,
+		noProvidesOrRequires,
+		onlyRequires,
+	}
+	for i := range len(ordered) - 1 {
+		if cmp := compareNodesByOrder(g, ordered[i], ordered[i+1]); cmp >= 0 {
+			t.Fatalf("expected node at order %d to sort before order %d, got %d", i, i+1, cmp)
+		}
+	}
+}
+
 func TestDFSPostOrderWithOrder(t *testing.T) {
 	t.Parallel()
 	// Build a small graph:
@@ -112,6 +134,46 @@ func TestDFSPostOrderWithOrderMultipleRoots(t *testing.T) {
 	}
 	if len(result[1].Provides) != 1 {
 		t.Errorf("expected second node to have 1 provides, got %d", len(result[1].Provides))
+	}
+}
+
+func TestConvertOutlineGraphToLayerMagicOrdersUnrelatedLayers(t *testing.T) {
+	t.Parallel()
+	g := graph.New[LayerOutlineGraphNodeInfo, struct{}]()
+
+	bothProvidesAndRequires := makeOutlineNode(1, 1)
+	onlyProvides := makeOutlineNode(1, 0)
+	noProvidesOrRequires := makeOutlineNode(0, 0)
+	onlyRequires := makeOutlineNode(0, 1)
+
+	// Add nodes in an order that differs from the expected composition order to
+	// verify unrelated roots are sorted by their layer shape, not source order.
+	g.AddNode(noProvidesOrRequires)
+	g.AddNode(onlyRequires)
+	g.AddNode(onlyProvides)
+	g.AddNode(bothProvidesAndRequires)
+
+	result := ConvertOutlineGraphToLayerMagic(nil, g, nil)
+	if len(result.Nodes) != 4 {
+		t.Fatalf("expected 4 nodes, got %d", len(result.Nodes))
+	}
+
+	expected := []LayerOutlineGraphNodeInfo{
+		bothProvidesAndRequires,
+		onlyProvides,
+		noProvidesOrRequires,
+		onlyRequires,
+	}
+	for i, expectedNode := range expected {
+		if result.Nodes[i].Node != expectedNode.Node {
+			t.Fatalf("result[%d] expected provides=%d requires=%d, got provides=%d requires=%d",
+				i,
+				len(expectedNode.Provides),
+				len(expectedNode.Requires),
+				len(result.Nodes[i].ProvidedTypes),
+				len(result.Nodes[i].RequiredTypes),
+			)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Rank unrelated layer magic nodes by shape before count-based tie breakers
- Compose require-only layers after inert layers that have no provides or requires
- Add unit coverage for unrelated layer ordering cases

## Validation
- pnpm setup-repo
- pnpm lint
- pnpm check
- pnpm test