### PR TITLE
Expose additional TypeScript-Go shims

### DIFF
--- a/.changeset/add-shim-exposures.md
+++ b/.changeset/add-shim-exposures.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Expose additional generated shims for TypeScript-Go language-service and checker internals, and add an `etsapi` helper for rendering structural schema statements from a resolved type.

--- a/etsapi/structural_schema.go
+++ b/etsapi/structural_schema.go
@@ -1,0 +1,50 @@
+package etsapi
+
+import (
+	"context"
+
+	"github.com/effect-ts/tsgo/internal/rewriter"
+	"github.com/effect-ts/tsgo/internal/schemagen"
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/ls/change"
+	"github.com/microsoft/typescript-go/shim/ls/lsconv"
+	"github.com/microsoft/typescript-go/shim/ls/lsutil"
+	"github.com/microsoft/typescript-go/shim/lsp/lsproto"
+)
+
+// RenderStructuralSchemaStatements converts a resolved TypeScript type into
+// rendered Effect Schema statements using the same structural generator as the
+// structuralTypeToSchema refactor.
+func (tp *TypeParser) RenderStructuralSchemaStatements(sourceFile *ast.SourceFile, name string, t *checker.Type, isExported bool) []string {
+	if tp == nil || tp.inner == nil || tp.program == nil || tp.checker == nil || sourceFile == nil || name == "" || t == nil {
+		return nil
+	}
+
+	converters := lsconv.NewConverters(lsproto.PositionEncodingKindUTF8, func(fileName string) *lsconv.LSPLineMap {
+		if fileName == sourceFile.FileName() {
+			return lsconv.ComputeLSPLineStarts(sourceFile.Text())
+		}
+		return nil
+	})
+	rawTracker := change.NewTracker(context.Background(), tp.program.Options(), lsutil.GetDefaultFormatCodeSettings(), converters)
+	tracker := rewriter.NewTracker(rawTracker)
+
+	gen := schemagen.NewStructuralSchemaGen(tracker, tp.inner, sourceFile, tp.checker, tp.inner.SupportedEffectVersion())
+	statements := gen.Process(map[string]*checker.Type{name: t}, sourceFile.AsNode(), isExported)
+	if len(statements) == 0 {
+		return nil
+	}
+
+	rendered := make([]string, 0, len(statements))
+	for _, statement := range statements {
+		if statement == nil {
+			continue
+		}
+		text, _ := change.Tracker_getNonformattedText(rawTracker, statement, sourceFile)
+		if text != "" {
+			rendered = append(rendered, text)
+		}
+	}
+	return rendered
+}

--- a/etsapi/type_parser.go
+++ b/etsapi/type_parser.go
@@ -10,6 +10,7 @@ import (
 
 // TypeParser wraps the internal type parser with a narrow public API.
 type TypeParser struct {
+	program checker.Program
 	inner   *typeparser.TypeParser
 	checker *checker.Checker
 }
@@ -42,7 +43,7 @@ type SchemaTypes struct {
 
 // NewTypeParser builds a checker-backed TypeParser.
 func NewTypeParser(program checker.Program, checker *checker.Checker) *TypeParser {
-	return &TypeParser{inner: typeparser.NewTypeParser(program, checker), checker: checker}
+	return &TypeParser{program: program, inner: typeparser.NewTypeParser(program, checker), checker: checker}
 }
 
 // GetTypeAtLocation returns the checker type for node using the parser's safety guards.

--- a/shim/checker/extra-shim.json
+++ b/shim/checker/extra-shim.json
@@ -4,7 +4,26 @@
     "Checker": ["isTypeAssignableTo", "isArrayType", "isReadonlyArrayType", "getIndexInfosOfType", "getTypeArguments", "getLiteralTypeFromProperty", "getSymbolIfSameReference", "getSymbolOfDeclaration", "isSignatureAssignableTo", "isReferenceToType", "newFunctionType", "newCallSignature", "isSymbolAssigned", "isPastLastAssignment"]
   },
   "ExtraFields": {
-    "Checker": ["getGlobalPromiseTypeChecked", "emptyGenericType"],
-    "IndexInfo": ["keyType", "valueType"]
+    "Checker": [
+      "getGlobalPromiseTypeChecked",
+      "emptyGenericType",
+      "symbolReferenceLinks",
+      "valueSymbolLinks",
+      "aliasSymbolLinks",
+      "moduleSymbolLinks",
+      "typeAliasLinks",
+      "declaredTypeLinks",
+      "symbolNodeLinks",
+      "typeNodeLinks"
+    ],
+    "IndexInfo": ["keyType", "valueType"],
+    "SymbolReferenceLinks": ["referenceKinds"],
+    "ValueSymbolLinks": ["resolvedType", "writeType"],
+    "AliasSymbolLinks": ["immediateTarget", "aliasTarget", "referenced"],
+    "ModuleSymbolLinks": ["resolvedExports", "exportsChecked"],
+    "TypeAliasLinks": ["declaredType"],
+    "DeclaredTypeLinks": ["declaredType"],
+    "SymbolNodeLinks": ["resolvedSymbol"],
+    "TypeNodeLinks": ["resolvedType"]
   }
 }

--- a/shim/checker/shim.go
+++ b/shim/checker/shim.go
@@ -32,6 +32,21 @@ const AccessFlagsSuppressNoImplicitAnyError = checker.AccessFlagsSuppressNoImpli
 const AccessFlagsWriting = checker.AccessFlagsWriting
 var AfterCheckSourceFileCallback = checker.AfterCheckSourceFileCallback
 type AliasSymbolLinks = checker.AliasSymbolLinks
+type extra_AliasSymbolLinks struct {
+  immediateTarget *ast.Symbol
+  aliasTarget *ast.Symbol
+  referenced bool
+  typeOnlyDeclaration *ast.Node
+}
+func AliasSymbolLinks_immediateTarget(v *checker.AliasSymbolLinks) *ast.Symbol {
+  return ((*extra_AliasSymbolLinks)(unsafe.Pointer(v))).immediateTarget
+}
+func AliasSymbolLinks_aliasTarget(v *checker.AliasSymbolLinks) *ast.Symbol {
+  return ((*extra_AliasSymbolLinks)(unsafe.Pointer(v))).aliasTarget
+}
+func AliasSymbolLinks_referenced(v *checker.AliasSymbolLinks) bool {
+  return ((*extra_AliasSymbolLinks)(unsafe.Pointer(v))).referenced
+}
 type ArrayLiteralLinks = checker.ArrayLiteralLinks
 type ArrayToSingleTypeMapper = checker.ArrayToSingleTypeMapper
 type ArrayTypeMapper = checker.ArrayTypeMapper
@@ -435,6 +450,30 @@ func Checker_getGlobalPromiseTypeChecked(v *checker.Checker) func() *checker.Typ
 func Checker_emptyGenericType(v *checker.Checker) *checker.Type {
   return ((*extra_Checker)(unsafe.Pointer(v))).emptyGenericType
 }
+func Checker_symbolReferenceLinks(v *checker.Checker) core.LinkStore[*ast.Symbol, checker.SymbolReferenceLinks] {
+  return ((*extra_Checker)(unsafe.Pointer(v))).symbolReferenceLinks
+}
+func Checker_valueSymbolLinks(v *checker.Checker) core.LinkStore[*ast.Symbol, checker.ValueSymbolLinks] {
+  return ((*extra_Checker)(unsafe.Pointer(v))).valueSymbolLinks
+}
+func Checker_aliasSymbolLinks(v *checker.Checker) core.LinkStore[*ast.Symbol, checker.AliasSymbolLinks] {
+  return ((*extra_Checker)(unsafe.Pointer(v))).aliasSymbolLinks
+}
+func Checker_moduleSymbolLinks(v *checker.Checker) core.LinkStore[*ast.Symbol, checker.ModuleSymbolLinks] {
+  return ((*extra_Checker)(unsafe.Pointer(v))).moduleSymbolLinks
+}
+func Checker_typeAliasLinks(v *checker.Checker) core.LinkStore[*ast.Symbol, checker.TypeAliasLinks] {
+  return ((*extra_Checker)(unsafe.Pointer(v))).typeAliasLinks
+}
+func Checker_declaredTypeLinks(v *checker.Checker) core.LinkStore[*ast.Symbol, checker.DeclaredTypeLinks] {
+  return ((*extra_Checker)(unsafe.Pointer(v))).declaredTypeLinks
+}
+func Checker_symbolNodeLinks(v *checker.Checker) core.LinkStore[*ast.Node, checker.SymbolNodeLinks] {
+  return ((*extra_Checker)(unsafe.Pointer(v))).symbolNodeLinks
+}
+func Checker_typeNodeLinks(v *checker.Checker) core.LinkStore[*ast.Node, checker.TypeNodeLinks] {
+  return ((*extra_Checker)(unsafe.Pointer(v))).typeNodeLinks
+}
 //go:linkname CompareTypes github.com/microsoft/typescript-go/internal/checker.CompareTypes
 func CompareTypes(t1 *checker.Type, t2 *checker.Type) int
 type CompositeSignature = checker.CompositeSignature
@@ -472,6 +511,16 @@ const DeclarationSpacesExportType = checker.DeclarationSpacesExportType
 const DeclarationSpacesExportValue = checker.DeclarationSpacesExportValue
 const DeclarationSpacesNone = checker.DeclarationSpacesNone
 type DeclaredTypeLinks = checker.DeclaredTypeLinks
+type extra_DeclaredTypeLinks struct {
+  declaredType *checker.Type
+  interfaceChecked bool
+  indexSignaturesChecked bool
+  typeParametersChecked bool
+  enumChecked bool
+}
+func DeclaredTypeLinks_declaredType(v *checker.DeclaredTypeLinks) *checker.Type {
+  return ((*extra_DeclaredTypeLinks)(unsafe.Pointer(v))).declaredType
+}
 type DeferredSymbolLinks = checker.DeferredSymbolLinks
 type DeferredTypeMapper = checker.DeferredTypeMapper
 type DiagnosticAndArguments = checker.DiagnosticAndArguments
@@ -706,6 +755,17 @@ const MinArgumentCountFlagsNone = checker.MinArgumentCountFlagsNone
 const MinArgumentCountFlagsStrongArityForUntypedJS = checker.MinArgumentCountFlagsStrongArityForUntypedJS
 const MinArgumentCountFlagsVoidIsNonOptional = checker.MinArgumentCountFlagsVoidIsNonOptional
 type ModuleSymbolLinks = checker.ModuleSymbolLinks
+type extra_ModuleSymbolLinks struct {
+  resolvedExports ast.SymbolTable
+  typeOnlyExportStarMap map[string]*ast.Node
+  exportsChecked bool
+}
+func ModuleSymbolLinks_resolvedExports(v *checker.ModuleSymbolLinks) ast.SymbolTable {
+  return ((*extra_ModuleSymbolLinks)(unsafe.Pointer(v))).resolvedExports
+}
+func ModuleSymbolLinks_exportsChecked(v *checker.ModuleSymbolLinks) bool {
+  return ((*extra_ModuleSymbolLinks)(unsafe.Pointer(v))).exportsChecked
+}
 type NarrowedTypeKey = checker.NarrowedTypeKey
 //go:linkname NewChecker github.com/microsoft/typescript-go/internal/checker.NewChecker
 func NewChecker(program checker.Program, tracer *checker.Tracer) (*checker.Checker, *sync.Mutex)
@@ -893,7 +953,19 @@ const SymbolFormatFlagsUseOnlyExternalAliasing = checker.SymbolFormatFlagsUseOnl
 const SymbolFormatFlagsWriteComputedProps = checker.SymbolFormatFlagsWriteComputedProps
 const SymbolFormatFlagsWriteTypeParametersOrArguments = checker.SymbolFormatFlagsWriteTypeParametersOrArguments
 type SymbolNodeLinks = checker.SymbolNodeLinks
+type extra_SymbolNodeLinks struct {
+  resolvedSymbol *ast.Symbol
+}
+func SymbolNodeLinks_resolvedSymbol(v *checker.SymbolNodeLinks) *ast.Symbol {
+  return ((*extra_SymbolNodeLinks)(unsafe.Pointer(v))).resolvedSymbol
+}
 type SymbolReferenceLinks = checker.SymbolReferenceLinks
+type extra_SymbolReferenceLinks struct {
+  referenceKinds ast.SymbolFlags
+}
+func SymbolReferenceLinks_referenceKinds(v *checker.SymbolReferenceLinks) ast.SymbolFlags {
+  return ((*extra_SymbolReferenceLinks)(unsafe.Pointer(v))).referenceKinds
+}
 type SymbolTrackerImpl = checker.SymbolTrackerImpl
 type TemplateLiteralType = checker.TemplateLiteralType
 type Ternary = checker.Ternary
@@ -911,6 +983,15 @@ type TupleType = checker.TupleType
 type Type = checker.Type
 type TypeAlias = checker.TypeAlias
 type TypeAliasLinks = checker.TypeAliasLinks
+type extra_TypeAliasLinks struct {
+  declaredType *checker.Type
+  typeParameters []*checker.Type
+  instantiations map[checker.CacheHashKey]*checker.Type
+  isConstructorDeclaredProperty bool
+}
+func TypeAliasLinks_declaredType(v *checker.TypeAliasLinks) *checker.Type {
+  return ((*extra_TypeAliasLinks)(unsafe.Pointer(v))).declaredType
+}
 type TypeBase = checker.TypeBase
 type TypeComparer = checker.TypeComparer
 type TypeData = checker.TypeData
@@ -1103,6 +1184,13 @@ const TypeMapperKindMerged = checker.TypeMapperKindMerged
 const TypeMapperKindSimple = checker.TypeMapperKindSimple
 const TypeMapperKindUnknown = checker.TypeMapperKindUnknown
 type TypeNodeLinks = checker.TypeNodeLinks
+type extra_TypeNodeLinks struct {
+  resolvedType *checker.Type
+  outerTypeParameters []*checker.Type
+}
+func TypeNodeLinks_resolvedType(v *checker.TypeNodeLinks) *checker.Type {
+  return ((*extra_TypeNodeLinks)(unsafe.Pointer(v))).resolvedType
+}
 type TypeParameter = checker.TypeParameter
 type TypePredicate = checker.TypePredicate
 type TypePredicateKind = checker.TypePredicateKind
@@ -1136,6 +1224,21 @@ type UnusedKind = checker.UnusedKind
 const UnusedKindLocal = checker.UnusedKindLocal
 const UnusedKindParameter = checker.UnusedKindParameter
 type ValueSymbolLinks = checker.ValueSymbolLinks
+type extra_ValueSymbolLinks struct {
+  resolvedType *checker.Type
+  writeType *checker.Type
+  target *ast.Symbol
+  mapper *checker.TypeMapper
+  nameType *checker.Type
+  containingType *checker.Type
+  functionOrConstructorChecked bool
+}
+func ValueSymbolLinks_resolvedType(v *checker.ValueSymbolLinks) *checker.Type {
+  return ((*extra_ValueSymbolLinks)(unsafe.Pointer(v))).resolvedType
+}
+func ValueSymbolLinks_writeType(v *checker.ValueSymbolLinks) *checker.Type {
+  return ((*extra_ValueSymbolLinks)(unsafe.Pointer(v))).writeType
+}
 //go:linkname ValueToString github.com/microsoft/typescript-go/internal/checker.ValueToString
 func ValueToString(value any) string
 type VarianceFlags = checker.VarianceFlags

--- a/shim/ls/extra-shim.json
+++ b/shim/ls/extra-shim.json
@@ -1,4 +1,5 @@
 {
+  "ExtraFunctions": ["getJSDocOrTag"],
   "ExtraMethods": {
     "LanguageService": ["getQuickInfoAndDocumentationForSymbol"]
   },

--- a/shim/ls/shim.go
+++ b/shim/ls/shim.go
@@ -152,3 +152,5 @@ const SourceTypeOnlyAlias = ls.SourceTypeOnlyAlias
 type SymbolAndEntries = ls.SymbolAndEntries
 type SymbolAndEntriesData = ls.SymbolAndEntriesData
 var TriggerCharacters = ls.TriggerCharacters
+//go:linkname GetJSDocOrTag github.com/microsoft/typescript-go/internal/ls.getJSDocOrTag
+func GetJSDocOrTag(c *checker.Checker, node *ast.Node) *ast.Node


### PR DESCRIPTION
## Summary
- expose getJSDocOrTag from the ls shim config
- expose additional checker link stores and link field accessors through generated shims
- add etsapi RenderStructuralSchemaStatements for rendering structural schema statements from a resolved name/type pair
- add a patch changeset for the shim and etsapi additions

## Validation
- pnpm setup-repo
- pnpm lint
- pnpm check
- pnpm test