### PR TITLE
ci: modernize release workflow publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -51,18 +51,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
           cache: false
 
       - name: Cache Go build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build
@@ -72,12 +72,12 @@ jobs:
             go-build-ci-${{ runner.os }}-
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
@@ -97,7 +97,7 @@ jobs:
         run: pnpm test
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9
           args: ./...

--- a/.github/workflows/generate-latest-branch.yml
+++ b/.github/workflows/generate-latest-branch.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: main
@@ -40,13 +40,13 @@ jobs:
         run: git config submodule.typescript-go.ignore dirty
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
           cache: false
 
       - name: Cache Go build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build
@@ -56,7 +56,7 @@ jobs:
             go-build-generate-latest-${{ runner.os }}-
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 

--- a/.github/workflows/refresh-flake-hash.yml
+++ b/.github/workflows/refresh-flake-hash.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Checkout PR branch
         if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Checkout requested branch
         if: github.event_name != 'pull_request_target' && inputs.target_ref != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ inputs.target_ref }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Checkout current branch
         if: github.event_name != 'pull_request_target' && inputs.target_ref == ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,19 +41,19 @@ jobs:
             ref: generated/latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ matrix.binary.ref }}
           submodules: recursive
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
           cache-dependency-path: "**/go.sum"
 
       - name: Cache Go build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/go-build
           key: go-build-release-${{ matrix.binary.name }}-${{ matrix.npm_target }}-${{ hashFiles('**/go.sum') }}
@@ -61,12 +61,12 @@ jobs:
             go-build-release-${{ matrix.binary.name }}-${{ matrix.npm_target }}-
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
@@ -87,7 +87,7 @@ jobs:
         run: pnpm release:prepare --target ${{ matrix.npm_target }} --binary-name ${{ matrix.binary.name }} --skip-cli
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.npm_target }}__${{ matrix.binary.name }}
           path: |
@@ -106,18 +106,18 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
@@ -125,7 +125,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download platform binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: _release-artifacts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,9 +116,6 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Upgrade npm for publish support
-        run: npm install -g npm@latest
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/update-typescript-go.yml
+++ b/.github/workflows/update-typescript-go.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
@@ -36,13 +36,13 @@ jobs:
         run: git config submodule.typescript-go.ignore dirty
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
           cache: false
 
       - name: Cache Go build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build
@@ -52,12 +52,12 @@ jobs:
             go-build-update-typescript-go-${{ runner.os }}-
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
@@ -198,7 +198,7 @@ jobs:
     steps:
       - name: Create PR validation check
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           HEAD_SHA: ${{ needs.update.outputs.head_sha }}
           PR_NUMBER: ${{ needs.update.outputs.pr_number }}
@@ -219,20 +219,20 @@ jobs:
             core.setOutput('check_run_id', String(data.id))
 
       - name: Checkout generated PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ needs.update.outputs.head_sha }}
           submodules: recursive
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
           cache: false
 
       - name: Cache Go build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build
@@ -242,12 +242,12 @@ jobs:
             go-build-update-typescript-go-${{ runner.os }}-
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
@@ -275,7 +275,7 @@ jobs:
       - name: Validate lint
         id: validate_lint
         continue-on-error: true
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9
           args: ./...
@@ -284,7 +284,7 @@ jobs:
 
       - name: Complete PR validation check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           CHECK_RUN_ID: ${{ steps.create_check.outputs.check_run_id }}
           PR_NUMBER: ${{ needs.update.outputs.pr_number }}

--- a/.github/workflows/validate-generated-latest.yml
+++ b/.github/workflows/validate-generated-latest.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Create PR validation check
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           HEAD_SHA: ${{ inputs.head_sha }}
           PR_NUMBER: ${{ inputs.pr_number }}
@@ -58,20 +58,20 @@ jobs:
             core.setOutput('check_run_id', String(data.id))
 
       - name: Checkout generated latest PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ inputs.head_sha }}
           submodules: recursive
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
           cache: false
 
       - name: Cache Go build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build
@@ -81,12 +81,12 @@ jobs:
             go-build-validate-generated-latest-${{ runner.os }}-
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
@@ -114,7 +114,7 @@ jobs:
       - name: Validate lint
         id: validate_lint
         continue-on-error: true
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9
           args: ./...
@@ -123,7 +123,7 @@ jobs:
 
       - name: Complete PR validation check
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           CHECK_RUN_ID: ${{ steps.create_check.outputs.check_run_id }}
           PR_NUMBER: ${{ inputs.pr_number }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -21,18 +21,18 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 


### PR DESCRIPTION
## Summary
- remove the global npm@latest upgrade from the release publish job
- rely on the Node 24 bundled npm for provenance/OIDC publishing to avoid missing npm internals such as sigstore
- update root GitHub workflow actions to current Node 24 runtime majors

## Testing
- git diff --check