### PR TITLE
chore: add minor release changeset

### DIFF
--- a/.changeset/minor-release-workflow-actions.md
+++ b/.changeset/minor-release-workflow-actions.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": minor
+---
+
+Modernize release workflow publishing and GitHub Actions runtimes.


### PR DESCRIPTION
## Summary
- add a minor changeset for @effect/tsgo covering release workflow publishing and GitHub Actions runtime modernization

## Testing
- not run; changeset-only Markdown change