### PR TITLE
feat: support aliased native TypeScript packages

### DIFF
--- a/.changeset/typescript-native-package.md
+++ b/.changeset/typescript-native-package.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": minor
+---
+
+Add `effect-tsgo patch --typescript-package <name>` and automatically fall back from `typescript` to `@typescript/native` when resolving the native TypeScript package to patch.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This will guide you through the installation process, which includes:
 4. Hinting at any additional editor configuration needed to ensure the LSP is active.
 
 > [!NOTE]
-> At the moment, you still need a native TypeScript install alongside `@effect/tsgo`: `typescript` >= 7 (e.g. `typescript@latest` or `typescript@next`). `effect-tsgo patch` selects the packaged Effect binary whose TypeScript git head matches the installed `typescript` package.
+> At the moment, you still need a native TypeScript install alongside `@effect/tsgo`: `typescript` >= 7 (e.g. `typescript@latest` or `typescript@next`) or an alias such as `@typescript/native`. `effect-tsgo patch` tries `typescript`, then `@typescript/native`, and accepts `--typescript-package <name>` to try a custom package name first.
 
 ## Diagnostic Status
 

--- a/_packages/tsgo/src/cli.ts
+++ b/_packages/tsgo/src/cli.ts
@@ -7,30 +7,61 @@ import * as Console from "effect/Console"
 import * as Data from "effect/Data"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
+import * as Option from "effect/Option"
 import * as Path from "effect/Path"
+import * as Schema from "effect/Schema"
 import * as Command from "effect/unstable/cli/Command"
 import * as Flag from "effect/unstable/cli/Flag"
 import { configCommand } from "./config.js"
 import { setupCommand } from "./setup/index.js"
-import { typescriptBackend, type NativeBackend } from "./setup/consts.js"
+import { defaultTypescriptPackageNames, isNativeTypescriptVersion } from "./setup/consts.js"
 import * as pkgJson from "../package.json" with { type: "json" }
 
 class NativeBackendNotInstalledError extends Data.TaggedError("NativeBackendNotInstalledError")<{
-  readonly details: string
+  readonly packageNames: ReadonlyArray<string>
 }> {
   get message(): string {
     return (
       "No native TypeScript backend is installed. " +
-      "Install `typescript` >= 7 first (e.g. `typescript@latest` or `typescript@next`)."
+      "Install `typescript` >= 7 first (e.g. `typescript@latest` or `typescript@next`) " +
+      "or `@typescript/native` (e.g. `@typescript/native@npm:typescript@latest`). " +
+      "Tried: " + this.packageNames.join(", ") + "."
     )
   }
 }
 
-class MissingTypeScriptMetadataError extends Data.TaggedError("MissingTypeScriptMetadataError")<{
+class PackageNotFoundError extends Data.TaggedError("PackageNotFoundError")<{
   readonly packageName: string
 }> {
   get message(): string {
-    return `Installed ${this.packageName} package.json does not contain a gitHead. Unable to select a compatible Effect binary.`
+    return `Unable to resolve ${this.packageName}.`
+  }
+}
+
+class ParsePackageJsonError extends Data.TaggedError("ParsePackageJsonError")<{
+  readonly packageName: string
+  readonly packageJsonPath: string
+  readonly reason: string
+}> {
+  get message(): string {
+    return `Unable to parse ${this.packageName} package.json at ${this.packageJsonPath}: ${this.reason}`
+  }
+}
+
+class BinaryMetadataNotFoundError extends Data.TaggedError("BinaryMetadataNotFoundError")<{
+  readonly metadataPath: string
+}> {
+  get message(): string {
+    return `Binary metadata not found at ${this.metadataPath}.`
+  }
+}
+
+class ParseBinaryMetadataError extends Data.TaggedError("ParseBinaryMetadataError")<{
+  readonly metadataPath: string
+  readonly reason: string
+}> {
+  get message(): string {
+    return `Unable to parse binary metadata at ${this.metadataPath}: ${this.reason}`
   }
 }
 
@@ -130,7 +161,10 @@ class VerificationFailedError extends Data.TaggedError("VerificationFailedError"
 
 type CliDomainError =
   | NativeBackendNotInstalledError
-  | MissingTypeScriptMetadataError
+  | PackageNotFoundError
+  | ParsePackageJsonError
+  | BinaryMetadataNotFoundError
+  | ParseBinaryMetadataError
   | UnsupportedPlatformPackageError
   | MissingTargetBinaryError
   | ResolvePackagedBinaryError
@@ -157,90 +191,149 @@ interface PackagedBinaryCandidate extends PackagedBinaryCandidateInfo {
   readonly metadata?: PackagedBinaryMetadata
 }
 
-interface InstalledTypeScriptMetadata {
+interface PackageJsonMetadata {
+  readonly name: string
   readonly version: string
   readonly gitHead: string
 }
 
+interface ResolvedPackageJson extends PackageJsonMetadata {
+  readonly requestedPackageName: string
+  readonly packageJsonPath: string
+}
+
+interface OfficialTypeScriptBinary {
+  readonly packageName: string
+  readonly packageJsonPath: string
+  readonly packageVersion: string
+  readonly packageGitHead: string
+  readonly platformPackageName: string
+  readonly platformPackageJsonPath: string
+  readonly platformGitHead: string
+  readonly binaryPath: string
+}
+
+const PackageJsonMetadataSchema = Schema.Struct({
+  name: Schema.String,
+  version: Schema.String,
+  gitHead: Schema.String
+})
+const PackageJsonMetadataFromStringSchema = Schema.fromJsonString(PackageJsonMetadataSchema)
+
+const BinaryMetadataSchema = Schema.Struct({
+  tsVersion: Schema.String,
+  tsGitHead: Schema.String
+})
+const BinaryMetadataFromStringSchema = Schema.fromJsonString(BinaryMetadataSchema)
+
 const packagedTypeScriptBinaryNames = ["tsc", "tsc-next"] as const
 
 
-/**
- * Outcome of probing a single native backend.
- * - `resolved`: the platform binary path was found.
- * - `notInstalled`: the main package is absent or fails the version check; the
- *   caller should try the next backend.
- * - `unsupportedPlatform`: the main package is installed but its platform
- *   sub-package is missing; a concrete, actionable error.
- */
-type BackendProbe =
-  | { readonly _tag: "resolved"; readonly path: string; readonly binaryName: string; readonly packageJson: { readonly version?: string; readonly gitHead?: string } }
-  | { readonly _tag: "notInstalled" }
-  | { readonly _tag: "unsupportedPlatform"; readonly packageName: string }
+const decodePackageJsonText = (packageName: string, packageJsonPath: string, text: string) =>
+  Schema.decodeUnknownEffect(PackageJsonMetadataFromStringSchema)(text).pipe(
+    Effect.mapError((error) => new ParsePackageJsonError({
+      packageName,
+      packageJsonPath,
+      reason: error.message
+    }))
+  )
 
-const probeBackend = (backend: NativeBackend, cwdRequire: NodeRequire, path: Path.Path): BackendProbe => {
-  const isWin = process.platform === "win32"
+const readPackageJsonFile = (packageName: string, packageJsonPath: string) =>
+  Effect.gen(function*() {
+    const fs = yield* FileSystem.FileSystem
+    const text = yield* fs.readFileString(packageJsonPath).pipe(
+      Effect.mapError((error) => new ParsePackageJsonError({
+        packageName,
+        packageJsonPath,
+        reason: error.message
+      }))
+    )
+    const metadata = yield* decodePackageJsonText(packageName, packageJsonPath, text)
+    return { requestedPackageName: packageName, packageJsonPath, ...metadata }
+  })
 
-  let mainPkg: { version?: string }
-  try {
-    mainPkg = cwdRequire(backend.packageName + "/package.json")
-  } catch {
-    return { _tag: "notInstalled" }
-  }
+const resolvePackageJson = (cwd: string, packageName: string) =>
+  Effect.gen(function*() {
+    const path = yield* Path.Path
+    const cwdRequire = nodeModule.createRequire(path.join(cwd, "noop.js"))
+    const packageJsonPath = yield* Effect.try({
+      try: () => cwdRequire.resolve(packageName + "/package.json"),
+      catch: () => new PackageNotFoundError({ packageName })
+    })
+    return yield* readPackageJsonFile(packageName, packageJsonPath)
+  })
 
-  if (backend.versionCheck !== undefined && !backend.versionCheck(mainPkg)) {
-    return { _tag: "notInstalled" }
-  }
+const decodeBinaryMetadataText = (metadataPath: string, text: string) =>
+  Schema.decodeUnknownEffect(BinaryMetadataFromStringSchema)(text).pipe(
+    Effect.mapError((error) => new ParseBinaryMetadataError({
+      metadataPath,
+      reason: error.message
+    }))
+  )
 
-  let mainPackageJsonPath: string
-  try {
-    mainPackageJsonPath = cwdRequire.resolve(backend.packageName + "/package.json")
-  } catch {
-    return { _tag: "notInstalled" }
-  }
-
-  const backendRequire = nodeModule.createRequire(mainPackageJsonPath)
-  const platformPackageName = backend.platformPackagePrefix + "-" + process.platform + "-" + process.arch
-  let platformPackageJsonPath: string
-  try {
-    platformPackageJsonPath = backendRequire.resolve(platformPackageName + "/package.json")
-  } catch {
-    return { _tag: "unsupportedPlatform", packageName: platformPackageName }
-  }
-
-  const platformDir = path.dirname(platformPackageJsonPath)
-  const binaryName = backend.binaryName + (isWin ? ".exe" : "")
-  return { _tag: "resolved", path: path.join(platformDir, "lib", binaryName), binaryName: backend.binaryName, packageJson: mainPkg }
-}
-
-/**
- * Resolve the native TypeScript binary to patch. The supported upstream package
- * is `typescript` >= 7, whose platform package exposes a `tsc` executable.
- */
-const getNativeBackendBinaryPath = Effect.gen(function*() {
-  const path = yield* Path.Path
-  const cwdRequire = nodeModule.createRequire(path.join(process.cwd(), "noop.js"))
-
-  const typescriptResult = probeBackend(typescriptBackend, cwdRequire, path)
-  if (typescriptResult._tag === "resolved") {
-    const installedGitHead = typescriptResult.packageJson.gitHead
-    if (installedGitHead === undefined) {
-      return yield* Effect.fail(new MissingTypeScriptMetadataError({ packageName: typescriptBackend.packageName }))
+const readBinaryMetadata = (binaryPath: string) =>
+  Effect.gen(function*() {
+    const fs = yield* FileSystem.FileSystem
+    const metadataPath = binaryPath + ".json"
+    const exists = yield* fs.exists(metadataPath)
+    if (!exists) {
+      return yield* Effect.fail(new BinaryMetadataNotFoundError({ metadataPath }))
     }
+
+    const text = yield* fs.readFileString(metadataPath).pipe(
+      Effect.mapError((error) => new ParseBinaryMetadataError({
+        metadataPath,
+        reason: error.message
+      }))
+    )
+    return yield* decodeBinaryMetadataText(metadataPath, text)
+  })
+
+const resolveOfficialTypeScriptBinary = (typescriptPackage: ResolvedPackageJson) =>
+  Effect.gen(function*() {
+    const path = yield* Path.Path
+    const platformPackageName = "@typescript/typescript-" + process.platform + "-" + process.arch
+    const packageRequire = nodeModule.createRequire(typescriptPackage.packageJsonPath)
+    const platformPackageJsonPath = yield* Effect.try({
+      try: () => packageRequire.resolve(platformPackageName + "/package.json"),
+      catch: () => new UnsupportedPlatformPackageError({ packageName: platformPackageName })
+    })
+    const platformPackage = yield* readPackageJsonFile(platformPackageName, platformPackageJsonPath)
+    const binaryName = "tsc" + (process.platform === "win32" ? ".exe" : "")
+
     return {
-      targetPath: typescriptResult.path,
-      installedTypeScript: {
-        version: typescriptResult.packageJson.version ?? "unknown",
-        gitHead: installedGitHead
-      }
-    }
-  }
-  if (typescriptResult._tag === "unsupportedPlatform") {
-    return yield* Effect.fail(new UnsupportedPlatformPackageError({ packageName: typescriptResult.packageName }))
-  }
+      packageName: typescriptPackage.requestedPackageName,
+      packageJsonPath: typescriptPackage.packageJsonPath,
+      packageVersion: typescriptPackage.version,
+      packageGitHead: typescriptPackage.gitHead,
+      platformPackageName,
+      platformPackageJsonPath,
+      platformGitHead: platformPackage.gitHead,
+      binaryPath: path.join(path.dirname(platformPackageJsonPath), "lib", binaryName)
+    } satisfies OfficialTypeScriptBinary
+  })
 
-  return yield* Effect.fail(new NativeBackendNotInstalledError({ details: "no native backend found" }))
-})
+const resolveInstalledTypeScriptBinary = (packageNames: ReadonlyArray<string>) =>
+  Effect.gen(function*() {
+    for (const packageName of packageNames) {
+      const packageResult = yield* resolvePackageJson(process.cwd(), packageName).pipe(
+        Effect.catchTag("PackageNotFoundError", () => Effect.succeed(undefined))
+      )
+      if (packageResult === undefined || !isNativeTypescriptVersion(packageResult.version)) {
+        continue
+      }
+      return yield* resolveOfficialTypeScriptBinary(packageResult)
+    }
+
+    return yield* Effect.fail(new NativeBackendNotInstalledError({ packageNames }))
+  })
+
+const packageNamesWithPreferred = (preferredPackageName: Option.Option<string>): ReadonlyArray<string> => {
+  const preferred = Option.getOrUndefined(preferredPackageName)
+  return preferred === undefined || preferred === ""
+    ? defaultTypescriptPackageNames
+    : Array.from(new Set([preferred, ...defaultTypescriptPackageNames]))
+}
 
 /**
  * Resolve the Effect-patched binary to copy over the native target. The
@@ -248,7 +341,7 @@ const getNativeBackendBinaryPath = Effect.gen(function*() {
  * `generated/latest`) and `lib/tsc-next` (built from `main`). The adjacent JSON
  * metadata files identify the TypeScript gitHead each binary was built from.
  */
-const getPackagedBinaryPath = (installedTypeScript: InstalledTypeScriptMetadata, force: boolean) =>
+const getPackagedBinaryPath = (installedTypeScript: OfficialTypeScriptBinary, force: boolean) =>
   Effect.gen(function*() {
     const fs = yield* FileSystem.FileSystem
     const path = yield* Path.Path
@@ -270,34 +363,27 @@ const getPackagedBinaryPath = (installedTypeScript: InstalledTypeScriptMetadata,
     for (const binaryName of packagedTypeScriptBinaryNames) {
       const exeName = binaryName + (process.platform === "win32" ? ".exe" : "")
       const exePath = path.join(packageDir, "lib", exeName)
-      const metadataPath = exePath + ".json"
       const exists = yield* fs.exists(exePath)
       if (!exists) {
         candidates.push({ binaryName, reason: "binary not packaged" })
         continue
       }
 
-      const metadataExists = yield* fs.exists(metadataPath)
-      if (!metadataExists) {
-        candidates.push({ binaryName, path: exePath, reason: "metadata not packaged" })
+      const metadataResult = yield* readBinaryMetadata(exePath).pipe(
+        Effect.match({
+          onFailure: (error) => ({ _tag: "failure" as const, error }),
+          onSuccess: (metadata) => ({ _tag: "success" as const, metadata })
+        })
+      )
+      if (metadataResult._tag === "failure") {
+        candidates.push({ binaryName, path: exePath, reason: metadataResult.error.message })
         continue
       }
 
-      const metadata = yield* fs.readFileString(metadataPath).pipe(
-        Effect.flatMap((text) => Effect.try({
-          try: () => {
-            const parsed = JSON.parse(text) as Partial<PackagedBinaryMetadata>
-            if (typeof parsed.tsVersion !== "string" || typeof parsed.tsGitHead !== "string") {
-              throw new Error("invalid metadata")
-            }
-            return { tsVersion: parsed.tsVersion, tsGitHead: parsed.tsGitHead }
-          },
-          catch: () => new ResolvePackagedBinaryError({ reason: "Invalid binary metadata: " + metadataPath })
-        }))
-      )
+      const metadata = metadataResult.metadata
 
       const candidate = { binaryName, path: exePath, metadata, ...metadata }
-      if (metadata.tsGitHead === installedTypeScript.gitHead) {
+      if (metadata.tsGitHead === installedTypeScript.packageGitHead) {
         return exePath
       }
       candidates.push(candidate)
@@ -308,8 +394,8 @@ const getPackagedBinaryPath = (installedTypeScript: InstalledTypeScriptMetadata,
         ?? candidates.find((candidate) => candidate.binaryName === "tsc" && candidate.path !== undefined)
       if (fallback?.path !== undefined) {
         yield* Console.warn(new PackagedBinaryVersionMismatchError({
-          installedVersion: installedTypeScript.version,
-          installedGitHead: installedTypeScript.gitHead,
+          installedVersion: installedTypeScript.packageVersion,
+          installedGitHead: installedTypeScript.packageGitHead,
           candidates
         }).message)
         yield* Console.warn("Forcing patch with " + fallback.binaryName + ". This may be incompatible.")
@@ -326,16 +412,17 @@ const getPackagedBinaryPath = (installedTypeScript: InstalledTypeScriptMetadata,
     }
 
     return yield* Effect.fail(new PackagedBinaryVersionMismatchError({
-      installedVersion: installedTypeScript.version,
-      installedGitHead: installedTypeScript.gitHead,
+      installedVersion: installedTypeScript.packageVersion,
+      installedGitHead: installedTypeScript.packageGitHead,
       candidates
     }))
   })
 
-const patch = (force: boolean) => Effect.gen(function*() {
+const patch = (force: boolean, packageNames: ReadonlyArray<string>) => Effect.gen(function*() {
   const fs = yield* FileSystem.FileSystem
   const path = yield* Path.Path
-  const { targetPath, installedTypeScript } = yield* getNativeBackendBinaryPath
+  const installedTypeScript = yield* resolveInstalledTypeScriptBinary(packageNames)
+  const targetPath = installedTypeScript.binaryPath
   const backupPath = path.join(path.dirname(targetPath), path.basename(targetPath) + ".original")
   const ourBinaryPath = yield* getPackagedBinaryPath(installedTypeScript, force)
 
@@ -394,7 +481,7 @@ const patch = (force: boolean) => Effect.gen(function*() {
 const unpatch = Effect.gen(function*() {
   const fs = yield* FileSystem.FileSystem
   const path = yield* Path.Path
-  const { targetPath } = yield* getNativeBackendBinaryPath
+  const { binaryPath: targetPath } = yield* resolveInstalledTypeScriptBinary(defaultTypescriptPackageNames)
   const backupPath = path.join(path.dirname(targetPath), path.basename(targetPath) + ".original")
 
   const backupExists = yield* fs.exists(backupPath)
@@ -430,9 +517,16 @@ const unpatch = Effect.gen(function*() {
   yield* Console.log("Restored original binary at " + targetPath)
 })
 
-const patchCommand = Command.make("patch", { force: Flag.boolean("force") }).pipe(
+const patchCommand = Command.make("patch", {
+  force: Flag.boolean("force"),
+  typescriptPackage: Flag.optional(
+    Flag.string("typescript-package").pipe(
+      Flag.withDescription("Native TypeScript package name to try before the default package names")
+    )
+  )
+}).pipe(
   Command.withDescription("Patch the Effect Language Service binary"),
-  Command.withHandler(({ force }) => patch(force))
+  Command.withHandler(({ force, typescriptPackage }) => patch(force, packageNamesWithPreferred(typescriptPackage)))
 )
 
 const unpatchCommand = Command.make("unpatch").pipe(
@@ -443,8 +537,8 @@ const unpatchCommand = Command.make("unpatch").pipe(
 const getExePathCommand = Command.make("get-exe-path").pipe(
   Command.withDescription("Print the Effect Language Service executable path"),
   Command.withHandler(() =>
-    getNativeBackendBinaryPath.pipe(
-      Effect.flatMap(({ installedTypeScript }) => getPackagedBinaryPath(installedTypeScript, false)),
+    resolveInstalledTypeScriptBinary(defaultTypescriptPackageNames).pipe(
+      Effect.flatMap((installedTypeScript) => getPackagedBinaryPath(installedTypeScript, false)),
       Effect.flatMap((exePath) => Console.log(exePath))
     )
   )

--- a/_packages/tsgo/src/setup/assessment.ts
+++ b/_packages/tsgo/src/setup/assessment.ts
@@ -7,9 +7,9 @@ import * as ts from "typescript"
 import { FileReadError, PackageJsonNotFoundError } from "./errors.js"
 import type { Assessment, FileInput, PackageDependency } from "./types.js"
 import {
+  defaultTypescriptPackageNames,
   LSP_PACKAGE_NAME,
   LSP_PLUGIN_NAME,
-  TYPESCRIPT_PACKAGE_NAME,
   isNativeTypescriptVersion,
   PATCH_COMMAND
 } from "./consts.js"
@@ -101,10 +101,14 @@ const assessPackageJson = (
   }
 
   const lspVersion = assessDependency(LSP_PACKAGE_NAME)
-  const typescriptDep = assessDependency(TYPESCRIPT_PACKAGE_NAME)
-  const typescriptVersion = Option.isSome(typescriptDep) && isNativeTypescriptVersion(typescriptDep.value.version)
-    ? Option.some({ ...typescriptDep.value, packageName: TYPESCRIPT_PACKAGE_NAME })
-    : Option.none<PackageDependency>()
+  let typescriptVersion = Option.none<PackageDependency>()
+  for (const packageName of defaultTypescriptPackageNames) {
+    const typescriptDep = assessDependency(packageName)
+    if (Option.isSome(typescriptDep) && isNativeTypescriptVersion(typescriptDep.value.version)) {
+      typescriptVersion = Option.some({ ...typescriptDep.value, packageName })
+      break
+    }
+  }
 
   // Check for prepare script
   const prepareScript = "prepare" in (parsed.scripts ?? {})

--- a/_packages/tsgo/src/setup/changes.ts
+++ b/_packages/tsgo/src/setup/changes.ts
@@ -9,10 +9,10 @@ import * as ts from "typescript"
 import { renderCodeActions } from "./diff-renderer.js"
 import type { Assessment, PackageDependency, SetupCodeAction, Target } from "./types.js"
 import {
+  defaultTypescriptPackageNames,
   LSP_PACKAGE_NAME,
   LSP_PLUGIN_NAME,
   PATCH_COMMAND,
-  TYPESCRIPT_PACKAGE_NAME,
   TSCONFIG_SCHEMA_URL
 } from "./consts.js"
 import type { RuleSeverity } from "./rule-info.js"
@@ -243,12 +243,30 @@ const computePackageJsonChanges = (
         Option.isNone(current.typescriptVersion) &&
         target.typescriptVersion.value.dependencyType === dependencyType
 
+      const getTypescriptPackageName = (dependency: PackageDependency) =>
+        dependency.packageName ?? defaultTypescriptPackageNames[0]
+
+      const appendTypescriptDependencyProperty = (dependencyProperties: Array<ts.PropertyAssignment>) => {
+        const targetTypescript = target.typescriptVersion.pipe(Option.getOrUndefined)
+        if (!targetTypescript) {
+          return
+        }
+
+        dependencyProperties.push(
+          ts.factory.createPropertyAssignment(
+            ts.factory.createStringLiteral(getTypescriptPackageName(targetTypescript)),
+            ts.factory.createStringLiteral(targetTypescript.version)
+          )
+        )
+      }
+
       const ensureTypescriptDependency = () => {
         if (Option.isNone(target.typescriptVersion) || Option.isSome(current.typescriptVersion)) {
           return
         }
 
         const targetTypescript = target.typescriptVersion.value
+        const targetTypescriptPackageName = getTypescriptPackageName(targetTypescript)
         const typescriptDepsProperty = findDependencyCollectionProperty(rootObj, targetTypescript.dependencyType)
 
         if (
@@ -260,9 +278,9 @@ const computePackageJsonChanges = (
         }
 
         descriptions.push(
-          `Add ${TYPESCRIPT_PACKAGE_NAME}@${targetTypescript.version} to ${targetTypescript.dependencyType}`
+          `Add ${targetTypescriptPackageName}@${targetTypescript.version} to ${targetTypescript.dependencyType}`
         )
-        upsertDependency(tracker, current.sourceFile, rootObj, TYPESCRIPT_PACKAGE_NAME, targetTypescript)
+        upsertDependency(tracker, current.sourceFile, rootObj, targetTypescriptPackageName, targetTypescript)
       }
 
       // Handle @effect/tsgo dependency
@@ -299,15 +317,7 @@ const computePackageJsonChanges = (
               ]
 
               if (shouldAddTypescriptWithDependencyType(targetDepType)) {
-                const targetTypescript = target.typescriptVersion.pipe(Option.getOrUndefined)
-                if (targetTypescript) {
-                dependencyProperties.push(
-                  ts.factory.createPropertyAssignment(
-                    ts.factory.createStringLiteral(TYPESCRIPT_PACKAGE_NAME),
-                    ts.factory.createStringLiteral(targetTypescript.version)
-                  )
-                )
-                }
+                appendTypescriptDependencyProperty(dependencyProperties)
               }
 
               const newDepsProp = ts.factory.createPropertyAssignment(
@@ -357,15 +367,7 @@ const computePackageJsonChanges = (
             ]
 
             if (shouldAddTypescriptWithDependencyType(targetDepType)) {
-              const targetTypescript = target.typescriptVersion.pipe(Option.getOrUndefined)
-              if (targetTypescript) {
-              dependencyProperties.push(
-                ts.factory.createPropertyAssignment(
-                  ts.factory.createStringLiteral(TYPESCRIPT_PACKAGE_NAME),
-                  ts.factory.createStringLiteral(targetTypescript.version)
-                )
-              )
-              }
+              appendTypescriptDependencyProperty(dependencyProperties)
             }
 
             const newDepsProp = ts.factory.createPropertyAssignment(

--- a/_packages/tsgo/src/setup/consts.ts
+++ b/_packages/tsgo/src/setup/consts.ts
@@ -2,7 +2,7 @@ import * as pkgJson from "../../package.json"
 
 export const LSP_PACKAGE_NAME = pkgJson.name
 export const LSP_PLUGIN_NAME = "@effect/language-service"
-export const TYPESCRIPT_PACKAGE_NAME = "typescript"
+export const defaultTypescriptPackageNames = ["typescript", "@typescript/native"] as const
 export const PATCH_COMMAND = "effect-tsgo patch"
 export const TSCONFIG_SCHEMA_URL = "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
 
@@ -14,25 +14,6 @@ export const TSCONFIG_SCHEMA_URL = "https://raw.githubusercontent.com/Effect-TS/
 export const isNativeTypescriptVersion = (version: string): boolean => {
   const match = /\d+/.exec(version.trim())
   return match !== null && Number(match[0]) >= 7
-}
-
-/**
- * Describes a native TypeScript backend that ships the Go-ported binary in a
- * platform-specific sub-package under `lib/<binaryName>`.
- */
-export interface NativeBackend {
-  readonly packageName: string
-  readonly platformPackagePrefix: string
-  readonly binaryName: string
-  readonly versionCheck?: (pkgJson: { readonly version?: string }) => boolean
-}
-
-/** The `typescript` >= 7 backend. */
-export const typescriptBackend: NativeBackend = {
-  packageName: TYPESCRIPT_PACKAGE_NAME,
-  platformPackagePrefix: "@typescript/typescript",
-  binaryName: "tsc",
-  versionCheck: (pkg) => isNativeTypescriptVersion(pkg.version ?? "0")
 }
 
 /**

--- a/_packages/tsgo/src/setup/target-prompt.ts
+++ b/_packages/tsgo/src/setup/target-prompt.ts
@@ -3,7 +3,7 @@ import * as Option from "effect/Option"
 import type * as Terminal from "effect/Terminal"
 import * as Prompt from "effect/unstable/cli/Prompt"
 import { applyPresetDiagnosticSeverities, type DiagnosticPresetName, isPresetEnabled } from "../presets.js"
-import { TYPESCRIPT_PACKAGE_NAME, nativeBackendTsdkPath } from "./consts.js"
+import { defaultTypescriptPackageNames, nativeBackendTsdkPath } from "./consts.js"
 import type { Assessment } from "./types.js"
 import type { Editor, Target } from "./target.js"
 import { getAllPresets, getAllRules } from "./rule-info.js"
@@ -135,10 +135,11 @@ export const gatherTargetState = (
 
     // Build target state
     // Point the TypeScript 7 extension at the project TypeScript package.
+    const defaultTypescriptPackageName = defaultTypescriptPackageNames[0]
     const vscodeSettings: Option.Option<Target.VSCodeSettings> = editors.includes("vscode")
       ? Option.some({
         settings: {
-          "typescript.native-preview.tsdk": nativeBackendTsdkPath(TYPESCRIPT_PACKAGE_NAME),
+          "typescript.native-preview.tsdk": nativeBackendTsdkPath(defaultTypescriptPackageName),
           "typescript.experimental.useTsgo": true,
           "js/ts.experimental.useTsgo": true
         }
@@ -153,7 +154,7 @@ export const gatherTargetState = (
           () => Option.some({
             dependencyType: lspDependencyType,
             version: context.defaultTypescriptVersion,
-            packageName: TYPESCRIPT_PACKAGE_NAME
+            packageName: defaultTypescriptPackageName
           })
         ),
         prepareScript: true

--- a/_packages/tsgo/test/setup/changes.test.ts
+++ b/_packages/tsgo/test/setup/changes.test.ts
@@ -170,6 +170,31 @@ describe("computeChanges", () => {
     }))
   })
 
+  it("should assess @typescript/native after typescript as the native backend", () => {
+    const packageJsonText = JSON.stringify({
+      name: "test-project",
+      version: "1.0.0",
+      devDependencies: {
+        "@typescript/native": "npm:typescript@^7.0.2",
+        "typescript": "npm:@typescript/typescript6@^6.0.2"
+      }
+    }, null, 2)
+
+    const input: Assessment.Input = {
+      packageJson: { fileName: "/test/package.json", text: packageJsonText },
+      tsconfig: { fileName: "/test/tsconfig.json", text: "{}" },
+      vscodeSettings: Option.none()
+    }
+
+    const assessment = assess(input)
+
+    expect(assessment.packageJson.typescriptVersion).toEqual(Option.some({
+      dependencyType: "devDependencies",
+      version: "npm:typescript@^7.0.2",
+      packageName: "@typescript/native"
+    }))
+  })
+
   it("should not assess typescript < 7 as the native backend", () => {
     const packageJsonText = JSON.stringify({
       name: "test-project",
@@ -224,7 +249,7 @@ describe("computeChanges", () => {
         devDependencies: {}
       }, null, 2),
       lspVersion: { dependencyType: "devDependencies", version: "0.0.4" },
-      typescriptVersion: { dependencyType: "devDependencies", version: "^7.0.1-rc", packageName: "typescript" },
+      typescriptVersion: { dependencyType: "devDependencies", version: "npm:typescript@^7.0.2", packageName: "@typescript/native" },
       prepareScript: false,
       editors: []
     })
@@ -234,8 +259,8 @@ describe("computeChanges", () => {
       .find((change) => change.fileName === "/test/package.json")
 
     expect(packageJsonChange).toBeDefined()
-    expect(packageJsonChange?.textChanges.some((change) => change.newText.includes('"typescript"'))).toBe(true)
-    expect(result.codeActions[0]?.description).toContain("Add typescript@^7.0.1-rc to devDependencies")
+    expect(packageJsonChange?.textChanges.some((change) => change.newText.includes('"@typescript/native"'))).toBe(true)
+    expect(result.codeActions[0]?.description).toContain("Add @typescript/native@npm:typescript@^7.0.2 to devDependencies")
   })
 
   it("should not throw when updating an existing prepare script from the legacy command", () => {

--- a/_packages/tsgo/test/setup/consts.test.ts
+++ b/_packages/tsgo/test/setup/consts.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest"
 import {
+  defaultTypescriptPackageNames,
   isNativeTypescriptVersion,
-  nativeBackendTsdkPath,
-  TYPESCRIPT_PACKAGE_NAME
+  nativeBackendTsdkPath
 } from "../../src/setup/consts.js"
 
 describe("isNativeTypescriptVersion", () => {
@@ -31,6 +31,12 @@ describe("isNativeTypescriptVersion", () => {
 
 describe("nativeBackendTsdkPath", () => {
   it("returns the node_modules folder for TypeScript", () => {
-    expect(nativeBackendTsdkPath(TYPESCRIPT_PACKAGE_NAME)).toBe("node_modules/typescript")
+    expect(nativeBackendTsdkPath(defaultTypescriptPackageNames[0])).toBe("node_modules/typescript")
+  })
+})
+
+describe("defaultTypescriptPackageNames", () => {
+  it("tries typescript before the @typescript/native alias", () => {
+    expect(defaultTypescriptPackageNames).toEqual(["typescript", "@typescript/native"])
   })
 })

--- a/testdata/baselines/reference/README.md
+++ b/testdata/baselines/reference/README.md
@@ -22,7 +22,7 @@ This will guide you through the installation process, which includes:
 4. Hinting at any additional editor configuration needed to ensure the LSP is active.
 
 > [!NOTE]
-> At the moment, you still need a native TypeScript install alongside `@effect/tsgo`: `typescript` >= 7 (e.g. `typescript@latest` or `typescript@next`). `effect-tsgo patch` selects the packaged Effect binary whose TypeScript git head matches the installed `typescript` package.
+> At the moment, you still need a native TypeScript install alongside `@effect/tsgo`: `typescript` >= 7 (e.g. `typescript@latest` or `typescript@next`) or an alias such as `@typescript/native`. `effect-tsgo patch` tries `typescript`, then `@typescript/native`, and accepts `--typescript-package <name>` to try a custom package name first.
 
 ## Diagnostic Status
 


### PR DESCRIPTION
## Summary
- support resolving native TypeScript packages from an ordered package-name list, including @typescript/native aliases
- add effect-tsgo patch --typescript-package to try a custom package name before defaults
- refactor patch resolution into schema-decoded package.json, platform package, and binary metadata helpers
- update setup detection/insertion, docs, tests, and add a minor changeset

## Testing
- pnpm setup-repo
- pnpm --filter @effect/tsgo check
- pnpm --filter @effect/tsgo test -- test/setup/consts.test.ts test/setup/changes.test.ts
- pnpm --filter @effect/tsgo build
- pnpm check
- pnpm lint
- pnpm test
- git diff --check