### PR TITLE
perf: skip library checking in effect tests

### DIFF
--- a/.changeset/fast-effect-tests.md
+++ b/.changeset/fast-effect-tests.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Enable `skipLibCheck` in the Effect test harness to avoid type-checking bundled declaration files that are not under test.

--- a/internal/effecttest/effect_in_failure_ts2589_test.go
+++ b/internal/effecttest/effect_in_failure_ts2589_test.go
@@ -136,6 +136,7 @@ func collectDiagnosticStringsFromContent(t testing.TB, content string) []string 
 	compilerOptions := &core.CompilerOptions{
 		NewLine:                      core.NewLineKindLF,
 		SkipDefaultLibCheck:          core.TSTrue,
+		SkipLibCheck:                 core.TSTrue,
 		NoErrorTruncation:            core.TSTrue,
 		Target:                       core.ScriptTargetESNext,
 		Module:                       core.ModuleKindNodeNext,
@@ -162,6 +163,7 @@ func collectDiagnosticStringsFromContent(t testing.TB, content string) []string 
 		if parsedConfig.CompilerOptions() != nil {
 			parsedConfig.CompilerOptions().NewLine = core.NewLineKindLF
 			parsedConfig.CompilerOptions().SkipDefaultLibCheck = core.TSTrue
+			parsedConfig.CompilerOptions().SkipLibCheck = core.TSTrue
 			parsedConfig.CompilerOptions().NoErrorTruncation = core.TSTrue
 			if parsedConfig.CompilerOptions().Target == core.ScriptTargetNone {
 				parsedConfig.CompilerOptions().Target = core.ScriptTargetESNext

--- a/internal/effecttest/runner.go
+++ b/internal/effecttest/runner.go
@@ -113,6 +113,7 @@ func parseTestUnits(content string, defaultFileName string) []*testUnit {
 // It enables the Effect language service plugin with default diagnostic severities.
 const DefaultTsConfig = `{
   "compilerOptions": {
+    "skipLibCheck": true,
     "plugins": [
       {
         "name": "@effect/language-service",
@@ -219,6 +220,7 @@ func RunEffectTest(t *testing.T, version bundledeffect.EffectVersion, testFile s
 	compilerOptions := &core.CompilerOptions{
 		NewLine:             core.NewLineKindLF,
 		SkipDefaultLibCheck: core.TSTrue,
+		SkipLibCheck:        core.TSTrue,
 		NoErrorTruncation:   core.TSTrue,
 		Target:              core.ScriptTargetESNext,
 		Module:              core.ModuleKindNodeNext,
@@ -257,6 +259,7 @@ func RunEffectTest(t *testing.T, version bundledeffect.EffectVersion, testFile s
 			// Merge with our defaults
 			parsedConfig.CompilerOptions().NewLine = core.NewLineKindLF
 			parsedConfig.CompilerOptions().SkipDefaultLibCheck = core.TSTrue
+			parsedConfig.CompilerOptions().SkipLibCheck = core.TSTrue
 			parsedConfig.CompilerOptions().NoErrorTruncation = core.TSTrue
 			if parsedConfig.CompilerOptions().Target == core.ScriptTargetNone {
 				parsedConfig.CompilerOptions().Target = core.ScriptTargetESNext


### PR DESCRIPTION
## Summary

- enable `skipLibCheck` in the Effect test harness default tsconfig
- force the option for diagnostic fixtures that provide custom tsconfigs
- apply the same option to the TS2589 diagnostic helper
- retain `skipDefaultLibCheck` while avoiding semantic checks of bundled Effect declaration files

The harness diagnostics target fixture source files rather than declarations under `node_modules`, so checking those declarations adds work without increasing coverage.

## Performance

Running the v3 and v4 diagnostic suites with `-count=1`:

- before: 47.4s reported test time
- after: 19.8s reported test time
- reduction: approximately 58%

The complete `pnpm test` workflow finished in approximately 101s after the change.

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`