### PR TITLE
fix: update setup VS Code settings

### DIFF
--- a/.changeset/setup-vscode-settings.md
+++ b/.changeset/setup-vscode-settings.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Update `effect-tsgo setup` to configure the current TypeScript Go VS Code settings, including the workspace TypeScript SDK path and additional SDK locations.

--- a/_packages/tsgo/src/setup/changes.ts
+++ b/_packages/tsgo/src/setup/changes.ts
@@ -744,6 +744,15 @@ const computeVSCodeSettingsChanges = (
 
   const ctx = createTrackerContext()
 
+  const createSettingValue = (value: unknown): ts.Expression =>
+    typeof value === "string"
+      ? ts.factory.createStringLiteral(value)
+      : typeof value === "boolean"
+      ? value ? ts.factory.createTrue() : ts.factory.createFalse()
+      : Array.isArray(value) && value.every((item): item is string => typeof item === "string")
+      ? ts.factory.createArrayLiteralExpression(value.map((item) => ts.factory.createStringLiteral(item)))
+      : ts.factory.createNull()
+
   const fileChanges = tsInternal.textChanges.ChangeTracker.with(
     ctx,
     (tracker: any) => {
@@ -756,11 +765,7 @@ const computeVSCodeSettingsChanges = (
           newProperties.push(
             ts.factory.createPropertyAssignment(
               ts.factory.createStringLiteral(key),
-              typeof value === "string"
-                ? ts.factory.createStringLiteral(value)
-                : typeof value === "boolean"
-                ? value ? ts.factory.createTrue() : ts.factory.createFalse()
-                : ts.factory.createNull()
+              createSettingValue(value)
             )
           )
         }
@@ -777,11 +782,7 @@ const computeVSCodeSettingsChanges = (
 
             const newProp = ts.factory.createPropertyAssignment(
               ts.factory.createStringLiteral(key),
-              typeof value === "string"
-                ? ts.factory.createStringLiteral(value)
-                : typeof value === "boolean"
-                ? value ? ts.factory.createTrue() : ts.factory.createFalse()
-                : ts.factory.createNull()
+              createSettingValue(value)
             )
             insertNodeAtEndOfList(tracker, current.sourceFile, rootObj.properties, newProp)
           }

--- a/_packages/tsgo/src/setup/consts.ts
+++ b/_packages/tsgo/src/setup/consts.ts
@@ -15,9 +15,3 @@ export const isNativeTypescriptVersion = (version: string): boolean => {
   const match = /\d+/.exec(version.trim())
   return match !== null && Number(match[0]) >= 7
 }
-
-/**
- * Resolve the VS Code TypeScript 7 tsdk folder.
- */
-export const nativeBackendTsdkPath = (packageName: string): string =>
-  "node_modules/" + packageName

--- a/_packages/tsgo/src/setup/target-prompt.ts
+++ b/_packages/tsgo/src/setup/target-prompt.ts
@@ -3,7 +3,7 @@ import * as Option from "effect/Option"
 import type * as Terminal from "effect/Terminal"
 import * as Prompt from "effect/unstable/cli/Prompt"
 import { applyPresetDiagnosticSeverities, type DiagnosticPresetName, isPresetEnabled } from "../presets.js"
-import { defaultTypescriptPackageNames, nativeBackendTsdkPath } from "./consts.js"
+import { defaultTypescriptPackageNames } from "./consts.js"
 import type { Assessment } from "./types.js"
 import type { Editor, Target } from "./target.js"
 import { getAllPresets, getAllRules } from "./rule-info.js"
@@ -134,14 +134,14 @@ export const gatherTargetState = (
     })
 
     // Build target state
-    // Point the TypeScript 7 extension at the project TypeScript package.
     const defaultTypescriptPackageName = defaultTypescriptPackageNames[0]
     const vscodeSettings: Option.Option<Target.VSCodeSettings> = editors.includes("vscode")
       ? Option.some({
         settings: {
-          "typescript.native-preview.tsdk": nativeBackendTsdkPath(defaultTypescriptPackageName),
-          "typescript.experimental.useTsgo": true,
-          "js/ts.experimental.useTsgo": true
+          "js/ts.experimental.useTsgo": true,
+          "js/ts.tsdk.path": "./node_modules/typescript/bin",
+          "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+          "js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"]
         }
       })
       : Option.none()

--- a/_packages/tsgo/test/setup/__snapshots__/setup-cli.test.ts.snap
+++ b/_packages/tsgo/test/setup/__snapshots__/setup-cli.test.ts.snap
@@ -48,9 +48,12 @@ exports[`Setup CLI > should add LSP plugin alongside existing plugins > tsconfig
 
 exports[`Setup CLI > should add LSP with VS Code editor selected and create new settings file > .vscode/settings.json 1`] = `
 "{
-  "typescript.native-preview.tsdk": "node_modules/typescript",
-  "typescript.experimental.useTsgo": true,
-  "js/ts.experimental.useTsgo": true
+  "js/ts.experimental.useTsgo": true,
+  "js/ts.tsdk.path": "./node_modules/typescript/bin",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+  "js/ts.tsdk.additionalLocations": [
+    "./node_modules/typescript/bin"
+  ]
 }
 "
 `;
@@ -511,9 +514,10 @@ exports[`Setup CLI > should preserve all existing VS Code settings from a real r
   "editor.wordBasedSuggestions": "matchingDocuments",
   "editor.parameterHints.enabled": true,
   "files.insertFinalNewline": true,
-"js/ts.experimental.useTsgo": true,
-"typescript.experimental.useTsgo": true,
-"typescript.native-preview.tsdk": "node_modules/typescript"
+"js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"],
+"js/ts.tsdk.promptToUseWorkspaceVersion": true,
+"js/ts.tsdk.path": "./node_modules/typescript/bin",
+"js/ts.experimental.useTsgo": true
 }"
 `;
 
@@ -528,7 +532,7 @@ exports[`Setup CLI > should preserve all existing VS Code settings from a real r
     "file": "tsconfig.json",
   },
   {
-    "description": "Add typescript.native-preview.tsdk setting; Add typescript.experimental.useTsgo setting; Add js/ts.experimental.useTsgo setting",
+    "description": "Add js/ts.experimental.useTsgo setting; Add js/ts.tsdk.path setting; Add js/ts.tsdk.promptToUseWorkspaceVersion setting; Add js/ts.tsdk.additionalLocations setting",
     "file": ".vscode/settings.json",
   },
 ]
@@ -575,9 +579,10 @@ exports[`Setup CLI > should preserve existing VS Code settings when adding LSP-s
   "editor.formatOnSave": true,
   "editor.tabSize": 2,
   "files.autoSave": "onFocusChange",
-"js/ts.experimental.useTsgo": true,
-"typescript.experimental.useTsgo": true,
-"typescript.native-preview.tsdk": "node_modules/typescript"
+"js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"],
+"js/ts.tsdk.promptToUseWorkspaceVersion": true,
+"js/ts.tsdk.path": "./node_modules/typescript/bin",
+"js/ts.experimental.useTsgo": true
 }"
 `;
 
@@ -592,7 +597,7 @@ exports[`Setup CLI > should preserve existing VS Code settings when adding LSP-s
     "file": "tsconfig.json",
   },
   {
-    "description": "Add typescript.native-preview.tsdk setting; Add typescript.experimental.useTsgo setting; Add js/ts.experimental.useTsgo setting",
+    "description": "Add js/ts.experimental.useTsgo setting; Add js/ts.tsdk.path setting; Add js/ts.tsdk.promptToUseWorkspaceVersion setting; Add js/ts.tsdk.additionalLocations setting",
     "file": ".vscode/settings.json",
   },
 ]

--- a/_packages/tsgo/test/setup/changes.test.ts
+++ b/_packages/tsgo/test/setup/changes.test.ts
@@ -361,6 +361,21 @@ describe("computeChanges", () => {
         }
       }
     })
+
+    it("should serialize array settings when modifying existing vscode settings", () => {
+      const result = runComputeChanges({
+        vscodeSettingsText: JSON.stringify({ "editor.formatOnSave": true }, null, 2),
+        vscodeTargetSettings: {
+          "js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"]
+        }
+      })
+
+      const vscodeChange = result.codeActions
+        .flatMap((action) => action.changes)
+        .find((change) => change.fileName.includes("settings.json"))
+
+      expect(vscodeChange?.textChanges[0]?.newText).toContain('["./node_modules/typescript/bin"]')
+    })
   })
 
   describe("new-file code action for .vscode/settings.json", () => {

--- a/_packages/tsgo/test/setup/consts.test.ts
+++ b/_packages/tsgo/test/setup/consts.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from "vitest"
 import {
   defaultTypescriptPackageNames,
-  isNativeTypescriptVersion,
-  nativeBackendTsdkPath
+  isNativeTypescriptVersion
 } from "../../src/setup/consts.js"
 
 describe("isNativeTypescriptVersion", () => {
@@ -26,12 +25,6 @@ describe("isNativeTypescriptVersion", () => {
     expect(isNativeTypescriptVersion("latest")).toBe(false)
     expect(isNativeTypescriptVersion("rc")).toBe(false)
     expect(isNativeTypescriptVersion("")).toBe(false)
-  })
-})
-
-describe("nativeBackendTsdkPath", () => {
-  it("returns the node_modules folder for TypeScript", () => {
-    expect(nativeBackendTsdkPath(defaultTypescriptPackageNames[0])).toBe("node_modules/typescript")
   })
 })
 

--- a/_packages/tsgo/test/setup/setup-cli.test.ts
+++ b/_packages/tsgo/test/setup/setup-cli.test.ts
@@ -138,9 +138,10 @@ function expectSetupChanges(
 
 const VSCODE_SETTINGS: Target.VSCodeSettings = {
   settings: {
-    "typescript.native-preview.tsdk": "node_modules/typescript",
-    "typescript.experimental.useTsgo": true,
-    "js/ts.experimental.useTsgo": true
+    "js/ts.experimental.useTsgo": true,
+    "js/ts.tsdk.path": "./node_modules/typescript/bin",
+    "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+    "js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"]
   }
 }
 


### PR DESCRIPTION
## Summary

- replace deprecated TypeScript Go VS Code settings generated by `effect-tsgo setup`
- configure the workspace SDK path, workspace-version prompt, and additional SDK locations
- support string-array values when merging settings into an existing `.vscode/settings.json`
- remove the now-unused native backend TSDK path helper

The generated settings are now:

```json
{
  "js/ts.experimental.useTsgo": true,
  "js/ts.tsdk.path": "./node_modules/typescript/bin",
  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
  "js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"]
}
```

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`