### PR TITLE
fix: use local schema in setup

### DIFF
--- a/.changeset/local-tsconfig-schema.md
+++ b/.changeset/local-tsconfig-schema.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Ship the generated schema and configure `tsconfig.json` to use the installed local copy during setup, fixing #346.

--- a/_packages/tsgo/.gitignore
+++ b/_packages/tsgo/.gitignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 README.md
+schema.json

--- a/_packages/tsgo/package.json
+++ b/_packages/tsgo/package.json
@@ -27,7 +27,8 @@
   },
   "files": [
     "dist/",
-    "README.md"
+    "README.md",
+    "schema.json"
   ],
   "optionalDependencies": {
     "@effect/tsgo-win32-x64": "workspace:*",

--- a/_packages/tsgo/src/setup/assessment.ts
+++ b/_packages/tsgo/src/setup/assessment.ts
@@ -138,6 +138,7 @@ const assessTsConfig = (
   const sourceFile = ts.parseJsonText(input.fileName, input.text)
   const errors: Array<ts.Diagnostic> = []
   const parsed = ts.convertToObject(sourceFile, errors) as {
+    $schema?: unknown
     compilerOptions?: {
       plugins?: Array<{
         name?: string
@@ -149,6 +150,7 @@ const assessTsConfig = (
   const hasPlugins = parsed.compilerOptions?.plugins !== undefined
   const plugins = parsed.compilerOptions?.plugins ?? []
   const hasLspPlugin = plugins.some((plugin) => plugin.name === LSP_PLUGIN_NAME)
+  const currentSchemaPath = typeof parsed.$schema === "string" ? Option.some(parsed.$schema) : Option.none()
   const currentDiagnosticSeverities = getCurrentDiagnosticSeverities(plugins)
 
   return {
@@ -158,6 +160,7 @@ const assessTsConfig = (
     text: input.text,
     hasPlugins,
     hasLspPlugin,
+    currentSchemaPath,
     currentDiagnosticSeverities
   }
 }

--- a/_packages/tsgo/src/setup/changes.ts
+++ b/_packages/tsgo/src/setup/changes.ts
@@ -12,8 +12,7 @@ import {
   defaultTypescriptPackageNames,
   LSP_PACKAGE_NAME,
   LSP_PLUGIN_NAME,
-  PATCH_COMMAND,
-  TSCONFIG_SCHEMA_URL
+  PATCH_COMMAND
 } from "./consts.js"
 import type { RuleSeverity } from "./rule-info.js"
 
@@ -537,9 +536,10 @@ const computeTsConfigChanges = (
       ctx,
       (tracker: any) => {
         const schemaProperty = findPropertyInObject(rootObj, "$schema")
-        const shouldAddSchema = !schemaProperty
-        const shouldUpdateSchema = !!schemaProperty && (
-          !ts.isStringLiteral(schemaProperty.initializer) || schemaProperty.initializer.text !== TSCONFIG_SCHEMA_URL
+        const shouldAddSchema = Option.isSome(target.schemaPath) && !schemaProperty
+        const shouldUpdateSchema = Option.isSome(target.schemaPath) && !!schemaProperty && (
+          !ts.isStringLiteral(schemaProperty.initializer) ||
+          schemaProperty.initializer.text !== target.schemaPath.value
         )
 
         if (shouldAddSchema) {
@@ -550,10 +550,11 @@ const computeTsConfigChanges = (
 
         descriptions.push(`Add compilerOptions with ${LSP_PLUGIN_NAME} plugin`)
 
-        const schemaPropertyAssignment = ts.factory.createPropertyAssignment(
-          ts.factory.createStringLiteral("$schema"),
-          ts.factory.createStringLiteral(TSCONFIG_SCHEMA_URL)
-        )
+        const schemaPropertyAssignment = Option.map(target.schemaPath, (schemaPath) =>
+          ts.factory.createPropertyAssignment(
+            ts.factory.createStringLiteral("$schema"),
+            ts.factory.createStringLiteral(schemaPath)
+          ))
 
         const compilerOptionsAssignment = ts.factory.createPropertyAssignment(
           ts.factory.createStringLiteral("compilerOptions"),
@@ -567,14 +568,14 @@ const computeTsConfigChanges = (
 
         // Rebuild the root object preserving existing properties, updating/adding $schema, appending compilerOptions
         const nextProperties: Array<ts.ObjectLiteralElementLike> = rootObj.properties.map((property) => {
-          if (schemaProperty && property === schemaProperty) {
-            return schemaPropertyAssignment
+          if (schemaProperty && property === schemaProperty && Option.isSome(schemaPropertyAssignment)) {
+            return schemaPropertyAssignment.value
           }
           return property
         })
 
-        if (shouldAddSchema) {
-          nextProperties.push(schemaPropertyAssignment)
+        if (shouldAddSchema && Option.isSome(schemaPropertyAssignment)) {
+          nextProperties.push(schemaPropertyAssignment.value)
         }
         nextProperties.push(compilerOptionsAssignment)
 
@@ -614,10 +615,11 @@ const computeTsConfigChanges = (
     (tracker: any) => {
       const schemaProperty = findPropertyInObject(rootObj, "$schema")
       const pluginsProperty = findPropertyInObject(compilerOptions, "plugins")
-      const schemaPropertyAssignment = ts.factory.createPropertyAssignment(
-        ts.factory.createStringLiteral("$schema"),
-        ts.factory.createStringLiteral(TSCONFIG_SCHEMA_URL)
-      )
+      const schemaPropertyAssignment = Option.map(target.schemaPath, (schemaPath) =>
+        ts.factory.createPropertyAssignment(
+          ts.factory.createStringLiteral("$schema"),
+          ts.factory.createStringLiteral(schemaPath)
+        ))
 
       if (Option.isNone(lspVersion)) {
         // User wants to remove LSP
@@ -646,15 +648,20 @@ const computeTsConfigChanges = (
         }
       } else {
         // User wants to add/keep LSP
-        if (!schemaProperty) {
+        if (!schemaProperty && Option.isSome(schemaPropertyAssignment)) {
           descriptions.push("Add $schema to tsconfig")
-          insertNodeAtEndOfList(tracker, current.sourceFile, rootObj.properties, schemaPropertyAssignment)
+          insertNodeAtEndOfList(tracker, current.sourceFile, rootObj.properties, schemaPropertyAssignment.value)
         } else if (
-          !ts.isStringLiteral(schemaProperty.initializer) ||
-          schemaProperty.initializer.text !== TSCONFIG_SCHEMA_URL
+          schemaProperty &&
+          Option.isSome(target.schemaPath) &&
+          (!ts.isStringLiteral(schemaProperty.initializer) || schemaProperty.initializer.text !== target.schemaPath.value)
         ) {
           descriptions.push("Update $schema in tsconfig")
-          tracker.replaceNode(current.sourceFile, schemaProperty.initializer, schemaPropertyAssignment.initializer)
+          tracker.replaceNode(
+            current.sourceFile,
+            schemaProperty.initializer,
+            Option.getOrThrow(schemaPropertyAssignment).initializer
+          )
         }
 
         const pluginObject = createLspPluginObject(target)

--- a/_packages/tsgo/src/setup/consts.ts
+++ b/_packages/tsgo/src/setup/consts.ts
@@ -4,7 +4,6 @@ export const LSP_PACKAGE_NAME = pkgJson.name
 export const LSP_PLUGIN_NAME = "@effect/language-service"
 export const defaultTypescriptPackageNames = ["typescript", "@typescript/native"] as const
 export const PATCH_COMMAND = "effect-tsgo patch"
-export const TSCONFIG_SCHEMA_URL = "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
 
 /**
  * `typescript` package versions >= 7 ship the native Go-ported binary that this

--- a/_packages/tsgo/src/setup/index.ts
+++ b/_packages/tsgo/src/setup/index.ts
@@ -21,7 +21,8 @@ export const setupCommand = Command.make("setup").pipe(
       const assessmentState = Assessment.assess(assessmentInput)
       const targetState = yield* gatherTargetState(assessmentState, {
         defaultLspVersion: pkgJson.version,
-        defaultTypescriptVersion: upstreamJson.tsVersion
+        defaultTypescriptVersion: upstreamJson.tsVersion,
+        defaultSchemaPath: path.resolve(currentDir, "node_modules", pkgJson.name, "schema.json")
       })
       const result = Changes.computeChanges(assessmentState, targetState)
 

--- a/_packages/tsgo/src/setup/target-prompt.ts
+++ b/_packages/tsgo/src/setup/target-prompt.ts
@@ -1,5 +1,6 @@
 import * as Effect from "effect/Effect"
 import * as Option from "effect/Option"
+import * as Path from "effect/Path"
 import type * as Terminal from "effect/Terminal"
 import * as Prompt from "effect/unstable/cli/Prompt"
 import { applyPresetDiagnosticSeverities, type DiagnosticPresetName, isPresetEnabled } from "../presets.js"
@@ -15,6 +16,7 @@ import { createRulePrompt } from "./rule-prompt.js"
 export interface GatherTargetContext {
   readonly defaultLspVersion: string
   readonly defaultTypescriptVersion: string
+  readonly defaultSchemaPath: string
 }
 
 /**
@@ -23,8 +25,10 @@ export interface GatherTargetContext {
 export const gatherTargetState = (
   assessment: Assessment.State,
   context: GatherTargetContext
-): Effect.Effect<Target.State, Terminal.QuitError, Prompt.Environment> =>
+): Effect.Effect<Target.State, Terminal.QuitError, Prompt.Environment | Path.Path> =>
   Effect.gen(function*() {
+    const path = yield* Path.Path
+
     // Determine current LSP installation state
     const currentLspState = Option.match(assessment.packageJson.lspVersion, {
       onNone: () => "no" as const,
@@ -64,6 +68,7 @@ export const gatherTargetState = (
           prepareScript: false
         },
         tsconfig: {
+          schemaPath: Option.none(),
           diagnosticSeverities: Option.none()
         },
         vscodeSettings: Option.none(),
@@ -135,6 +140,9 @@ export const gatherTargetState = (
 
     // Build target state
     const defaultTypescriptPackageName = defaultTypescriptPackageNames[0]
+    const relativeSchemaPath = path
+      .relative(path.dirname(assessment.tsconfig.path), context.defaultSchemaPath)
+      .replaceAll("\\", "/")
     const vscodeSettings: Option.Option<Target.VSCodeSettings> = editors.includes("vscode")
       ? Option.some({
         settings: {
@@ -160,6 +168,7 @@ export const gatherTargetState = (
         prepareScript: true
       },
       tsconfig: {
+        schemaPath: Option.some(relativeSchemaPath.startsWith(".") ? relativeSchemaPath : `./${relativeSchemaPath}`),
         diagnosticSeverities
       },
       vscodeSettings,

--- a/_packages/tsgo/src/setup/target.ts
+++ b/_packages/tsgo/src/setup/target.ts
@@ -14,6 +14,7 @@ export const fromAssessment = (inputState: Assessment.State): Target.State => ({
     )
   },
   tsconfig: {
+    schemaPath: inputState.tsconfig.currentSchemaPath,
     diagnosticSeverities: inputState.tsconfig.currentDiagnosticSeverities
   },
   vscodeSettings: Option.map(inputState.vscodeSettings, (settings) => ({

--- a/_packages/tsgo/src/setup/types.ts
+++ b/_packages/tsgo/src/setup/types.ts
@@ -54,6 +54,7 @@ export namespace Assessment {
     readonly text: string
     readonly hasPlugins: boolean
     readonly hasLspPlugin: boolean
+    readonly currentSchemaPath: Option.Option<string>
     readonly currentDiagnosticSeverities: Option.Option<Record<string, RuleSeverity>>
   }
 
@@ -79,6 +80,7 @@ export namespace Target {
   }
 
   export interface TsConfig {
+    readonly schemaPath: Option.Option<string>
     readonly diagnosticSeverities: Option.Option<Record<string, RuleSeverity>>
   }
 

--- a/_packages/tsgo/test/setup/__snapshots__/setup-cli.test.ts.snap
+++ b/_packages/tsgo/test/setup/__snapshots__/setup-cli.test.ts.snap
@@ -42,7 +42,7 @@ exports[`Setup CLI > should add LSP plugin alongside existing plugins > tsconfig
 }
     ]
   },
-"$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
+"$schema": "./node_modules/@effect/tsgo/schema.json"
 }"
 `;
 
@@ -107,7 +107,7 @@ exports[`Setup CLI > should add LSP with VS Code editor selected and create new 
 	}
 ]
   },
-"$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
+"$schema": "./node_modules/@effect/tsgo/schema.json"
 }"
 `;
 
@@ -154,7 +154,7 @@ exports[`Setup CLI > should add LSP with custom diagnostic severities when no pl
 	}
 ]
   },
-"$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
+"$schema": "./node_modules/@effect/tsgo/schema.json"
 }"
 `;
 
@@ -204,7 +204,7 @@ exports[`Setup CLI > should add custom diagnostic severities when plugin exists 
       }
     ]
   },
-"$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
+"$schema": "./node_modules/@effect/tsgo/schema.json"
 }"
 `;
 
@@ -271,7 +271,7 @@ exports[`Setup CLI > should generate changes for Astro-style configs using the l
       }
     ]
   },
-"$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
+"$schema": "./node_modules/@effect/tsgo/schema.json"
 }"
 `;
 
@@ -314,7 +314,7 @@ exports[`Setup CLI > should generate changes for adding LSP with defaults > tsco
 	}
 ]
   },
-"$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
+"$schema": "./node_modules/@effect/tsgo/schema.json"
 }"
 `;
 
@@ -358,7 +358,7 @@ exports[`Setup CLI > should generate changes for adding LSP with prepare script 
 	}
 ]
   },
-"$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
+"$schema": "./node_modules/@effect/tsgo/schema.json"
 }"
 `;
 
@@ -493,7 +493,7 @@ exports[`Setup CLI > should not override existing plugins when adding LSP plugin
 }
     ]
   },
-"$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
+"$schema": "./node_modules/@effect/tsgo/schema.json"
 }"
 `;
 
@@ -570,7 +570,7 @@ exports[`Setup CLI > should preserve all existing VS Code settings from a real r
 	}
 ]
   },
-"$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
+"$schema": "./node_modules/@effect/tsgo/schema.json"
 }"
 `;
 
@@ -635,7 +635,7 @@ exports[`Setup CLI > should preserve existing VS Code settings when adding LSP-s
 	}
 ]
   },
-"$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
+"$schema": "./node_modules/@effect/tsgo/schema.json"
 }"
 `;
 
@@ -758,7 +758,7 @@ exports[`Setup CLI > should replace existing tsconfig schema when adding LSP > p
 
 exports[`Setup CLI > should replace existing tsconfig schema when adding LSP > tsconfig.json 1`] = `
 "{
-  "$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json",
+  "$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -813,7 +813,7 @@ exports[`Setup CLI > should update LSP version when already installed with older
       }
     ]
   },
-"$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
+"$schema": "./node_modules/@effect/tsgo/schema.json"
 }"
 `;
 
@@ -864,6 +864,6 @@ exports[`Setup CLI > should update custom diagnostic severities when plugin alre
       }
     ]
   },
-"$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
+"$schema": "./node_modules/@effect/tsgo/schema.json"
 }"
 `;

--- a/_packages/tsgo/test/setup/changes.test.ts
+++ b/_packages/tsgo/test/setup/changes.test.ts
@@ -5,6 +5,7 @@ import { assess } from "../../src/setup/assessment.js"
 import type { Assessment } from "../../src/setup/types.js"
 
 const TEST_TYPESCRIPT_VERSION = "7.1.0-dev.test"
+const TEST_SCHEMA_PATH = "./node_modules/@effect/tsgo/schema.json"
 
 /**
  * Helper to create an Assessment.Input and run assess() + computeChanges()
@@ -70,6 +71,10 @@ function runComputeChanges(opts: {
       prepareScript: opts.prepareScript ?? true
     },
     tsconfig: {
+      schemaPath: Option.match(lspVersion, {
+        onNone: () => Option.none(),
+        onSome: () => Option.some(TEST_SCHEMA_PATH)
+      }),
       diagnosticSeverities: opts.diagnosticSeverities === undefined
         ? Option.none()
         : opts.diagnosticSeverities === null
@@ -558,7 +563,7 @@ describe("computeChanges", () => {
 
       const rendered = tsconfigAction!.changes.flatMap((c) => c.textChanges.map((tc) => tc.newText)).join("")
       expect(rendered).toContain("$schema")
-      expect(rendered).toContain("raw.githubusercontent.com")
+      expect(rendered).toContain(TEST_SCHEMA_PATH)
     })
 
     it("should update $schema when creating compilerOptions on a tsconfig with wrong $schema", () => {
@@ -576,7 +581,7 @@ describe("computeChanges", () => {
       expect(tsconfigAction!.description).toContain("Update $schema")
 
       const rendered = tsconfigAction!.changes.flatMap((c) => c.textChanges.map((tc) => tc.newText)).join("")
-      expect(rendered).toContain("raw.githubusercontent.com")
+      expect(rendered).toContain(TEST_SCHEMA_PATH)
       expect(rendered).not.toContain("example.com")
     })
 

--- a/_packages/tsgo/test/setup/diff-renderer.test.ts
+++ b/_packages/tsgo/test/setup/diff-renderer.test.ts
@@ -91,6 +91,7 @@ function makeAssessmentState(opts?: {
       text: tsconfigText,
       hasPlugins: false,
       hasLspPlugin: false,
+      currentSchemaPath: Option.none(),
       currentDiagnosticSeverities: Option.none()
     },
     vscodeSettings
@@ -165,6 +166,7 @@ describe("renderCodeActions", () => {
         text: existingText,
         hasPlugins: false,
         hasLspPlugin: false,
+        currentSchemaPath: Option.none(),
         currentDiagnosticSeverities: Option.none()
       }
     }

--- a/_packages/tsgo/test/setup/setup-cli.test.ts
+++ b/_packages/tsgo/test/setup/setup-cli.test.ts
@@ -2,8 +2,9 @@ import * as Option from "effect/Option"
 import { describe, expect, it } from "vitest"
 import { assess } from "../../src/setup/assessment.js"
 import { computeChanges } from "../../src/setup/changes.js"
-import { TSCONFIG_SCHEMA_URL } from "../../src/setup/consts.js"
-import type { Assessment, Target } from "../../src/setup/types.js"
+import type { Assessment, Editor, Target } from "../../src/setup/types.js"
+
+const TEST_SCHEMA_PATH = "./node_modules/@effect/tsgo/schema.json"
 
 /**
  * Create a test assessment input from plain objects
@@ -54,13 +55,28 @@ function applyTextChanges(
  */
 function expectSetupChanges(
   assessmentInput: Assessment.Input,
-  targetState: Target.State
+  targetState: {
+    readonly packageJson: Target.PackageJson
+    readonly tsconfig: {
+      readonly schemaPath?: Option.Option<string>
+      readonly diagnosticSeverities: Option.Option<Record<string, string>>
+    }
+    readonly vscodeSettings: Option.Option<Target.VSCodeSettings>
+    readonly editors: ReadonlyArray<string>
+  }
 ) {
   const normalizedTargetState: Target.State = {
     ...targetState,
+    editors: targetState.editors.filter((editor): editor is Editor =>
+      editor === "vscode" || editor === "nvim" || editor === "emacs"
+    ),
     tsconfig: {
       ...targetState.tsconfig,
-      diagnosticSeverities: targetState.tsconfig.diagnosticSeverities ?? Option.none()
+      schemaPath: targetState.tsconfig.schemaPath ?? Option.match(targetState.packageJson.lspVersion, {
+        onNone: () => Option.none(),
+        onSome: () => Option.some(TEST_SCHEMA_PATH)
+      }),
+      diagnosticSeverities: targetState.tsconfig.diagnosticSeverities as Target.TsConfig["diagnosticSeverities"]
     }
   }
 
@@ -163,7 +179,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.some({ dependencyType: "devDependencies" as const, version: "^0.0.5" }),
         typescriptVersion: Option.some({ dependencyType: "devDependencies" as const, version: TEST_TYPESCRIPT_VERSION, packageName: "typescript" }),
@@ -189,7 +205,7 @@ describe("Setup CLI", () => {
         }
       },
       {
-        $schema: TSCONFIG_SCHEMA_URL,
+        $schema: TEST_SCHEMA_PATH,
         compilerOptions: {
           strict: true,
           target: "ES2022",
@@ -202,7 +218,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.none(),
         typescriptVersion: Option.none(),
@@ -232,7 +248,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.some({ dependencyType: "devDependencies" as const, version: "^0.0.5" }),
         typescriptVersion: Option.some({ dependencyType: "devDependencies" as const, version: TEST_TYPESCRIPT_VERSION, packageName: "typescript" }),
@@ -272,7 +288,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.some({ dependencyType: "devDependencies" as const, version: "^0.0.5" }),
         typescriptVersion: Option.some({ dependencyType: "devDependencies" as const, version: TEST_TYPESCRIPT_VERSION, packageName: "typescript" }),
@@ -301,7 +317,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.some({ dependencyType: "devDependencies" as const, version: "^0.0.5" }),
         typescriptVersion: Option.some({ dependencyType: "devDependencies" as const, version: TEST_TYPESCRIPT_VERSION, packageName: "typescript" }),
@@ -341,7 +357,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.none(),
         typescriptVersion: Option.none(),
@@ -384,7 +400,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.none(),
         typescriptVersion: Option.none(),
@@ -424,7 +440,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.some({ dependencyType: "devDependencies" as const, version: "^0.0.5" }),
         typescriptVersion: Option.some({ dependencyType: "devDependencies" as const, version: TEST_TYPESCRIPT_VERSION, packageName: "typescript" }),
@@ -460,7 +476,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.some({ dependencyType: "devDependencies" as const, version: "^0.0.5" }),
         typescriptVersion: Option.some({ dependencyType: "devDependencies" as const, version: TEST_TYPESCRIPT_VERSION, packageName: "typescript" }),
@@ -501,7 +517,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.none(),
         typescriptVersion: Option.none(),
@@ -531,7 +547,7 @@ describe("Setup CLI", () => {
       // No vscodeSettings — file does not exist
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.some({ dependencyType: "devDependencies" as const, version: "^0.0.5" }),
         typescriptVersion: Option.some({ dependencyType: "devDependencies" as const, version: TEST_TYPESCRIPT_VERSION, packageName: "typescript" }),
@@ -565,7 +581,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.some({ dependencyType: "devDependencies" as const, version: "^0.0.5" }),
         typescriptVersion: Option.some({ dependencyType: "devDependencies" as const, version: TEST_TYPESCRIPT_VERSION, packageName: "typescript" }),
@@ -611,7 +627,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.some({ dependencyType: "devDependencies" as const, version: "^0.0.5" }),
         typescriptVersion: Option.some({ dependencyType: "devDependencies" as const, version: TEST_TYPESCRIPT_VERSION, packageName: "typescript" }),
@@ -640,7 +656,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.some({ dependencyType: "devDependencies" as const, version: "^0.0.5" }),
         typescriptVersion: Option.some({ dependencyType: "devDependencies" as const, version: TEST_TYPESCRIPT_VERSION, packageName: "typescript" }),
@@ -693,7 +709,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.some({ dependencyType: "devDependencies" as const, version: "^0.0.5" }),
         typescriptVersion: Option.some({ dependencyType: "devDependencies" as const, version: TEST_TYPESCRIPT_VERSION, packageName: "typescript" }),
@@ -736,7 +752,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.some({ dependencyType: "devDependencies" as const, version: "^0.0.5" }),
         typescriptVersion: Option.some({ dependencyType: "devDependencies" as const, version: TEST_TYPESCRIPT_VERSION, packageName: "typescript" }),
@@ -779,7 +795,7 @@ describe("Setup CLI", () => {
       }
     )
 
-    const targetState: Target.State = {
+    const targetState = {
       packageJson: {
         lspVersion: Option.some({ dependencyType: "devDependencies" as const, version: "^0.0.5" }),
         typescriptVersion: Option.some({ dependencyType: "devDependencies" as const, version: TEST_TYPESCRIPT_VERSION, packageName: "typescript" }),

--- a/_packages/tsgo/tsdown.config.ts
+++ b/_packages/tsgo/tsdown.config.ts
@@ -30,6 +30,9 @@ export default defineConfig({
 
       const readme = yield* fs.readFileString("../../README.md")
       yield* fs.writeFileString(path.join("README.md"), readme)
+
+      const schemaJson = yield* fs.readFileString("../../schema.json")
+      yield* fs.writeFileString(path.join("schema.json"), schemaJson)
     }).pipe(Effect.provide(Layer.merge(NodeFileSystem.layer, NodePath.layerPosix)))
 
     return Effect.runPromise(program)


### PR DESCRIPTION
## Summary

- ship the generated `schema.json` with `@effect/tsgo`
- configure setup to use the installed schema relative to the selected `tsconfig.json`
- replace the mutable GitHub `main` schema URL and preserve schema state in config flows

For a project-root tsconfig, setup now writes:

```json
{
  "$schema": "./node_modules/@effect/tsgo/schema.json"
}
```

Nested tsconfig paths are adjusted relative to their location.

Fixes #346

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`