### PR TITLE
fix: satisfy staticcheck in nil assertions

### DIFF
--- a/.changeset/fix-staticcheck-nil-guards.md
+++ b/.changeset/fix-staticcheck-nil-guards.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix staticcheck nil pointer warnings in tests.

--- a/internal/autoimportstyle/stylepolicy_test.go
+++ b/internal/autoimportstyle/stylepolicy_test.go
@@ -117,6 +117,7 @@ func TestApplyNamespaceRewriteFromAddToExisting(t *testing.T) {
 	result := sp.Apply(export, fix)
 	if result == nil {
 		t.Fatal("expected non-nil result")
+		return
 	}
 	if result.Kind != lsproto.AutoImportFixKindAddNew {
 		t.Errorf("expected rewrite to AddNew, got %v", result.Kind)

--- a/internal/effecttest/completion_test.go
+++ b/internal/effecttest/completion_test.go
@@ -124,6 +124,7 @@ class MyService extends Context./*1*/`
 	completions := f.GetCompletions(t, nil)
 	if completions == nil {
 		t.Fatal("completions is nil")
+		return
 	}
 	if findCompletionLabel(completions.Items, "Service<MyService, {}>") {
 		t.Error("did not expect Effect completion when completions=false")

--- a/internal/typeparser/data_first_signature_test.go
+++ b/internal/typeparser/data_first_signature_test.go
@@ -33,6 +33,7 @@ const provided = Effect.provide(program, MyService.Default, { local: true })
 	result := tp.DataFirstOrLastCall(call.AsNode())
 	if result == nil {
 		t.Fatal("expected provide call to normalize via derived signature comparison")
+		return
 	}
 	if result.SubjectIndex != 0 {
 		t.Fatalf("expected provide subject index 0, got %d", result.SubjectIndex)
@@ -62,6 +63,7 @@ const live = Layer.succeed(Service, make)
 	result := tp.DataFirstOrLastCall(call.AsNode())
 	if result == nil {
 		t.Fatal("expected Layer.succeed call to normalize via derived signature comparison")
+		return
 	}
 	if result.SubjectIndex != 1 {
 		t.Fatalf("expected Layer.succeed subject index 1, got %d", result.SubjectIndex)
@@ -133,6 +135,7 @@ export const shouldReportDataFirst = Effect.catchAll(
 	result := tp.DataFirstOrLastCall(call.AsNode())
 	if result == nil {
 		t.Fatal("expected data-first catchAll to normalize")
+		return
 	}
 	if strings.TrimSpace(nodeText(sf, result.Subject)) != "Effect.never" {
 		t.Fatalf("subject = %q, want %q", strings.TrimSpace(nodeText(sf, result.Subject)), "Effect.never")
@@ -259,6 +262,7 @@ func assertSingleTransformation(t *testing.T, sf *ast.SourceFile, flow *PipingFl
 	t.Helper()
 	if flow == nil {
 		t.Fatal("flow is nil")
+		return
 	}
 	if len(flow.Transformations) != 1 {
 		t.Fatalf("transformation count = %d, want 1", len(flow.Transformations))

--- a/internal/typeparser/helpers_test.go
+++ b/internal/typeparser/helpers_test.go
@@ -383,6 +383,7 @@ const value = Bar`,
 	b := sourceFiles["/.src/b.ts"]
 	if a == nil || b == nil {
 		t.Fatal("expected both source files")
+		return
 	}
 
 	moduleSym := checker.Checker_getSymbolOfDeclaration(c, a.AsNode())

--- a/internal/typeparser/service_type_test.go
+++ b/internal/typeparser/service_type_test.go
@@ -29,6 +29,7 @@ export class UserRepo extends Context.Service<UserRepo, { readonly find: () => s
 	service := tp.ServiceType(classType, className)
 	if service == nil {
 		t.Fatal("expected v4 service type to parse")
+		return
 	}
 	if service.Identifier == nil {
 		t.Fatal("expected service identifier type")
@@ -62,6 +63,7 @@ export class Config extends Context.Tag("Config")<Config, { readonly port: numbe
 	contextTag := tp.ContextTag(classType, className)
 	if contextTag == nil {
 		t.Fatal("expected v3 Context.Tag type to parse")
+		return
 	}
 	if contextTag.Identifier == nil {
 		t.Fatal("expected context tag identifier type")


### PR DESCRIPTION
## Summary
- stop test execution explicitly after fatal nil assertions
- avoid staticcheck SA5011 false positives in generated/latest CI
- add a patch changeset

## Testing
- pnpm setup-repo
- pnpm lint
- pnpm check
- pnpm test