### PR TITLE
Fix pipeable signature depth overflow

### DIFF
--- a/.changeset/fix-pipeable-signature-depth.md
+++ b/.changeset/fix-pipeable-signature-depth.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Avoid excessive type-depth diagnostics when matching data-first and pipeable overloads with complex return types.

--- a/internal/effecttest/effect_in_failure_ts2589_test.go
+++ b/internal/effecttest/effect_in_failure_ts2589_test.go
@@ -86,6 +86,7 @@ type NTuple<T, N extends number, Result extends unknown[] = []> = Result["length
 type Chunk<T extends readonly unknown[], N extends number> = T extends readonly [] ? [] : NTuple<T[number], N>[] | { [K in IntRangeInclusive<1, N>]: NTuple<T[number], K> }[IntRangeInclusive<1, N>]
 
 declare function chunk<T extends readonly unknown[], N extends number>(array: T, size: N): Chunk<T, N>
+declare function chunk<N extends number>(size: N): <T extends readonly unknown[]>(array: T) => Chunk<T, N>
 declare const items: Array<string>
 const result = chunk(items, 2)
 `

--- a/internal/rules/missing_pipeable_signature.go
+++ b/internal/rules/missing_pipeable_signature.go
@@ -51,15 +51,11 @@ func checkMissingPipeableSignatures(ctx *rule.Context) []*ast.Diagnostic {
 			}
 			params := dataFirst.Parameters()
 			for _, subjectIndex := range []int{0, len(params) - 1} {
-				derived := typeparser.DerivePipeableSignatureFromDataFirst(ctx.Checker, dataFirst, subjectIndex)
-				if derived == nil {
-					continue
-				}
 				for _, candidate := range signatures {
-					if candidate == dataFirst || !returnsUnaryFunction(ctx.Checker, candidate) {
+					if candidate == dataFirst {
 						continue
 					}
-					if checker.Checker_isSignatureAssignableTo(ctx.Checker, candidate, derived, false) {
+					if typeparser.MatchesPipeableSignature(ctx.Checker, dataFirst, candidate, subjectIndex, nil) {
 						hasPipeableSignature[dataFirst] = true
 						pipeableTargets[candidate] = true
 					}
@@ -121,20 +117,4 @@ func localExportTarget(ctx *rule.Context, exportSymbol *ast.Symbol) (*ast.Symbol
 
 func isEligibleDataFirstSignature(signature *checker.Signature) bool {
 	return signature != nil && !signature.HasRestParameter() && len(signature.Parameters()) >= 2
-}
-
-func returnsUnaryFunction(c *checker.Checker, signature *checker.Signature) bool {
-	if c == nil || signature == nil {
-		return false
-	}
-	returnType := c.GetReturnTypeOfSignature(signature)
-	if returnType == nil {
-		return false
-	}
-	for _, returned := range c.GetSignaturesOfType(returnType, checker.SignatureKindCall) {
-		if returned != nil && !returned.HasRestParameter() && len(returned.Parameters()) == 1 {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/typeparser/data_first_signature.go
+++ b/internal/typeparser/data_first_signature.go
@@ -15,11 +15,15 @@ type ParsedDataFirstOrLastCall struct {
 	SubjectIndex int
 }
 
+type PipeableSignatureWitness struct {
+	ArgumentTypes []*checker.Type
+	SubjectType   *checker.Type
+}
+
 func (tp *TypeParser) DataFirstOrLastCall(node *ast.Node) *ParsedDataFirstOrLastCall {
 	if tp == nil || tp.checker == nil || node == nil || node.Kind != ast.KindCallExpression {
 		return nil
 	}
-
 	call := node.AsCallExpression()
 	if call == nil || call.Expression == nil || call.Arguments == nil || len(call.Arguments.Nodes) < 2 {
 		return nil
@@ -65,10 +69,16 @@ func (tp *TypeParser) DataFirstOrLastCall(node *ast.Node) *ParsedDataFirstOrLast
 	}
 
 	for _, subjectIndex := range subjectIndexes {
-		derived := DerivePipeableSignatureFromDataFirst(c, resolved, subjectIndex)
-		if derived == nil {
+		subjectType := tp.GetTypeAtLocation(call.Arguments.Nodes[subjectIndex])
+		if subjectType == nil {
 			continue
 		}
+		args := omitArgAt(call.Arguments.Nodes, subjectIndex)
+		argumentTypes := make([]*checker.Type, 0, len(args))
+		for _, arg := range args {
+			argumentTypes = append(argumentTypes, tp.GetTypeAtLocation(arg))
+		}
+		witness := &PipeableSignatureWitness{ArgumentTypes: argumentTypes, SubjectType: subjectType}
 
 		for _, candidate := range candidates {
 			if candidate == nil || candidate.Declaration() == nil {
@@ -78,22 +88,7 @@ func (tp *TypeParser) DataFirstOrLastCall(node *ast.Node) *ParsedDataFirstOrLast
 			if candidateSymbol == nil || checker.Checker_getSymbolIfSameReference(c, resolvedSymbol, candidateSymbol) == nil {
 				continue
 			}
-			candidateReturn := c.GetReturnTypeOfSignature(candidate)
-			if candidateReturn == nil {
-				continue
-			}
-			returnedSigs := c.GetSignaturesOfType(candidateReturn, checker.SignatureKindCall)
-			hasUnaryReturnedCall := false
-			for _, returnedSig := range returnedSigs {
-				if returnedSig != nil && len(returnedSig.Parameters()) == 1 {
-					hasUnaryReturnedCall = true
-					break
-				}
-			}
-			if !hasUnaryReturnedCall {
-				continue
-			}
-			if !checker.Checker_isSignatureAssignableTo(c, candidate, derived, false) {
+			if !MatchesPipeableSignature(c, resolved, candidate, subjectIndex, witness) {
 				continue
 			}
 
@@ -101,13 +96,156 @@ func (tp *TypeParser) DataFirstOrLastCall(node *ast.Node) *ParsedDataFirstOrLast
 				Node:         call,
 				Callee:       call.Expression,
 				Subject:      call.Arguments.Nodes[subjectIndex],
-				Args:         omitArgAt(call.Arguments.Nodes, subjectIndex),
+				Args:         args,
 				SubjectIndex: subjectIndex,
 			}
 		}
 	}
 
 	return nil
+}
+
+// MatchesPipeableSignature reports whether candidate is the pipeable form of
+// dataFirst with the parameter at subjectIndex moved into a returned unary function.
+// When witness is nil, parameter types from dataFirst are used for comparison.
+func MatchesPipeableSignature(c *checker.Checker, dataFirst *checker.Signature, candidate *checker.Signature, subjectIndex int, witness *PipeableSignatureWitness) bool {
+	if c == nil || dataFirst == nil || candidate == nil {
+		return false
+	}
+	params := dataFirst.Parameters()
+	if subjectIndex < 0 || subjectIndex >= len(params) {
+		return false
+	}
+
+	derived := DerivePipeableSignatureFromDataFirst(c, dataFirst, subjectIndex)
+	if derived == nil {
+		return false
+	}
+
+	var argumentTypes []*checker.Type
+	var subjectType *checker.Type
+	if witness != nil {
+		argumentTypes = witness.ArgumentTypes
+		subjectType = witness.SubjectType
+	} else {
+		argumentTypes = make([]*checker.Type, 0, len(params)-1)
+		for i, param := range params {
+			if i == subjectIndex {
+				subjectType = c.GetTypeOfSymbol(param)
+				continue
+			}
+			argumentTypes = append(argumentTypes, c.GetTypeOfSymbol(param))
+		}
+	}
+
+	return argumentTypesMatchParameters(c, argumentTypes, candidate) && hasMatchingUnaryReturn(c, candidate, derived, subjectType)
+}
+
+func argumentTypesMatchParameters(c *checker.Checker, args []*checker.Type, sig *checker.Signature) bool {
+	if c == nil || sig == nil || len(args) < sig.MinArgumentCount() {
+		return false
+	}
+	params := sig.Parameters()
+	if len(params) == 0 {
+		return len(args) == 0
+	}
+	if len(args) > len(params) && !sig.HasRestParameter() {
+		return false
+	}
+	for i, argType := range args {
+		paramIndex := i
+		if paramIndex >= len(params) {
+			paramIndex = len(params) - 1
+		}
+		paramType := c.GetTypeOfSymbol(params[paramIndex])
+		if !typeAcceptsArgument(c, argType, paramType) && (len(sig.TypeParameters()) == 0 || !hasCompatibleCallShape(c, argType, paramType)) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasMatchingUnaryReturn(c *checker.Checker, candidate *checker.Signature, derived *checker.Signature, subjectType *checker.Type) bool {
+	if c == nil || candidate == nil || derived == nil || subjectType == nil {
+		return false
+	}
+	candidateReturn := c.GetReturnTypeOfSignature(candidate)
+	derivedReturn := c.GetReturnTypeOfSignature(derived)
+	if candidateReturn == nil || derivedReturn == nil {
+		return false
+	}
+	derivedSigs := c.GetSignaturesOfType(derivedReturn, checker.SignatureKindCall)
+	for _, candidateSig := range c.GetSignaturesOfType(candidateReturn, checker.SignatureKindCall) {
+		if candidateSig == nil || len(candidateSig.Parameters()) != 1 {
+			continue
+		}
+		for _, derivedSig := range derivedSigs {
+			if derivedSig == nil || len(derivedSig.Parameters()) != 1 {
+				continue
+			}
+			candidateParamType := c.GetTypeOfSymbol(candidateSig.Parameters()[0])
+			if !typeAcceptsArgument(c, subjectType, candidateParamType) && ((len(candidate.TypeParameters()) == 0 && len(candidateSig.TypeParameters()) == 0) || !hasCompatibleCallShape(c, subjectType, candidateParamType)) {
+				continue
+			}
+			if !sameShallowTypeOrigin(c, c.GetReturnTypeOfSignature(candidateSig), c.GetReturnTypeOfSignature(derivedSig)) {
+				continue
+			}
+			return true
+		}
+	}
+	return false
+}
+
+func hasCompatibleCallShape(c *checker.Checker, left *checker.Type, right *checker.Type) bool {
+	if c == nil || left == nil || right == nil {
+		return false
+	}
+	leftCallable := len(c.GetSignaturesOfType(left, checker.SignatureKindCall)) > 0
+	rightCallable := len(c.GetSignaturesOfType(right, checker.SignatureKindCall)) > 0
+	return leftCallable == rightCallable
+}
+
+func typeAcceptsArgument(c *checker.Checker, argument *checker.Type, parameter *checker.Type) bool {
+	if c == nil || argument == nil || parameter == nil {
+		return false
+	}
+	if parameter.Flags()&checker.TypeFlagsTypeParameter != 0 {
+		constraint := c.GetConstraintOfTypeParameter(parameter)
+		return constraint == nil || typeAcceptsArgument(c, argument, constraint)
+	}
+	return sameShallowTypeOrigin(c, argument, parameter) || checker.Checker_isTypeAssignableTo(c, argument, parameter)
+}
+
+func sameShallowTypeOrigin(c *checker.Checker, left *checker.Type, right *checker.Type) bool {
+	if left == right {
+		return true
+	}
+	if c == nil || left == nil || right == nil {
+		return false
+	}
+
+	if left.ObjectFlags()&checker.ObjectFlagsReference != 0 || right.ObjectFlags()&checker.ObjectFlagsReference != 0 {
+		if left.ObjectFlags()&checker.ObjectFlagsReference == 0 || right.ObjectFlags()&checker.ObjectFlagsReference == 0 {
+			return false
+		}
+		leftTarget, rightTarget := left.Target(), right.Target()
+		return leftTarget == rightTarget || sameSymbolReference(c, leftTarget.Symbol(), rightTarget.Symbol())
+	}
+
+	leftAlias, rightAlias := left.Alias(), right.Alias()
+	if leftAlias != nil || rightAlias != nil {
+		return leftAlias != nil && rightAlias != nil && sameSymbolReference(c, leftAlias.Symbol(), rightAlias.Symbol())
+	}
+
+	if left.Symbol() != nil || right.Symbol() != nil {
+		return sameSymbolReference(c, left.Symbol(), right.Symbol())
+	}
+
+	return left.Flags() == right.Flags() && left.Flags()&checker.TypeFlagsSingleton != 0
+}
+
+func sameSymbolReference(c *checker.Checker, left *ast.Symbol, right *ast.Symbol) bool {
+	return left != nil && right != nil && checker.Checker_getSymbolIfSameReference(c, left, right) != nil
 }
 
 // DerivePipeableSignatureFromDataFirst removes the subject parameter from a

--- a/internal/typeparser/data_first_signature_test.go
+++ b/internal/typeparser/data_first_signature_test.go
@@ -158,6 +158,49 @@ export const shouldReportDataFirst = Effect.catchAll(
 	assertSingleTransformation(t, sf, flow, TransformationKindDataFirst, "Effect.catchAll", []string{"() => Effect.log(\"error\")"})
 }
 
+func TestDataFirstOrLastCallRejectsDifferentReturnOrigins(t *testing.T) {
+	t.Parallel()
+
+	source := `
+type DataFirstResult<T> = { readonly dataFirst: T }
+type DataLastResult<T> = { readonly dataLast: T }
+
+declare function operation<T>(self: T, size: number): DataFirstResult<T>
+declare function operation(size: number): <T>(self: T) => DataLastResult<T>
+
+const result = operation("value", 2)
+`
+
+	_, tp, sf, done := compileAndGetCheckerAndSourceFileInternal(t, source)
+	defer done()
+
+	call := findVariableInitializerCallByName(t, sf, "result")
+	if result := tp.DataFirstOrLastCall(call.AsNode()); result != nil {
+		t.Fatal("expected overloads with different return origins not to normalize")
+	}
+}
+
+func TestDataFirstOrLastCallRejectsIncompatibleSubject(t *testing.T) {
+	t.Parallel()
+
+	source := `
+type Result = { readonly value: string }
+
+declare function operation(self: string, size: number): Result
+declare function operation(size: number): (self: boolean) => Result
+
+const result = operation("value", 2)
+`
+
+	_, tp, sf, done := compileAndGetCheckerAndSourceFileInternal(t, source)
+	defer done()
+
+	call := findVariableInitializerCallByName(t, sf, "result")
+	if result := tp.DataFirstOrLastCall(call.AsNode()); result != nil {
+		t.Fatal("expected overloads with an incompatible subject not to normalize")
+	}
+}
+
 func logDerivedPipeableSignatureComparison(t *testing.T, tp *TypeParser, node *ast.Node) {
 	t.Helper()
 	if tp == nil || tp.checker == nil || node == nil {
@@ -226,15 +269,14 @@ func logDerivedPipeableSignatureComparison(t *testing.T, tp *TypeParser, node *a
 				}
 			}
 			t.Logf(
-				"derived=%s | candidate %d=%s | return=%s typeArgs=%d returnedArity=%v cand->derived=%v derived->cand=%v",
+				"derived=%s | candidate %d=%s | return=%s typeArgs=%d returnedArity=%v matches=%v",
 				signatureString(c, derived),
 				i,
 				signatureString(c, candidate),
 				c.TypeToString(candidateReturn),
 				len(candidate.TypeParameters()),
 				returnedArity,
-				checker.Checker_isSignatureAssignableTo(c, candidate, derived, false),
-				checker.Checker_isSignatureAssignableTo(c, derived, candidate, false),
+				MatchesPipeableSignature(c, resolved, candidate, subjectIndex, nil),
 			)
 		}
 	}

--- a/shim/checker/extra-shim.json
+++ b/shim/checker/extra-shim.json
@@ -1,7 +1,7 @@
 {
   "ExtraFunctions": ["forEachYieldExpression"],
   "ExtraMethods": {
-    "Checker": ["isTypeAssignableTo", "isArrayType", "isReadonlyArrayType", "getIndexInfosOfType", "getTypeArguments", "getLiteralTypeFromProperty", "getSymbolIfSameReference", "getSymbolOfDeclaration", "isSignatureAssignableTo", "isReferenceToType", "newFunctionType", "newCallSignature", "isSymbolAssigned", "isPastLastAssignment"]
+    "Checker": ["isTypeAssignableTo", "isArrayType", "isReadonlyArrayType", "getIndexInfosOfType", "getTypeArguments", "getLiteralTypeFromProperty", "getSymbolIfSameReference", "getSymbolOfDeclaration", "isReferenceToType", "newFunctionType", "newCallSignature", "isSymbolAssigned", "isPastLastAssignment"]
   },
   "ExtraFields": {
     "Checker": [

--- a/shim/checker/shim.go
+++ b/shim/checker/shim.go
@@ -121,8 +121,6 @@ func Checker_isSymbolAssigned(recv *checker.Checker, symbol *ast.Symbol) bool
 func Checker_isPastLastAssignment(recv *checker.Checker, symbol *ast.Symbol, location *ast.Node) bool
 //go:linkname Checker_isTypeAssignableTo github.com/microsoft/typescript-go/internal/checker.(*Checker).isTypeAssignableTo
 func Checker_isTypeAssignableTo(recv *checker.Checker, source *checker.Type, target *checker.Type) bool
-//go:linkname Checker_isSignatureAssignableTo github.com/microsoft/typescript-go/internal/checker.(*Checker).isSignatureAssignableTo
-func Checker_isSignatureAssignableTo(recv *checker.Checker, source *checker.Signature, target *checker.Signature, ignoreReturnTypes bool) bool
 type extra_Checker struct {
   id uint32
   program checker.Program


### PR DESCRIPTION
## Summary

- replace speculative full signature assignability with a shared data-first/pipeable correspondence matcher
- use concrete call types for piping-flow normalization and declaration types for `missingPipeableSignature`
- compare final return origins shallowly to avoid expanding recursive generic return types
- remove the now-unused `isSignatureAssignableTo` checker shim

## Example

The Effect plugin no longer introduces `TS2321` or `TS2589` for Remeda calls such as:

```ts
import { chunk } from "remeda"

declare const items: Array<string>
const result = chunk(items, 2)
```

The matcher still verifies outer arguments, the moved subject parameter, and the final return alias/reference origin without structurally expanding `Chunk<T, N>`.

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- verified the cloned `effect-tsgo-stack-depth-repro` project with the locally built binary

References #362