### PR TITLE
fix yield star hover quickinfo

### DIFF
--- a/.changeset/fix-yield-star-hover.md
+++ b/.changeset/fix-yield-star-hover.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Return enhanced Effect quickinfo when hovering the asterisk or trailing space in a `yield*` expression.

--- a/etslshooks/init.go
+++ b/etslshooks/init.go
@@ -178,11 +178,20 @@ func afterQuickInfo(program checker.Program, c *checker.Checker, sf *ast.SourceF
 		return quickInfo, documentation, nil
 	}
 
-	// Yield* hover: detect yield keyword inside yield* expressions in Effect generator scopes
-	if node.Kind == ast.KindYieldKeyword && node.Parent != nil && node.Parent.Kind == ast.KindYieldExpression {
-		yield := node.Parent.AsYieldExpression()
+	// Yield* hover: normalize positions on yield, *, and the space before the operand.
+	var yieldNode *ast.Node
+	switch node.Kind {
+	case ast.KindYieldExpression:
+		yieldNode = node
+	case ast.KindYieldKeyword, ast.KindAsteriskToken:
+		if node.Parent != nil && node.Parent.Kind == ast.KindYieldExpression {
+			yieldNode = node.Parent
+		}
+	}
+	if yieldNode != nil {
+		yield := yieldNode.AsYieldExpression()
 		if yield.AsteriskToken != nil && yield.Expression != nil {
-			if tp.GetEffectContextFlags(node)&typeparser.EffectContextFlagCanYieldEffect != 0 {
+			if tp.GetEffectContextFlags(yieldNode)&typeparser.EffectContextFlagCanYieldEffect != 0 {
 				t := tp.GetTypeAtLocation(yield.Expression)
 				if t != nil {
 					effect := tp.EffectYieldableType(t, yield.Expression)
@@ -190,7 +199,7 @@ func afterQuickInfo(program checker.Program, c *checker.Checker, sf *ast.SourceF
 						typeStr := c.TypeToStringEx(t, nil, checker.TypeFormatFlagsNoTruncation, nil)
 						quickInfo = "(yield*) " + typeStr
 						documentation = formatEffectTypeParams(c, effect, "", isMarkdown)
-						return quickInfo, documentation, node.Parent
+						return quickInfo, documentation, yieldNode
 					}
 				}
 			}

--- a/internal/effecttest/hover_test.go
+++ b/internal/effecttest/hover_test.go
@@ -27,18 +27,20 @@ func TestEffectHoverYieldStar(t *testing.T) {
   }
 }
 // @Filename: /test.ts
-import { Effect } from "effect"
+import { Config, Effect } from "effect"
 const program = Effect.gen(function*() {
-  const result = /*1*/yield* Effect.succeed("hello")
+  const token = /*yield*/yield/*asterisk*/*/*space*/ Config.redacted("WEBHOOK_TOKEN")
 })`
 
 	f, done := fourslash.NewFourslash(t, nil /*capabilities*/, content)
 	defer done()
 
-	f.VerifyQuickInfoAt(t, "1",
-		"(yield*) Effect<string, never, never>",
-		"```ts\n/* Effect Type Parameters */\ntype Success = string\ntype Failure = never\ntype Requirements = never\n```\n",
-	)
+	for _, marker := range []string{"yield", "asterisk", "space"} {
+		f.VerifyQuickInfoAt(t, marker,
+			"(yield*) Config<Redacted<string>>",
+			"```ts\n/* Effect Type Parameters */\ntype Success = Redacted<string>\ntype Failure = ConfigError\ntype Requirements = never\n```\n",
+		)
+	}
 }
 
 func TestEffectHoverTypeArgs(t *testing.T) {


### PR DESCRIPTION
## Summary

- normalize hover positions on `yield`, `*`, and the following space to the enclosing `yield*` expression
- return the same enhanced Effect quickinfo for each position
- cover the reported `Config.redacted("WEBHOOK_TOKEN")` case with a regression test

## Behavior

Before this change, hovering `*` or the following space in `yield* Config.redacted(...)` returned `null`. These positions now return the same Effect type information as hovering `yield`.

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`

Refs #372