### PR TITLE
fix: avoid effectInVoidSuccess type depth overflow

### DIFF
--- a/.changeset/fix-effect-void-depth.md
+++ b/.changeset/fix-effect-void-depth.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Avoid `effectInVoidSuccess` introducing TS2589 for assignments with recursive expected types and non-Effect values.

--- a/internal/effecttest/effect_in_void_success_ts2589_test.go
+++ b/internal/effecttest/effect_in_void_success_ts2589_test.go
@@ -1,0 +1,64 @@
+package effecttest
+
+import "testing"
+
+func TestIssue381EffectInVoidSuccessDoesNotReportExcessiveTypeDepth(t *testing.T) {
+	t.Parallel()
+
+	withoutPlugin := collectDiagnosticStringsFromContent(t, buildIssue381EffectInVoidSuccessCase(false))
+	if hasDiagnosticCode(withoutPlugin, "TS2589:") {
+		t.Fatalf("did not expect TS2589 without plugin, got %v", withoutPlugin)
+	}
+
+	withPlugin := collectDiagnosticStringsFromContent(t, buildIssue381EffectInVoidSuccessCase(true))
+	if hasDiagnosticCode(withPlugin, "TS2589:") {
+		t.Fatalf("did not expect effectInVoidSuccess to introduce TS2589, got %v", withPlugin)
+	}
+}
+
+func buildIssue381EffectInVoidSuccessCase(pluginEnabled bool) string {
+	pluginConfig := ""
+	if pluginEnabled {
+		pluginConfig = `,
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnosticSeverity": {
+          "effectInVoidSuccess": "warning"
+        }
+      }
+    ]`
+	}
+
+	return `// @filename: tsconfig.json
+{
+  "compilerOptions": {
+    "target": "ES2025",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true` + pluginConfig + `
+  }
+}
+
+// @filename: test.ts
+import type { Schema } from "effect"
+
+type Recurse<Value> = {
+  [Key in keyof Value]: Recurse<Value[Key]>
+}
+
+type Json = readonly Json[] | JsonObject
+type JsonObject = { readonly [key: string]: Json }
+
+type ValueType<Definition> =
+  Definition extends Schema.Codec<infer Value, Json> ? Value : never
+
+declare let value: Recurse<
+  ValueType<Schema.Codec<JsonObject>> | null
+>
+
+value = null
+`
+}

--- a/internal/rules/effect_in_void_success.go
+++ b/internal/rules/effect_in_void_success.go
@@ -28,10 +28,13 @@ var EffectInVoidSuccess = rule.Rule{
 				continue
 			}
 
-			expectedEffect := ctx.TypeParser.EffectType(entry.ExpectedType, entry.Node)
 			realEffect := ctx.TypeParser.EffectType(entry.RealType, entry.ValueNode)
+			if realEffect == nil {
+				continue
+			}
 
-			if expectedEffect == nil || realEffect == nil {
+			expectedEffect := ctx.TypeParser.EffectType(entry.ExpectedType, entry.Node)
+			if expectedEffect == nil {
 				continue
 			}
 


### PR DESCRIPTION
## Summary

- inspect the real assignment value before structurally parsing the expected Effect type
- skip recursive expected-type expansion when the value cannot be an Effect
- add regression coverage and a patch changeset

## Example

Assignments such as this no longer make `effectInVoidSuccess` introduce a fileless `TS2589`:

```ts
declare let value: Recurse<ValueType<Schema.Codec<JsonObject>> | null>
value = null
```

## Testing

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`

Fixes #381