### PR TITLE
fix: preserve release binary permissions

### DIFF
--- a/.changeset/calm-files-execute.md
+++ b/.changeset/calm-files-execute.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Preserve executable permissions on packaged Unix binaries so the diagnostics command can launch them after installation.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,8 @@ jobs:
             else
               cp "${artifact_dir}/${binary_name}" "${package_dir}/${binary_name}"
               cp "${artifact_dir}/${binary_name}.json" "${package_dir}/${binary_name}.json"
+              chmod 0755 "${package_dir}/${binary_name}"
+              test -x "${package_dir}/${binary_name}"
             fi
           done
 


### PR DESCRIPTION
## Summary

- restore `0755` permissions on downloaded Unix binaries before package publication
- fail the release job if a copied Unix binary is not executable
- add a patch changeset for the fixed package group

## Root Cause

GitHub Actions artifact uploads normalize file modes to `0644`. The publish job copied those downloaded files without restoring their executable bits, so `effect-tsgo diagnostics` failed with `spawnSync ... EACCES` after installation.

## Verification

- reproduced the failure with Yarn 4 and `@effect/tsgo@0.24.2`
- confirmed `@effect/tsgo-linux-x64` published binaries as `0644`, while `@typescript/typescript-linux-x64` publishes `lib/tsc` as `0755`
- confirmed diagnostics run successfully after restoring the executable bit
- `git diff --check`
- `pnpm changeset status --since=origin/main`

The Go and TypeScript validation suite was skipped because this PR changes only the release workflow and a changeset.