### PR TITLE
Fix diagnostics binary permissions at runtime

### DIFF
--- a/.changeset/fix-diagnostics-binary-permissions.md
+++ b/.changeset/fix-diagnostics-binary-permissions.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Ensure the packaged diagnostics binary is executable immediately before launch instead of relying on file permissions preserved during publishing.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,8 +144,6 @@ jobs:
             else
               cp "${artifact_dir}/${binary_name}" "${package_dir}/${binary_name}"
               cp "${artifact_dir}/${binary_name}.json" "${package_dir}/${binary_name}.json"
-              chmod 0755 "${package_dir}/${binary_name}"
-              test -x "${package_dir}/${binary_name}"
             fi
           done
 

--- a/_packages/tsgo/src/cli.ts
+++ b/_packages/tsgo/src/cli.ts
@@ -601,8 +601,12 @@ const diagnosticsCommand = Command.make("diagnostics", {
   Command.withDescription("Gets the Effect language service diagnostics on the given files or project"),
   Command.withHandler(({ file, format, lspconfig, progress, project, severity, strict }) =>
     Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
       const installedTypeScript = yield* resolveInstalledTypeScriptBinary(defaultTypescriptPackageNames)
       const binaryPath = yield* getPackagedBinaryPath(installedTypeScript, false)
+      yield* fs.chmod(binaryPath, 0o755).pipe(
+        Effect.mapError(() => new ChmodBinaryError({ targetPath: binaryPath }))
+      )
       const result = runDiagnosticsBinary(binaryPath, {
         cwd: process.cwd(),
         file: Option.getOrUndefined(file),


### PR DESCRIPTION
## Summary

- set the packaged diagnostics binary mode to `0755` immediately before `runDiagnosticsBinary`
- report permission failures through the existing `ChmodBinaryError` path used by the patch command
- remove the ineffective publish-time `chmod` and executable assertion from the release workflow

This makes `effect-tsgo diagnostics` independent of whether npm publishing preserves the binary executable bit.

## Testing

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`