### PR TITLE
fix: publish platform binaries with the executable bit

### DIFF
--- a/.changeset/publish-executable-platform-binaries.md
+++ b/.changeset/publish-executable-platform-binaries.md
@@ -1,0 +1,12 @@
+---
+"@effect/tsgo": patch
+---
+
+Publish the packaged `lib/tsc` and `lib/tsc-next` binaries with mode `0755`.
+
+`pnpm pack`/`pnpm publish` normalises every packed file to `0644` and grants `0755` only to files
+referenced by the published manifest's `bin` field, ignoring the on-disk mode. Every published
+`@effect/tsgo-*` tarball therefore shipped non-executable binaries, so `effect-tsgo diagnostics`
+failed with `spawnSync ... EACCES` and `effect-tsgo get-exe-path` printed a path that consumers
+could not execute. The POSIX platform packages now declare `publishConfig.bin` for both binaries,
+which is what makes pnpm mark them executable at pack time.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check platform package publish permissions
+        run: bash _tools/check-platform-package-bins.sh
+
       - name: Setup repo (submodules, patches, generated files)
         run: pnpm setup-repo --ci
 

--- a/_packages/tsgo-darwin-arm64/package.json
+++ b/_packages/tsgo-darwin-arm64/package.json
@@ -12,7 +12,11 @@
   "homepage": "https://github.com/Effect-TS/tsgo#readme",
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "bin": {
+      "effect-tsgo-tsc": "./lib/tsc",
+      "effect-tsgo-tsc-next": "./lib/tsc-next"
+    }
   },
   "preferUnplugged": true,
   "files": [

--- a/_packages/tsgo-darwin-x64/package.json
+++ b/_packages/tsgo-darwin-x64/package.json
@@ -12,7 +12,11 @@
   "homepage": "https://github.com/Effect-TS/tsgo#readme",
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "bin": {
+      "effect-tsgo-tsc": "./lib/tsc",
+      "effect-tsgo-tsc-next": "./lib/tsc-next"
+    }
   },
   "preferUnplugged": true,
   "files": [

--- a/_packages/tsgo-linux-arm/package.json
+++ b/_packages/tsgo-linux-arm/package.json
@@ -12,7 +12,11 @@
   "homepage": "https://github.com/Effect-TS/tsgo#readme",
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "bin": {
+      "effect-tsgo-tsc": "./lib/tsc",
+      "effect-tsgo-tsc-next": "./lib/tsc-next"
+    }
   },
   "preferUnplugged": true,
   "files": [

--- a/_packages/tsgo-linux-arm64/package.json
+++ b/_packages/tsgo-linux-arm64/package.json
@@ -12,7 +12,11 @@
   "homepage": "https://github.com/Effect-TS/tsgo#readme",
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "bin": {
+      "effect-tsgo-tsc": "./lib/tsc",
+      "effect-tsgo-tsc-next": "./lib/tsc-next"
+    }
   },
   "preferUnplugged": true,
   "files": [

--- a/_packages/tsgo-linux-x64/package.json
+++ b/_packages/tsgo-linux-x64/package.json
@@ -12,7 +12,11 @@
   "homepage": "https://github.com/Effect-TS/tsgo#readme",
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "bin": {
+      "effect-tsgo-tsc": "./lib/tsc",
+      "effect-tsgo-tsc-next": "./lib/tsc-next"
+    }
   },
   "preferUnplugged": true,
   "files": [

--- a/_tools/check-platform-package-bins.sh
+++ b/_tools/check-platform-package-bins.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-platform-package-bins.sh — Guards the executable bit on published binaries.
+#
+# pnpm pack/publish normalises every packed file to 0644 and grants 0755 only to
+# files referenced by the published manifest's `bin` field; the on-disk mode is
+# ignored. Each POSIX platform package is packed here with placeholder binaries
+# (deliberately 0644 on disk) and the resulting tarball entries are asserted to
+# be 0755, so removing `publishConfig.bin` fails CI instead of shipping a broken
+# release.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BINARIES=(tsc tsc-next)
+
+# Discovered, not hardcoded: a new POSIX platform package must not be able to
+# escape the guard by being forgotten here. win32 is excluded because the mode
+# bit is meaningless for .exe.
+TARGETS=()
+for dir in "${REPO_ROOT}"/_packages/tsgo-*/; do
+  name="$(basename "${dir}")"
+  name="${name#tsgo-}"
+  case "${name}" in win32-*) continue ;; esac
+  TARGETS+=("${name}")
+done
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+  echo "ERROR: no POSIX platform packages found under _packages/" >&2
+  exit 1
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+status=0
+for target in "${TARGETS[@]}"; do
+  package_dir="${workdir}/tsgo-${target}"
+  mkdir -p "${package_dir}/lib"
+  cp "${REPO_ROOT}/_packages/tsgo-${target}/package.json" "${package_dir}/package.json"
+
+  for binary in "${BINARIES[@]}"; do
+    printf '#!/bin/sh\nexit 0\n' > "${package_dir}/lib/${binary}"
+    printf '{}\n' > "${package_dir}/lib/${binary}.json"
+    chmod 0644 "${package_dir}/lib/${binary}"
+  done
+
+  if ! (cd "${package_dir}" && pnpm pack --pack-destination "${package_dir}" > /dev/null); then
+    echo "  FAIL tsgo-${target}: pnpm pack failed"
+    status=1
+    continue
+  fi
+  tarball="$(find "${package_dir}" -maxdepth 1 -name '*.tgz' | head -n 1)"
+
+  listing="$(tar -tvf "${tarball}")"
+  for binary in "${BINARIES[@]}"; do
+    mode="$(printf '%s\n' "${listing}" | awk -v entry="package/lib/${binary}" '$NF == entry { print $1 }')"
+    if [ "${mode}" = "-rwxr-xr-x" ]; then
+      echo "  ok   @effect/tsgo-${target} lib/${binary} ${mode}"
+    else
+      echo "  FAIL @effect/tsgo-${target} lib/${binary} ${mode:-<missing from tarball>} (expected -rwxr-xr-x)"
+      status=1
+    fi
+  done
+done
+
+if [ "${status}" -ne 0 ]; then
+  echo ""
+  echo "ERROR: packed platform binaries are not executable."
+  echo "Every POSIX platform package must declare publishConfig.bin for each packaged binary."
+  exit 1
+fi
+
+echo ""
+echo "All packed platform binaries are executable."


### PR DESCRIPTION
Follow-up to #385, as requested there — the fix in #391 did not take effect, and #397 removed it.

## Summary

- declare `publishConfig.bin` for `lib/tsc` and `lib/tsc-next` in the five POSIX platform packages, so `pnpm publish` packs them as `0755`
- add `_tools/check-platform-package-bins.sh` and run it in CI, so a regression fails the PR instead of shipping a broken release

## Problem

Every published `@effect/tsgo-*` tarball ships `lib/tsc` and `lib/tsc-next` with mode `0644`:

```console
$ curl -sL "$(npm view @effect/tsgo-darwin-arm64 dist.tarball)" -o p.tgz
$ tar -tvzf p.tgz | grep 'lib/tsc'
-rw-r--r--  0 0  0  29361682  package/lib/tsc
-rw-r--r--  0 0  0  29430898  package/lib/tsc-next
```

Same on `0.24.1`, `0.24.2` and `0.24.3` (`latest`), and on every POSIX platform package. Because the mode is already wrong inside the tarball on the registry, no package manager or install flag can work around it.

This is the `spawnSync ... EACCES` from #385. It also breaks `effect-tsgo get-exe-path` in a way that produces no error at all: the command prints the path and exits `0` for a file the caller cannot execute, so editor integrations that resolve the server through it (`get-exe-path`, then a `vim.fn.executable()` guard) silently fall back to stock `tsc`. The user gets TypeScript with zero Effect diagnostics and nothing in any log to indicate it. That is how I found this.

## Root cause

`pnpm pack` / `pnpm publish` normalise every packed file to `0644` and grant `0755` **only** to files referenced by the published manifest's `bin` field. The on-disk mode is ignored entirely. `npm pack` preserves the on-disk mode, which is why `@typescript/native-preview-*` ships `lib/tsgo` as `0755` with no `bin` field — Microsoft publishes with npm.

Minimal repro, both directions, on pnpm 9.15.9 (the version pinned in `release.yml`) and 10.26.1:

```console
$ printf '{"name":"m","version":"1.0.0","files":["lib/tsc"]}' > package.json
$ chmod 0755 lib/tsc

$ npm pack  && tar -tvzf m-1.0.0.tgz | grep 'lib/tsc$'
-rwxr-xr-x  ...  package/lib/tsc        # npm  -> preserved
$ pnpm pack && tar -tvzf m-1.0.0.tgz | grep 'lib/tsc$'
-rw-r--r--  ...  package/lib/tsc        # pnpm -> stripped

# now with a bin entry, leaving the file 0644 on disk:
$ chmod 0644 lib/tsc
$ printf '{"name":"m","version":"1.0.0","files":["lib/tsc"],"bin":{"m":"./lib/tsc"}}' > package.json
$ pnpm pack && tar -tvzf m-1.0.0.tgz | grep 'lib/tsc$'
-rwxr-xr-x  ...  package/lib/tsc        # pnpm -> granted from the manifest
```

Releases go out through `pnpm changeset:publish`, and `@changesets/cli` spawns `pnpm publish` when pnpm is detected, so the pnpm packer is what writes these tarballs.

The repo's own artifacts corroborate this: in the same publish run, `@effect/tsgo` ships `dist/effect-tsgo.js` as `-rwxr-xr-x` — it is a `bin` target via `publishConfig.bin` in `_packages/tsgo/package.json` — while the platform binaries beside it ship `0644`.

## Why #391 did not fix it

#391 added `chmod 0755` + `test -x` to the `Copy binaries into platform packages` step. Those commands **ran and passed** in the job that published `0.24.3` (run `30021920384`, job `89258657797`), and `0.24.3` is still `0644` on the registry — pnpm rewrites the mode afterwards, at pack time. Any working-tree chmod is unobservable in the resulting tarball. #397 then removed those lines.

## The change

Each POSIX platform package declares both binaries under `publishConfig.bin`:

```jsonc
"publishConfig": {
  "access": "public",
  "provenance": true,
  "bin": {
    "effect-tsgo-tsc": "./lib/tsc",
    "effect-tsgo-tsc-next": "./lib/tsc-next"
  }
}
```

`publishConfig.bin` rather than a top-level `bin` on purpose: `lib/` is gitignored and absent in a clean checkout, and a top-level `bin` makes `pnpm install` emit `WARN Failed to create bin ... ENOENT ... lib/tsc` for every platform package. `publishConfig.bin` is applied by pnpm only when packing, is inert at install time, and matches the convention already used by `_packages/tsgo/package.json`.

The win32 packages are deliberately untouched — the mode bit is meaningless for `.exe`, and adding `bin` there would only create dead shims.

`_tools/check-platform-package-bins.sh` copies each POSIX platform manifest into a temp dir with placeholder binaries deliberately `0644` on disk, runs `pnpm pack`, and asserts the tarball entries are `-rwxr-xr-x`. The platform list is discovered from `_packages/tsgo-*` rather than hardcoded, so a new platform cannot be forgotten by the guard meant to prevent exactly this. It runs in the CI `Test` job.

## Risks considered

- **`.bin` shim collision with the real `tsc`.** The reason for the `effect-tsgo-` prefix: `typescript` owns the `tsc` bin name, so naming these `tsc` / `tsc-next` would shadow it. With npm, a transitive optional dependency's bins are hoisted into the consumer's root `node_modules/.bin`; with pnpm the shim stays nested and the root `.bin` is unchanged.
- **Yarn PnP + `preferUnplugged: true`** (the environment in #385). With Yarn 4.6.0, the package with the `bin` declaration unplugs to `0755`, the one without unplugs to `0644`.
- **Install size** is unchanged; `bin` adds no files.
- **Belt and braces:** npm also chmods `bin` targets to `0755` at install time, even from a `0644` tarball. So this fixes the problem at pack time under pnpm and at install time under npm.

## Verification

- `bash _tools/check-platform-package-bins.sh` — fails on `main` (all entries `-rw-r--r--`), passes with this change; removing `publishConfig.bin` from a single package makes it exit 1 with that package named
- `pnpm install --frozen-lockfile` — clean, no warnings, lockfile unchanged
- `pnpm --filter @effect/tsgo check` — clean
- `pnpm --filter @effect/tsgo test` — 57 passed
- `pnpm changeset status` — patch bump for the fixed group
- pack matrix on pnpm 9.15.9 and 10.26.1, `npm pack` for contrast, Yarn 4.6.0 PnP unplug modes
- published tarball modes for `0.24.1` / `0.24.2` / `0.24.3` across platforms, and `@typescript/typescript-darwin-arm64@7.0.2` for contrast

No Go source is changed, so the Go suite was not run.

## What I could not verify

I cannot execute `release.yml`, so the final step is one inference: pnpm grants `0755` from the manifest at pack time (verified locally on the pinned CI version) → the published tarball will be `0755`. The `upload-artifact` / `download-artifact` round trip strips modes, but that no longer matters once the manifest is the source of the bit.

Step logs for run `30021920384` have expired; I confirmed via the API that `Copy binaries into platform packages` concluded `success` at `72bf5ec`, and via `git show 72bf5ec:.github/workflows/release.yml` that the `chmod 0755` / `test -x` lines were present.

I have deliberately left `get-exe-path`'s silent-failure behaviour alone here, to keep this PR to the packaging defect. Happy to open a separate one if you'd like that surfaced rather than silent for consumers still on a published `0.24.x`.
