### PR TITLE
fix: chmod get-exe-path binary

### DIFF
--- a/.changeset/fix-get-exe-path-permissions.md
+++ b/.changeset/fix-get-exe-path-permissions.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Ensure `get-exe-path` marks the Effect Language Service binary as executable before returning its path.

--- a/_packages/tsgo/src/cli.ts
+++ b/_packages/tsgo/src/cli.ts
@@ -556,10 +556,15 @@ const unpatchCommand = Command.make("unpatch").pipe(
 const getExePathCommand = Command.make("get-exe-path").pipe(
   Command.withDescription("Print the Effect Language Service executable path"),
   Command.withHandler(() =>
-    resolveInstalledTypeScriptBinary(defaultTypescriptPackageNames).pipe(
-      Effect.flatMap((installedTypeScript) => getPackagedBinaryPath(installedTypeScript, false)),
-      Effect.flatMap((exePath) => Console.log(exePath))
-    )
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const installedTypeScript = yield* resolveInstalledTypeScriptBinary(defaultTypescriptPackageNames)
+      const exePath = yield* getPackagedBinaryPath(installedTypeScript, false)
+      yield* fs.chmod(exePath, 0o755).pipe(
+        Effect.mapError(() => new ChmodBinaryError({ targetPath: exePath }))
+      )
+      yield* Console.log(exePath)
+    })
   )
 )
 


### PR DESCRIPTION
## Summary

- mark the packaged Effect Language Service binary executable before `get-exe-path` prints it
- report permission failures through the existing `ChmodBinaryError`
- add a patch changeset for `@effect/tsgo`

## Testing

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`