### PR TITLE
perf: cache module export identity queries

### DIFF
--- a/.changeset/cache-module-export-references.md
+++ b/.changeset/cache-module-export-references.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Improve diagnostic performance by caching module export identity checks.

--- a/internal/typeparser/context_type.go
+++ b/internal/typeparser/context_type.go
@@ -5,9 +5,9 @@ import (
 	"github.com/microsoft/typescript-go/shim/checker"
 )
 
-var effectContextPackageSourceFileDescriptor = PackageSourceFileDescriptor{
-	PackageName: "effect",
-	MatchesSourceFile: func(tp *TypeParser, c *checker.Checker, sf *ast.SourceFile) bool {
+var effectContextPackageSourceFileDescriptor = newPackageSourceFileDescriptor(
+	"effect",
+	func(tp *TypeParser, c *checker.Checker, sf *ast.SourceFile) bool {
 		if c == nil || sf == nil {
 			return false
 		}
@@ -31,7 +31,7 @@ var effectContextPackageSourceFileDescriptor = PackageSourceFileDescriptor{
 		tagSym := c.TryGetMemberInModuleExportsAndProperties("Tag", moduleSym)
 		return tagSym != nil
 	},
-}
+)
 
 func (tp *TypeParser) IsNodeReferenceToEffectContextModuleApi(node *ast.Node, memberName string) bool {
 	return tp.IsNodeReferenceToModuleExport(node, effectContextPackageSourceFileDescriptor, memberName)

--- a/internal/typeparser/data_type.go
+++ b/internal/typeparser/data_type.go
@@ -5,9 +5,9 @@ import (
 	"github.com/microsoft/typescript-go/shim/checker"
 )
 
-var effectDataPackageSourceFileDescriptor = PackageSourceFileDescriptor{
-	PackageName: "effect",
-	MatchesSourceFile: func(_ *TypeParser, c *checker.Checker, sf *ast.SourceFile) bool {
+var effectDataPackageSourceFileDescriptor = newPackageSourceFileDescriptor(
+	"effect",
+	func(_ *TypeParser, c *checker.Checker, sf *ast.SourceFile) bool {
 		if c == nil || sf == nil {
 			return false
 		}
@@ -34,7 +34,7 @@ var effectDataPackageSourceFileDescriptor = PackageSourceFileDescriptor{
 
 		return true
 	},
-}
+)
 
 func (tp *TypeParser) IsNodeReferenceToEffectDataModuleApi(node *ast.Node, memberName string) bool {
 	return tp.IsNodeReferenceToModuleExport(node, effectDataPackageSourceFileDescriptor, memberName)

--- a/internal/typeparser/effect_model_type.go
+++ b/internal/typeparser/effect_model_type.go
@@ -5,10 +5,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/checker"
 )
 
-var effectModelPackageSourceFileDescriptor = PackageSourceFileDescriptor{
-	PackageName:       "effect",
-	MatchesSourceFile: isEffectModelTypeSourceFile,
-}
+var effectModelPackageSourceFileDescriptor = newPackageSourceFileDescriptor("effect", isEffectModelTypeSourceFile)
 
 // isEffectModelTypeSourceFile checks if a source file is the effect/unstable/schema Model module
 // by verifying it exports "Class", "Generated", and "FieldOption".

--- a/internal/typeparser/effect_type.go
+++ b/internal/typeparser/effect_type.go
@@ -8,14 +8,9 @@ import (
 	"github.com/microsoft/typescript-go/shim/checker"
 )
 
-var effectModuleDescriptor = PackageSourceFileDescriptor{
-	PackageName:       "effect",
-	MatchesSourceFile: isEffectTypeSourceFile,
-}
+var effectModuleDescriptor = newPackageSourceFileDescriptor("effect", isEffectTypeSourceFile)
 
-var effectPackageExportDescriptor = PackageSourceFileDescriptor{
-	PackageName: "effect",
-}
+var effectPackageExportDescriptor = newPackageSourceFileDescriptor("effect", nil)
 
 // EffectTypeId is the property key for Effect's variance struct.
 // Effect v4 (effect-smol) uses this pattern to encode type parameters.

--- a/internal/typeparser/helpers_test.go
+++ b/internal/typeparser/helpers_test.go
@@ -2,6 +2,7 @@ package typeparser
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -15,14 +16,16 @@ import (
 	"github.com/microsoft/typescript-go/shim/vfs/vfstest"
 )
 
-func compileAndGetCheckerAndSourceFilesInternal(t *testing.T, sources map[string]string) (*checker.Checker, *TypeParser, map[string]*ast.SourceFile, func()) {
+func compileAndGetCheckerAndSourceFilesInternal(t testing.TB, sources map[string]string) (*checker.Checker, *TypeParser, map[string]*ast.SourceFile, func()) {
 	t.Helper()
 
 	testfs := make(map[string]any, len(sources))
 	fileNames := make([]string, 0, len(sources))
 	for path, source := range sources {
 		testfs[path] = &fstest.MapFile{Data: []byte(source)}
-		fileNames = append(fileNames, path)
+		if !strings.Contains(path, "/node_modules/") && strings.HasSuffix(path, ".ts") {
+			fileNames = append(fileNames, path)
+		}
 	}
 
 	fs := vfstest.FromMap(testfs, true)
@@ -168,7 +171,7 @@ func compileAndGetCheckerAndSourceFileWithEffectVersionInternal(t *testing.T, ve
 	return c, NewTypeParser(c.Program(), c), sf, done
 }
 
-func findIdentifierByText(t *testing.T, sf *ast.SourceFile, text string, occurrence int) *ast.Node {
+func findIdentifierByText(t testing.TB, sf *ast.SourceFile, text string, occurrence int) *ast.Node {
 	t.Helper()
 
 	count := 0

--- a/internal/typeparser/layer_type.go
+++ b/internal/typeparser/layer_type.go
@@ -8,10 +8,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/checker"
 )
 
-var effectLayerModuleDescriptor = PackageSourceFileDescriptor{
-	PackageName:       "effect",
-	MatchesSourceFile: isLayerTypeSourceFile,
-}
+var effectLayerModuleDescriptor = newPackageSourceFileDescriptor("effect", isLayerTypeSourceFile)
 
 // LayerTypeId is the property key for Layer's variance struct.
 const LayerTypeId = "~effect/Layer"

--- a/internal/typeparser/module_export_reference.go
+++ b/internal/typeparser/module_export_reference.go
@@ -10,6 +10,26 @@ import (
 type PackageSourceFileDescriptor struct {
 	PackageName       string
 	MatchesSourceFile func(*TypeParser, *checker.Checker, *ast.SourceFile) bool
+	cacheKey          *packageSourceFileDescriptorCacheKey
+}
+
+type packageSourceFileDescriptorCacheKey byte
+
+type moduleExportReferenceCacheKey struct {
+	symbol     *ast.Symbol
+	descriptor *packageSourceFileDescriptorCacheKey
+	memberName string
+}
+
+func newPackageSourceFileDescriptor(
+	packageName string,
+	matchesSourceFile func(*TypeParser, *checker.Checker, *ast.SourceFile) bool,
+) PackageSourceFileDescriptor {
+	return PackageSourceFileDescriptor{
+		PackageName:       packageName,
+		MatchesSourceFile: matchesSourceFile,
+		cacheKey:          new(packageSourceFileDescriptorCacheKey),
+	}
 }
 
 func (tp *TypeParser) ReferenceSymbolAtNode(node *ast.Node) *ast.Symbol {
@@ -17,14 +37,16 @@ func (tp *TypeParser) ReferenceSymbolAtNode(node *ast.Node) *ast.Symbol {
 		return nil
 	}
 
-	sym := tp.GetSymbolAtLocation(node)
-	if sym == nil && node.Kind == ast.KindPropertyAccessExpression {
-		if prop := node.AsPropertyAccessExpression(); prop != nil && prop.Name() != nil {
-			sym = tp.GetSymbolAtLocation(prop.Name())
+	return Cached(&tp.links.ReferenceSymbol, node, func() *ast.Symbol {
+		sym := tp.GetSymbolAtLocation(node)
+		if sym == nil && node.Kind == ast.KindPropertyAccessExpression {
+			if prop := node.AsPropertyAccessExpression(); prop != nil && prop.Name() != nil {
+				sym = tp.GetSymbolAtLocation(prop.Name())
+			}
 		}
-	}
 
-	return tp.resolveAliasedSymbol(sym)
+		return tp.resolveAliasedSymbol(sym)
+	})
 }
 
 func (tp *TypeParser) IsSourceFileInPackage(sf *ast.SourceFile, packageName string) bool {
@@ -44,7 +66,22 @@ func (tp *TypeParser) IsNodeReferenceToModuleExport(node *ast.Node, desc Package
 	if sym == nil {
 		return false
 	}
+	// Exported descriptors built as struct literals have no stable matcher identity.
+	if desc.cacheKey == nil {
+		return tp.isSymbolReferenceToModuleExport(sym, desc, memberName)
+	}
 
+	key := moduleExportReferenceCacheKey{
+		symbol:     sym,
+		descriptor: desc.cacheKey,
+		memberName: memberName,
+	}
+	return Cached(&tp.links.ModuleExportReference, key, func() bool {
+		return tp.isSymbolReferenceToModuleExport(sym, desc, memberName)
+	})
+}
+
+func (tp *TypeParser) isSymbolReferenceToModuleExport(sym *ast.Symbol, desc PackageSourceFileDescriptor, memberName string) bool {
 	for _, decl := range sym.Declarations {
 		if decl == nil {
 			continue

--- a/internal/typeparser/module_export_reference_test.go
+++ b/internal/typeparser/module_export_reference_test.go
@@ -1,0 +1,140 @@
+package typeparser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+)
+
+const moduleExportReferencePackageJSON = `{
+  "name": "cache-fixture",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": { ".": "./index.d.ts" }
+}`
+
+func moduleExportReferenceSources() map[string]string {
+	return map[string]string{
+		"/.src/main.ts": `import { Foo as RootFoo, Bar } from "cache-fixture"
+const rootFoo1 = RootFoo
+const rootFoo2 = RootFoo
+const rootBar = Bar`,
+		"/packages/consumer/main.ts": `import { Foo as NestedFoo } from "cache-fixture"
+const nestedFoo = NestedFoo`,
+		"/node_modules/cache-fixture/package.json": moduleExportReferencePackageJSON,
+		"/node_modules/cache-fixture/index.d.ts":   `export { Foo, Bar } from "./source.js"`,
+		"/node_modules/cache-fixture/source.d.ts": `export declare const Foo: unique symbol
+export declare const Bar: unique symbol`,
+		"/packages/consumer/node_modules/cache-fixture/package.json": strings.Replace(moduleExportReferencePackageJSON, "1.0.0", "2.0.0", 1),
+		"/packages/consumer/node_modules/cache-fixture/index.d.ts":   `export { Foo } from "./source.js"`,
+		"/packages/consumer/node_modules/cache-fixture/source.d.ts":  `export declare const Foo: unique symbol`,
+	}
+}
+
+func moduleExportReferenceFixture(t testing.TB) (*TypeParser, map[string]*ast.SourceFile, func()) {
+	t.Helper()
+
+	_, tp, sourceFiles, done := compileAndGetCheckerAndSourceFilesInternal(t, moduleExportReferenceSources())
+	return tp, sourceFiles, done
+}
+
+func sourceFileNameMatcher(suffix string, calls *int) func(*TypeParser, *checker.Checker, *ast.SourceFile) bool {
+	return func(_ *TypeParser, _ *checker.Checker, sf *ast.SourceFile) bool {
+		if calls != nil {
+			(*calls)++
+		}
+		return strings.HasSuffix(sf.FileName(), suffix)
+	}
+}
+
+func TestIsNodeReferenceToModuleExport_AliasesAndReexports(t *testing.T) {
+	t.Parallel()
+
+	tp, sourceFiles, done := moduleExportReferenceFixture(t)
+	defer done()
+
+	desc := newPackageSourceFileDescriptor("cache-fixture", sourceFileNameMatcher("/source.d.ts", nil))
+	main := sourceFiles["/.src/main.ts"]
+	rootFoo := findIdentifierByText(t, main, "RootFoo", 1)
+	rootBar := findIdentifierByText(t, main, "Bar", 1)
+
+	if !tp.IsNodeReferenceToModuleExport(rootFoo, desc, "Foo") {
+		t.Fatal("expected aliased Foo reference through a reexport to match")
+	}
+	if tp.IsNodeReferenceToModuleExport(rootFoo, desc, "Bar") {
+		t.Fatal("expected Foo reference not to match the Bar export")
+	}
+	if !tp.IsNodeReferenceToModuleExport(rootBar, desc, "Bar") {
+		t.Fatal("expected Bar reference through a reexport to match")
+	}
+}
+
+func TestIsNodeReferenceToModuleExport_DuplicatePackageVersions(t *testing.T) {
+	t.Parallel()
+
+	tp, sourceFiles, done := moduleExportReferenceFixture(t)
+	defer done()
+
+	desc := newPackageSourceFileDescriptor("cache-fixture", nil)
+	rootFoo := findIdentifierByText(t, sourceFiles["/.src/main.ts"], "RootFoo", 1)
+	nestedFoo := findIdentifierByText(t, sourceFiles["/packages/consumer/main.ts"], "NestedFoo", 1)
+
+	if !tp.IsNodeReferenceToModuleExport(rootFoo, desc, "Foo") {
+		t.Fatal("expected Foo from the root package version to match")
+	}
+	if !tp.IsNodeReferenceToModuleExport(nestedFoo, desc, "Foo") {
+		t.Fatal("expected Foo from the nested package version to match independently")
+	}
+	if tp.ReferenceSymbolAtNode(rootFoo) == tp.ReferenceSymbolAtNode(nestedFoo) {
+		t.Fatal("expected duplicate package versions to resolve to distinct symbols")
+	}
+}
+
+func TestIsNodeReferenceToModuleExport_CachesBySymbolDescriptorAndMember(t *testing.T) {
+	t.Parallel()
+
+	tp, sourceFiles, done := moduleExportReferenceFixture(t)
+	defer done()
+
+	main := sourceFiles["/.src/main.ts"]
+	rootFoo1 := findIdentifierByText(t, main, "RootFoo", 1)
+	rootFoo2 := findIdentifierByText(t, main, "RootFoo", 2)
+	calls := 0
+	matchingDesc := newPackageSourceFileDescriptor("cache-fixture", sourceFileNameMatcher("/source.d.ts", &calls))
+
+	if !tp.IsNodeReferenceToModuleExport(rootFoo1, matchingDesc, "Foo") {
+		t.Fatal("expected first Foo reference to match")
+	}
+	firstCallCount := calls
+	if !tp.IsNodeReferenceToModuleExport(rootFoo2, matchingDesc, "Foo") {
+		t.Fatal("expected second Foo reference to match")
+	}
+	if calls != firstCallCount {
+		t.Fatalf("expected resolved-symbol cache hit, matcher calls increased from %d to %d", firstCallCount, calls)
+	}
+
+	nonMatchingDesc := newPackageSourceFileDescriptor("cache-fixture", sourceFileNameMatcher("/other.d.ts", nil))
+	if tp.IsNodeReferenceToModuleExport(rootFoo1, nonMatchingDesc, "Foo") {
+		t.Fatal("expected a different source descriptor not to reuse the cached match")
+	}
+	if tp.IsNodeReferenceToModuleExport(rootFoo1, matchingDesc, "Bar") {
+		t.Fatal("expected a different member not to reuse the cached Foo match")
+	}
+}
+
+func BenchmarkIsNodeReferenceToModuleExport(b *testing.B) {
+	tp, sourceFiles, done := moduleExportReferenceFixture(b)
+	defer done()
+
+	desc := newPackageSourceFileDescriptor("cache-fixture", sourceFileNameMatcher("/source.d.ts", nil))
+	rootFoo := findIdentifierByText(b, sourceFiles["/.src/main.ts"], "RootFoo", 1)
+
+	b.ResetTimer()
+	for b.Loop() {
+		if !tp.IsNodeReferenceToModuleExport(rootFoo, desc, "Foo") {
+			b.Fatal("expected Foo reference to match")
+		}
+	}
+}

--- a/internal/typeparser/schema_type.go
+++ b/internal/typeparser/schema_type.go
@@ -5,20 +5,11 @@ import (
 	"github.com/microsoft/typescript-go/shim/checker"
 )
 
-var effectSchemaModuleDescriptor = PackageSourceFileDescriptor{
-	PackageName:       "effect",
-	MatchesSourceFile: isSchemaTypeSourceFile,
-}
+var effectSchemaModuleDescriptor = newPackageSourceFileDescriptor("effect", isSchemaTypeSourceFile)
 
-var effectParseResultModuleDescriptor = PackageSourceFileDescriptor{
-	PackageName:       "effect",
-	MatchesSourceFile: isParseResultSourceFile,
-}
+var effectParseResultModuleDescriptor = newPackageSourceFileDescriptor("effect", isParseResultSourceFile)
 
-var effectSchemaParserModuleDescriptor = PackageSourceFileDescriptor{
-	PackageName:       "effect",
-	MatchesSourceFile: isSchemaParserSourceFile,
-}
+var effectSchemaParserModuleDescriptor = newPackageSourceFileDescriptor("effect", isSchemaParserSourceFile)
 
 // SchemaTypeId is the property key for Schema's variance struct.
 const SchemaTypeId = "~effect/Schema/Schema"

--- a/internal/typeparser/sql_model_type.go
+++ b/internal/typeparser/sql_model_type.go
@@ -5,10 +5,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/checker"
 )
 
-var sqlModelModuleDescriptor = PackageSourceFileDescriptor{
-	PackageName:       "@effect/sql",
-	MatchesSourceFile: isSqlModelTypeSourceFile,
-}
+var sqlModelModuleDescriptor = newPackageSourceFileDescriptor("@effect/sql", isSqlModelTypeSourceFile)
 
 // isSqlModelTypeSourceFile checks if a source file is @effect/sql Model module
 // by verifying it exports "Class", "makeRepository", and "makeDataLoaders".

--- a/internal/typeparser/type_parser.go
+++ b/internal/typeparser/type_parser.go
@@ -18,23 +18,25 @@ type TypeParser struct {
 // EffectLinks holds per-checker cached type-parser results.
 // One instance is lazily created per Checker and cached on TypeParser.
 type EffectLinks struct {
-	TypeAtLocation       core.LinkStore[*ast.Node, *checker.Type]
-	EffectType           core.LinkStore[*checker.Type, *Effect]
-	StreamType           core.LinkStore[*checker.Type, *Effect]
-	StrictEffectType     core.LinkStore[*checker.Type, *Effect]
-	EffectSubtype        core.LinkStore[*checker.Type, *Effect]
-	FiberType            core.LinkStore[*checker.Type, *Effect]
-	EffectYieldableType  core.LinkStore[*checker.Type, *Effect]
-	HasEffectTypeId      core.LinkStore[*checker.Type, bool]
-	LayerType            core.LinkStore[*checker.Type, *Layer]
-	ServiceType          core.LinkStore[*checker.Type, *Service]
-	ContextTag           core.LinkStore[*checker.Type, *Service]
-	EffectSchemaTypes    core.LinkStore[*checker.Type, *SchemaTypes]
-	IsScopeType          core.LinkStore[*checker.Type, bool]
-	IsPipeableType       core.LinkStore[*checker.Type, bool]
-	PromiseType          core.LinkStore[*checker.Type, *checker.Type]
-	IsGlobalErrorType    core.LinkStore[*checker.Type, bool]
-	IsYieldableErrorType core.LinkStore[*checker.Type, bool]
+	TypeAtLocation        core.LinkStore[*ast.Node, *checker.Type]
+	EffectType            core.LinkStore[*checker.Type, *Effect]
+	StreamType            core.LinkStore[*checker.Type, *Effect]
+	StrictEffectType      core.LinkStore[*checker.Type, *Effect]
+	EffectSubtype         core.LinkStore[*checker.Type, *Effect]
+	FiberType             core.LinkStore[*checker.Type, *Effect]
+	EffectYieldableType   core.LinkStore[*checker.Type, *Effect]
+	HasEffectTypeId       core.LinkStore[*checker.Type, bool]
+	LayerType             core.LinkStore[*checker.Type, *Layer]
+	ServiceType           core.LinkStore[*checker.Type, *Service]
+	ContextTag            core.LinkStore[*checker.Type, *Service]
+	EffectSchemaTypes     core.LinkStore[*checker.Type, *SchemaTypes]
+	IsScopeType           core.LinkStore[*checker.Type, bool]
+	IsPipeableType        core.LinkStore[*checker.Type, bool]
+	PromiseType           core.LinkStore[*checker.Type, *checker.Type]
+	IsGlobalErrorType     core.LinkStore[*checker.Type, bool]
+	IsYieldableErrorType  core.LinkStore[*checker.Type, bool]
+	ReferenceSymbol       core.LinkStore[*ast.Node, *ast.Symbol]
+	ModuleExportReference core.LinkStore[moduleExportReferenceCacheKey, bool]
 
 	ExtendsContextTag          core.LinkStore[*ast.Node, *ContextTagResult]
 	ExtendsDataTaggedError     core.LinkStore[*ast.Node, *DataTaggedErrorResult]
@@ -73,8 +75,8 @@ type EffectLinks struct {
 // stores the result, and returns it. This correctly caches zero/nil values
 // as valid negative results.
 func Cached[K comparable, V any](store *core.LinkStore[K, V], key K, compute func() V) V {
-	if store.Has(key) {
-		return *store.TryGet(key)
+	if value := store.TryGet(key); value != nil {
+		return *value
 	}
 	value := compute()
 	*store.Get(key) = value

--- a/internal/typeparser/type_parser_test.go
+++ b/internal/typeparser/type_parser_test.go
@@ -1,0 +1,53 @@
+package typeparser
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/core"
+)
+
+func TestCachedCachesNegativeValues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		var store core.LinkStore[string, *int]
+		calls := 0
+		compute := func() *int {
+			calls++
+			return nil
+		}
+
+		if Cached(&store, "key", compute) != nil {
+			t.Fatal("expected nil result")
+		}
+		if Cached(&store, "key", compute) != nil {
+			t.Fatal("expected cached nil result")
+		}
+		if calls != 1 {
+			t.Fatalf("expected nil result to be computed once, got %d calls", calls)
+		}
+	})
+
+	t.Run("false", func(t *testing.T) {
+		t.Parallel()
+
+		var store core.LinkStore[string, bool]
+		calls := 0
+		compute := func() bool {
+			calls++
+			return false
+		}
+
+		if Cached(&store, "key", compute) {
+			t.Fatal("expected false result")
+		}
+		if Cached(&store, "key", compute) {
+			t.Fatal("expected cached false result")
+		}
+		if calls != 1 {
+			t.Fatalf("expected false result to be computed once, got %d calls", calls)
+		}
+	})
+}

--- a/internal/typeparser/vitest_api.go
+++ b/internal/typeparser/vitest_api.go
@@ -2,17 +2,11 @@ package typeparser
 
 import "github.com/microsoft/typescript-go/shim/ast"
 
-var vitestRunnerPackageDescriptor = PackageSourceFileDescriptor{
-	PackageName: "@vitest/runner",
-}
+var vitestRunnerPackageDescriptor = newPackageSourceFileDescriptor("@vitest/runner", nil)
 
-var vitestPackageDescriptor = PackageSourceFileDescriptor{
-	PackageName: "vitest",
-}
+var vitestPackageDescriptor = newPackageSourceFileDescriptor("vitest", nil)
 
-var effectVitestPackageDescriptor = PackageSourceFileDescriptor{
-	PackageName: "@effect/vitest",
-}
+var effectVitestPackageDescriptor = newPackageSourceFileDescriptor("@effect/vitest", nil)
 
 // IsNodeReferenceToVitestApi reports whether node resolves to a Vitest API.
 // Vitest re-exports most test APIs from @vitest/runner, while global APIs are

--- a/testdata/baselines/reference/effect-v4/moduleExportReferenceCache.errors.txt
+++ b/testdata/baselines/reference/effect-v4/moduleExportReferenceCache.errors.txt
@@ -1,0 +1,45 @@
+=== Metadata ===
+Effect version: unknown
+
+/.src/test.ts(6,24): warning TS377013: This pipe call contains no arguments. effect(unnecessaryPipe)
+/.src/test.ts(7,24): warning TS377013: This pipe call contains no arguments. effect(unnecessaryPipe)
+/.src/test.ts(8,26): warning TS377013: This pipe call contains no arguments. effect(unnecessaryPipe)
+/.src/test.ts(9,26): warning TS377013: This pipe call contains no arguments. effect(unnecessaryPipe)
+
+
+==== /.src/tsconfig.json (0 errors) ====
+    {
+      "compilerOptions": {
+        "plugins": [
+          {
+            "name": "@effect/language-service"
+          }
+        ]
+      }
+    }
+    
+
+==== /.src/barrel.ts (0 errors) ====
+    // @effect-diagnostics *:off
+    export { pipe } from "effect/Function"
+    
+
+==== /.src/test.ts (4 errors) ====
+    // @effect-diagnostics *:off
+    // @effect-diagnostics unnecessaryPipe:warning
+    import * as RootFunction from "./barrel.js"
+    import * as NestedFunction from "cache-wrapper"
+    
+    export const rootOne = RootFunction.pipe(1)
+                           ~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377013: This pipe call contains no arguments. effect(unnecessaryPipe)
+    export const rootTwo = RootFunction.pipe(2)
+                           ~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377013: This pipe call contains no arguments. effect(unnecessaryPipe)
+    export const nestedOne = NestedFunction.pipe(3)
+                             ~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377013: This pipe call contains no arguments. effect(unnecessaryPipe)
+    export const nestedTwo = NestedFunction.pipe(4)
+                             ~~~~~~~~~~~~~~~~~~~~~~
+!!! warning TS377013: This pipe call contains no arguments. effect(unnecessaryPipe)
+    

--- a/testdata/baselines/reference/effect-v4/moduleExportReferenceCache.flows.barrel.mermaid
+++ b/testdata/baselines/reference/effect-v4/moduleExportReferenceCache.flows.barrel.mermaid
@@ -1,0 +1,1 @@
+flowchart TB

--- a/testdata/baselines/reference/effect-v4/moduleExportReferenceCache.flows.test.mermaid
+++ b/testdata/baselines/reference/effect-v4/moduleExportReferenceCache.flows.test.mermaid
@@ -1,0 +1,5 @@
+flowchart TB
+  0[/"type: 1<br/>node: 1"/]
+  1[/"type: 2<br/>node: 2"/]
+  2[/"type: 3<br/>node: 3"/]
+  3[/"type: 4<br/>node: 4"/]

--- a/testdata/baselines/reference/effect-v4/moduleExportReferenceCache.flows.txt
+++ b/testdata/baselines/reference/effect-v4/moduleExportReferenceCache.flows.txt
@@ -1,0 +1,2 @@
+/.src/barrel.ts -> moduleExportReferenceCache.flows.barrel.mermaid
+/.src/test.ts -> moduleExportReferenceCache.flows.test.mermaid

--- a/testdata/baselines/reference/effect-v4/moduleExportReferenceCache.layers.txt
+++ b/testdata/baselines/reference/effect-v4/moduleExportReferenceCache.layers.txt
@@ -1,0 +1,2 @@
+==== /.src/barrel.ts (0 layer exports) ====
+==== /.src/test.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v4/moduleExportReferenceCache.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/moduleExportReferenceCache.pipings.txt
@@ -1,0 +1,42 @@
+==== /.src/barrel.ts (0 flows) ====
+==== /.src/test.ts (4 flows) ====
+
+=== Piping Flow ===
+Location: 6:23 - 6:44
+Node: RootFunction.pipe(1)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (0):
+
+=== Piping Flow ===
+Location: 7:23 - 7:44
+Node: RootFunction.pipe(2)
+Node Kind: KindCallExpression
+
+Subject: 2
+Subject Type: 2
+
+Transformations (0):
+
+=== Piping Flow ===
+Location: 8:25 - 8:48
+Node: NestedFunction.pipe(3)
+Node Kind: KindCallExpression
+
+Subject: 3
+Subject Type: 3
+
+Transformations (0):
+
+=== Piping Flow ===
+Location: 9:25 - 9:48
+Node: NestedFunction.pipe(4)
+Node Kind: KindCallExpression
+
+Subject: 4
+Subject Type: 4
+
+Transformations (0):

--- a/testdata/tests/effect-v4/moduleExportReferenceCache.ts
+++ b/testdata/tests/effect-v4/moduleExportReferenceCache.ts
@@ -1,0 +1,37 @@
+// @filename: tsconfig.json
+{
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
+  }
+}
+
+// @filename: barrel.ts
+// @effect-diagnostics *:off
+export { pipe } from "effect/Function"
+
+// @filename: /node_modules/cache-wrapper/package.json
+{ "name": "cache-wrapper", "version": "1.0.0", "type": "module", "exports": { ".": "./index.d.ts" } }
+
+// @filename: /node_modules/cache-wrapper/index.d.ts
+export { pipe } from "effect/Function"
+
+// @filename: /node_modules/cache-wrapper/node_modules/effect/package.json
+{ "name": "effect", "version": "0.0.0-cache-test", "type": "module", "exports": { "./Function": "./Function.d.ts" } }
+
+// @filename: /node_modules/cache-wrapper/node_modules/effect/Function.d.ts
+export declare function pipe<A>(value: A): A
+
+// @filename: test.ts
+// @effect-diagnostics *:off
+// @effect-diagnostics unnecessaryPipe:warning
+import * as RootFunction from "./barrel.js"
+import * as NestedFunction from "cache-wrapper"
+
+export const rootOne = RootFunction.pipe(1)
+export const rootTwo = RootFunction.pipe(2)
+export const nestedOne = NestedFunction.pipe(3)
+export const nestedTwo = NestedFunction.pipe(4)


### PR DESCRIPTION
## Summary

Caches module-export identity checks used by the type parsers to avoid repeated symbol, source, and member resolution work.

## Changes

- Adds per-checker module-export caching keyed by resolved symbol, source descriptor identity, and member.
- Preserves conservative uncached behavior for descriptors without stable identity.
- Adds direct coverage for aliases, reexports, duplicate package versions, descriptor and member isolation, cached nil and false values, and symbol reuse.
- Adds diagnostic fixtures for aliases and reexports across root and nested Effect packages.
- Includes a patch changeset.

## Verification

- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm build`