### PR TITLE
Expose executable path helper

### DIFF
--- a/.changeset/expose-executable-path.md
+++ b/.changeset/expose-executable-path.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": minor
+---
+
+Expose `@effect/tsgo/lib/getExePath`, which resolves the packaged `tsc` or `tsc-next` executable matching the installed native TypeScript version.

--- a/_packages/tsgo/lib/getExePath.d.ts
+++ b/_packages/tsgo/lib/getExePath.d.ts
@@ -1,0 +1,2 @@
+declare function getExePath(): string;
+export default getExePath;

--- a/_packages/tsgo/lib/getExePath.js
+++ b/_packages/tsgo/lib/getExePath.js
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import module from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const typescriptPackageNames = ["typescript", "@typescript/native"];
+const binNames = ["tsc", "tsc-next"];
+
+function readJson(fileName) {
+  return JSON.parse(fs.readFileSync(fileName, "utf8"));
+}
+
+function resolveTypeScriptPackage() {
+  const cwdRequire = module.createRequire(path.join(process.cwd(), "noop.js"));
+
+  for (const packageName of typescriptPackageNames) {
+    let packageJson;
+    try {
+      packageJson = cwdRequire.resolve(packageName + "/package.json");
+    }
+    catch {
+      continue;
+    }
+
+    const pkg = readJson(packageJson);
+    const major = /^\s*(\d+)/.exec(pkg.version);
+    if (major && Number(major[1]) >= 7) {
+      if (typeof pkg.gitHead !== "string") {
+        throw new Error("Missing gitHead in " + packageName + "/package.json.");
+      }
+      return pkg;
+    }
+  }
+
+  throw new Error("Unable to resolve a native TypeScript package. Install typescript >= 7 or @typescript/native.");
+}
+
+export default function getExePath() {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const typescriptPackage = resolveTypeScriptPackage();
+  const platformPackageName = "@effect/tsgo-" + process.platform + "-" + process.arch;
+  let packageJson;
+
+  try {
+    const require_ = module.createRequire(path.join(__dirname, "getExePath.js"));
+    packageJson = require_.resolve(platformPackageName + "/package.json");
+  }
+  catch {
+    throw new Error("Unable to resolve " + platformPackageName + ". Either your platform is unsupported, or you are missing the package on disk.");
+  }
+
+  const exeDir = path.join(path.dirname(packageJson), "lib");
+  for (const binName of binNames) {
+    let exe = path.join(exeDir, binName);
+    if (process.platform === "win32") {
+      exe += ".exe";
+      if (exe.length >= 248) {
+        exe = "\\\\?\\" + exe;
+      }
+    }
+
+    if (!fs.existsSync(exe) || !fs.existsSync(exe + ".json")) {
+      continue;
+    }
+
+    const metadata = readJson(exe + ".json");
+    if (metadata.tsGitHead === typescriptPackage.gitHead) {
+      return exe;
+    }
+  }
+
+  throw new Error("No packaged Effect TypeScript executable matches installed TypeScript " + typescriptPackage.version + " gitHead " + typescriptPackage.gitHead + ".");
+}

--- a/_packages/tsgo/package.json
+++ b/_packages/tsgo/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@effect/tsgo",
   "version": "0.25.0",
+  "type": "module",
   "description": "Effect Language Service for TypeScript-Go — Effect-specific diagnostics and hover features.",
   "license": "MIT",
   "repository": {
@@ -14,7 +15,7 @@
     "access": "public",
     "provenance": true,
     "bin": {
-      "effect-tsgo": "./dist/effect-tsgo.js"
+      "effect-tsgo": "./dist/effect-tsgo.cjs"
     }
   },
   "scripts": {
@@ -25,8 +26,16 @@
   "bin": {
     "effect-tsgo": "./src/cli.ts"
   },
+  "exports": {
+    "./package.json": "./package.json",
+    "./lib/getExePath": {
+      "types": "./lib/getExePath.d.ts",
+      "default": "./lib/getExePath.js"
+    }
+  },
   "files": [
     "dist/",
+    "lib/",
     "README.md",
     "schema.json"
   ],

--- a/_packages/tsgo/tsdown.config.ts
+++ b/_packages/tsgo/tsdown.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   dts: false,
   clean: true,
   outExtensions: () => ({
-    js: ".js",
+    js: ".cjs",
   }),
   banner: {
     js: "#!/usr/bin/env node",

--- a/_tools/release-prepare.sh
+++ b/_tools/release-prepare.sh
@@ -170,7 +170,7 @@ errors=()
 
 # Check CLI bundle
 if [ "$skip_cli" != "true" ]; then
-  cli_bundle="${PACKAGES_DIR}/tsgo/dist/effect-tsgo.js"
+  cli_bundle="${PACKAGES_DIR}/tsgo/dist/effect-tsgo.cjs"
   if [ ! -s "${cli_bundle}" ]; then
     errors+=("Missing or empty CLI bundle: ${cli_bundle}")
   fi


### PR DESCRIPTION
## Summary

- expose `@effect/tsgo/lib/getExePath` as a typed ESM package export
- resolve `tsc` or `tsc-next` by matching the installed native TypeScript package `gitHead` with packaged binary metadata
- emit the bundled CLI as `.cjs` so the package can use `"type": "module"` without breaking its CommonJS-only bundled dependencies

```ts
import getExePath from "@effect/tsgo/lib/getExePath"

const exePath = getExePath()
```

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm build:cli`
- CLI smoke test with `node dist/effect-tsgo.cjs --help`
- `npm pack --dry-run`