### PR TITLE
Create GitHub releases when publishing packages

### DIFF
--- a/.changeset/create-github-releases.md
+++ b/.changeset/create-github-releases.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Create package tags and GitHub Releases with changelog notes when publishing npm packages.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 concurrency:
@@ -150,7 +150,10 @@ jobs:
       - name: Build CLI bundle
         run: pnpm build:cli
 
-      - name: Publish packages
-        run: pnpm changeset:publish
+      - name: Publish packages and create releases
+        uses: changesets/action@v1
+        with:
+          publish: pnpm changeset:publish
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Summary

- grant the release workflow write access to repository contents
- publish through `changesets/action@v1` instead of invoking `changeset publish` directly
- let Changesets push package tags and create package-specific GitHub Releases from generated changelog entries
- preserve npm trusted-publishing provenance and the existing cross-platform build matrix

The releases contain changelog notes and no attached package assets.

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- verified the pinned `changesets/action@v1` inputs and default `createGithubReleases: true` behavior

`actionlint` was not available locally; GitHub will validate the workflow syntax on this PR.