### PR TITLE
Document type-aware Oxlint rule configuration

### DIFF
--- a/.changeset/enable-type-aware-doc-examples.md
+++ b/.changeset/enable-type-aware-doc-examples.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Enable Oxlint type-aware mode in generated rule configuration examples.

--- a/docs/rules/abort-controller-in-effect.md
+++ b/docs/rules/abort-controller-in-effect.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/abort-controller-in-effect": "warn"

--- a/docs/rules/any-unknown-in-error-context.md
+++ b/docs/rules/any-unknown-in-error-context.md
@@ -59,6 +59,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/any-unknown-in-error-context": "warn"

--- a/docs/rules/async-function.md
+++ b/docs/rules/async-function.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/async-function": "warn"

--- a/docs/rules/catch-all-to-map-error.md
+++ b/docs/rules/catch-all-to-map-error.md
@@ -56,6 +56,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/catch-all-to-map-error": "warn"

--- a/docs/rules/catch-chain-to-first-success-of.md
+++ b/docs/rules/catch-chain-to-first-success-of.md
@@ -57,6 +57,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/catch-chain-to-first-success-of": "warn"

--- a/docs/rules/catch-tag-to-catch-reason.md
+++ b/docs/rules/catch-tag-to-catch-reason.md
@@ -79,6 +79,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/catch-tag-to-catch-reason": "warn"

--- a/docs/rules/catch-to-ignore.md
+++ b/docs/rules/catch-to-ignore.md
@@ -54,6 +54,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/catch-to-ignore": "warn"

--- a/docs/rules/catch-to-or-else-succeed.md
+++ b/docs/rules/catch-to-or-else-succeed.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/catch-to-or-else-succeed": "warn"

--- a/docs/rules/catch-unfailable-effect.md
+++ b/docs/rules/catch-unfailable-effect.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/catch-unfailable-effect": "warn"

--- a/docs/rules/class-self-mismatch.md
+++ b/docs/rules/class-self-mismatch.md
@@ -55,6 +55,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/class-self-mismatch": "warn"

--- a/docs/rules/crypto-random-uuid-in-effect.md
+++ b/docs/rules/crypto-random-uuid-in-effect.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/crypto-random-uuid-in-effect": "warn"

--- a/docs/rules/crypto-random-uuid.md
+++ b/docs/rules/crypto-random-uuid.md
@@ -48,6 +48,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/crypto-random-uuid": "warn"

--- a/docs/rules/deterministic-keys.md
+++ b/docs/rules/deterministic-keys.md
@@ -51,6 +51,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/deterministic-keys": "warn"

--- a/docs/rules/duplicate-package.md
+++ b/docs/rules/duplicate-package.md
@@ -51,6 +51,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/duplicate-package": "warn"

--- a/docs/rules/effect-do-notation.md
+++ b/docs/rules/effect-do-notation.md
@@ -56,6 +56,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/effect-do-notation": "warn"

--- a/docs/rules/effect-fn-iife.md
+++ b/docs/rules/effect-fn-iife.md
@@ -58,6 +58,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/effect-fn-iife": "warn"

--- a/docs/rules/effect-fn-implicit-any.md
+++ b/docs/rules/effect-fn-implicit-any.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/effect-fn-implicit-any": "warn"

--- a/docs/rules/effect-fn-opportunity.md
+++ b/docs/rules/effect-fn-opportunity.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/effect-fn-opportunity": "warn"

--- a/docs/rules/effect-gen-uses-adapter.md
+++ b/docs/rules/effect-gen-uses-adapter.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/effect-gen-uses-adapter": "warn"

--- a/docs/rules/effect-in-failure.md
+++ b/docs/rules/effect-in-failure.md
@@ -65,6 +65,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/effect-in-failure": "warn"

--- a/docs/rules/effect-in-void-success.md
+++ b/docs/rules/effect-in-void-success.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/effect-in-void-success": "warn"

--- a/docs/rules/effect-map-flatten.md
+++ b/docs/rules/effect-map-flatten.md
@@ -53,6 +53,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/effect-map-flatten": "warn"

--- a/docs/rules/effect-map-void.md
+++ b/docs/rules/effect-map-void.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/effect-map-void": "warn"

--- a/docs/rules/effect-succeed-with-void.md
+++ b/docs/rules/effect-succeed-with-void.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/effect-succeed-with-void": "warn"

--- a/docs/rules/extends-native-error.md
+++ b/docs/rules/extends-native-error.md
@@ -48,6 +48,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/extends-native-error": "warn"

--- a/docs/rules/flat-map-to-map.md
+++ b/docs/rules/flat-map-to-map.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/flat-map-to-map": "warn"

--- a/docs/rules/floating-effect-in-vitest.md
+++ b/docs/rules/floating-effect-in-vitest.md
@@ -51,6 +51,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/floating-effect-in-vitest": "warn"

--- a/docs/rules/floating-effect.md
+++ b/docs/rules/floating-effect.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/floating-effect": "warn"

--- a/docs/rules/generic-effect-services.md
+++ b/docs/rules/generic-effect-services.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/generic-effect-services": "warn"

--- a/docs/rules/global-console-in-effect.md
+++ b/docs/rules/global-console-in-effect.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/global-console-in-effect": "warn"

--- a/docs/rules/global-console.md
+++ b/docs/rules/global-console.md
@@ -48,6 +48,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/global-console": "warn"

--- a/docs/rules/global-date-in-effect.md
+++ b/docs/rules/global-date-in-effect.md
@@ -53,6 +53,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/global-date-in-effect": "warn"

--- a/docs/rules/global-date.md
+++ b/docs/rules/global-date.md
@@ -48,6 +48,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/global-date": "warn"

--- a/docs/rules/global-error-in-effect-catch.md
+++ b/docs/rules/global-error-in-effect-catch.md
@@ -53,6 +53,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/global-error-in-effect-catch": "warn"

--- a/docs/rules/global-error-in-effect-failure.md
+++ b/docs/rules/global-error-in-effect-failure.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/global-error-in-effect-failure": "warn"

--- a/docs/rules/global-fetch-in-effect.md
+++ b/docs/rules/global-fetch-in-effect.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/global-fetch-in-effect": "warn"

--- a/docs/rules/global-fetch.md
+++ b/docs/rules/global-fetch.md
@@ -48,6 +48,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/global-fetch": "warn"

--- a/docs/rules/global-random-in-effect.md
+++ b/docs/rules/global-random-in-effect.md
@@ -53,6 +53,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/global-random-in-effect": "warn"

--- a/docs/rules/global-random.md
+++ b/docs/rules/global-random.md
@@ -48,6 +48,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/global-random": "warn"

--- a/docs/rules/global-timers-in-effect.md
+++ b/docs/rules/global-timers-in-effect.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/global-timers-in-effect": "warn"

--- a/docs/rules/global-timers.md
+++ b/docs/rules/global-timers.md
@@ -48,6 +48,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/global-timers": "warn"

--- a/docs/rules/instance-of-schema.md
+++ b/docs/rules/instance-of-schema.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/instance-of-schema": "warn"

--- a/docs/rules/layer-merge-all-with-dependencies.md
+++ b/docs/rules/layer-merge-all-with-dependencies.md
@@ -56,6 +56,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/layer-merge-all-with-dependencies": "warn"

--- a/docs/rules/lazy-effect.md
+++ b/docs/rules/lazy-effect.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/lazy-effect": "warn"

--- a/docs/rules/lazy-promise-in-effect-sync.md
+++ b/docs/rules/lazy-promise-in-effect-sync.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/lazy-promise-in-effect-sync": "warn"

--- a/docs/rules/leaking-requirements.md
+++ b/docs/rules/leaking-requirements.md
@@ -58,6 +58,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/leaking-requirements": "warn"

--- a/docs/rules/missed-pipeable-opportunity.md
+++ b/docs/rules/missed-pipeable-opportunity.md
@@ -51,6 +51,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/missed-pipeable-opportunity": "warn"

--- a/docs/rules/missing-effect-context.md
+++ b/docs/rules/missing-effect-context.md
@@ -53,6 +53,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/missing-effect-context": "warn"

--- a/docs/rules/missing-effect-error.md
+++ b/docs/rules/missing-effect-error.md
@@ -55,6 +55,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/missing-effect-error": "warn"

--- a/docs/rules/missing-effect-service-dependency.md
+++ b/docs/rules/missing-effect-service-dependency.md
@@ -56,6 +56,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/missing-effect-service-dependency": "warn"

--- a/docs/rules/missing-layer-context.md
+++ b/docs/rules/missing-layer-context.md
@@ -55,6 +55,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/missing-layer-context": "warn"

--- a/docs/rules/missing-pipeable-signature.md
+++ b/docs/rules/missing-pipeable-signature.md
@@ -48,6 +48,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/missing-pipeable-signature": "warn"

--- a/docs/rules/missing-return-yield-star.md
+++ b/docs/rules/missing-return-yield-star.md
@@ -53,6 +53,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/missing-return-yield-star": "warn"

--- a/docs/rules/missing-star-in-yield-effect-gen.md
+++ b/docs/rules/missing-star-in-yield-effect-gen.md
@@ -53,6 +53,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/missing-star-in-yield-effect-gen": "warn"

--- a/docs/rules/multiple-catch-tag.md
+++ b/docs/rules/multiple-catch-tag.md
@@ -59,6 +59,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/multiple-catch-tag": "warn"

--- a/docs/rules/multiple-effect-provide.md
+++ b/docs/rules/multiple-effect-provide.md
@@ -56,6 +56,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/multiple-effect-provide": "warn"

--- a/docs/rules/nested-effect-gen-yield.md
+++ b/docs/rules/nested-effect-gen-yield.md
@@ -60,6 +60,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/nested-effect-gen-yield": "warn"

--- a/docs/rules/new-promise.md
+++ b/docs/rules/new-promise.md
@@ -48,6 +48,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/new-promise": "warn"

--- a/docs/rules/new-schema-class.md
+++ b/docs/rules/new-schema-class.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/new-schema-class": "warn"

--- a/docs/rules/node-builtin-import.md
+++ b/docs/rules/node-builtin-import.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/node-builtin-import": "warn"

--- a/docs/rules/non-object-effect-service-type.md
+++ b/docs/rules/non-object-effect-service-type.md
@@ -53,6 +53,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/non-object-effect-service-type": "warn"

--- a/docs/rules/outdated-api.md
+++ b/docs/rules/outdated-api.md
@@ -56,6 +56,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/outdated-api": "warn"

--- a/docs/rules/overridden-schema-constructor.md
+++ b/docs/rules/overridden-schema-constructor.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/overridden-schema-constructor": "warn"

--- a/docs/rules/prefer-schema-over-json.md
+++ b/docs/rules/prefer-schema-over-json.md
@@ -53,6 +53,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/prefer-schema-over-json": "warn"

--- a/docs/rules/prefer-schema-type-property.md
+++ b/docs/rules/prefer-schema-type-property.md
@@ -51,6 +51,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/prefer-schema-type-property": "warn"

--- a/docs/rules/prefer-unsafe-constructor.md
+++ b/docs/rules/prefer-unsafe-constructor.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/prefer-unsafe-constructor": "warn"

--- a/docs/rules/process-env-in-effect.md
+++ b/docs/rules/process-env-in-effect.md
@@ -53,6 +53,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/process-env-in-effect": "warn"

--- a/docs/rules/process-env.md
+++ b/docs/rules/process-env.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/process-env": "warn"

--- a/docs/rules/promise-in-effect-success.md
+++ b/docs/rules/promise-in-effect-success.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/promise-in-effect-success": "warn"

--- a/docs/rules/redundant-map-error.md
+++ b/docs/rules/redundant-map-error.md
@@ -65,6 +65,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/redundant-map-error": "warn"

--- a/docs/rules/redundant-or-die.md
+++ b/docs/rules/redundant-or-die.md
@@ -57,6 +57,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/redundant-or-die": "warn"

--- a/docs/rules/redundant-schema-tag-identifier.md
+++ b/docs/rules/redundant-schema-tag-identifier.md
@@ -53,6 +53,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/redundant-schema-tag-identifier": "warn"

--- a/docs/rules/return-effect-in-gen.md
+++ b/docs/rules/return-effect-in-gen.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/return-effect-in-gen": "warn"

--- a/docs/rules/run-effect-inside-effect.md
+++ b/docs/rules/run-effect-inside-effect.md
@@ -53,6 +53,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/run-effect-inside-effect": "warn"

--- a/docs/rules/schema-literal-non-finite.md
+++ b/docs/rules/schema-literal-non-finite.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/schema-literal-non-finite": "warn"

--- a/docs/rules/schema-number.md
+++ b/docs/rules/schema-number.md
@@ -56,6 +56,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/schema-number": "warn"

--- a/docs/rules/schema-opaque-instance-member.md
+++ b/docs/rules/schema-opaque-instance-member.md
@@ -58,6 +58,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/schema-opaque-instance-member": "warn"

--- a/docs/rules/schema-struct-with-tag.md
+++ b/docs/rules/schema-struct-with-tag.md
@@ -62,6 +62,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/schema-struct-with-tag": "warn"

--- a/docs/rules/schema-sync-in-effect.md
+++ b/docs/rules/schema-sync-in-effect.md
@@ -56,6 +56,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/schema-sync-in-effect": "warn"

--- a/docs/rules/schema-union-of-literals.md
+++ b/docs/rules/schema-union-of-literals.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/schema-union-of-literals": "warn"

--- a/docs/rules/scope-in-layer-effect.md
+++ b/docs/rules/scope-in-layer-effect.md
@@ -65,6 +65,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/scope-in-layer-effect": "warn"

--- a/docs/rules/service-not-as-class.md
+++ b/docs/rules/service-not-as-class.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/service-not-as-class": "warn"

--- a/docs/rules/strict-boolean-expressions.md
+++ b/docs/rules/strict-boolean-expressions.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/strict-boolean-expressions": "warn"

--- a/docs/rules/strict-effect-provide.md
+++ b/docs/rules/strict-effect-provide.md
@@ -53,6 +53,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/strict-effect-provide": "warn"

--- a/docs/rules/sync-to-succeed.md
+++ b/docs/rules/sync-to-succeed.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/sync-to-succeed": "warn"

--- a/docs/rules/try-catch-in-effect-gen.md
+++ b/docs/rules/try-catch-in-effect-gen.md
@@ -56,6 +56,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/try-catch-in-effect-gen": "warn"

--- a/docs/rules/unknown-in-effect-catch.md
+++ b/docs/rules/unknown-in-effect-catch.md
@@ -53,6 +53,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/unknown-in-effect-catch": "warn"

--- a/docs/rules/unnecessary-arrow-block.md
+++ b/docs/rules/unnecessary-arrow-block.md
@@ -56,6 +56,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/unnecessary-arrow-block": "warn"

--- a/docs/rules/unnecessary-effect-gen.md
+++ b/docs/rules/unnecessary-effect-gen.md
@@ -58,6 +58,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/unnecessary-effect-gen": "warn"

--- a/docs/rules/unnecessary-fail-yieldable-error.md
+++ b/docs/rules/unnecessary-fail-yieldable-error.md
@@ -54,6 +54,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/unnecessary-fail-yieldable-error": "warn"

--- a/docs/rules/unnecessary-pipe-chain.md
+++ b/docs/rules/unnecessary-pipe-chain.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/unnecessary-pipe-chain": "warn"

--- a/docs/rules/unnecessary-pipe.md
+++ b/docs/rules/unnecessary-pipe.md
@@ -50,6 +50,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/unnecessary-pipe": "warn"

--- a/docs/rules/unnecessary-typeof-type.md
+++ b/docs/rules/unnecessary-typeof-type.md
@@ -55,6 +55,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/unnecessary-typeof-type": "warn"

--- a/docs/rules/unsafe-effect-type-assertion.md
+++ b/docs/rules/unsafe-effect-type-assertion.md
@@ -52,6 +52,9 @@ See the [Oxlint setup guide](../README.md#oxlint-setup) for installation and pat
 
 ```json
 {
+  "options": {
+    "typeAware": true
+  },
   "plugins": ["effecttsgo"],
   "rules": {
     "effecttsgo/unsafe-effect-type-assertion": "warn"

--- a/internal/rules/rules_json_test.go
+++ b/internal/rules/rules_json_test.go
@@ -819,7 +819,7 @@ func generateRuleDocs(metadata metadataDocument) map[string]string {
 		}
 
 		fmt.Fprintf(&page, "\n## Language Service Configuration\n\nSee the [Language Service setup guide](../../README.md#installation) for installation instructions.\n\n```jsonc\n{\n  \"compilerOptions\": {\n    \"plugins\": [\n      {\n        \"name\": \"@effect/language-service\",\n        \"diagnosticSeverity\": {\n          \"%s\": \"warning\"\n        }\n      }\n    ]\n  }\n}\n```\n", current.Name)
-		fmt.Fprintf(&page, "\n## Oxlint Configuration\n\nSee the [Oxlint setup guide](../README.md#oxlint-setup) for installation and patching instructions.\n\n```json\n{\n  \"plugins\": [\"effecttsgo\"],\n  \"rules\": {\n    \"effecttsgo/%s\": \"warn\"\n  }\n}\n```\n", slug)
+		fmt.Fprintf(&page, "\n## Oxlint Configuration\n\nSee the [Oxlint setup guide](../README.md#oxlint-setup) for installation and patching instructions.\n\n```json\n{\n  \"options\": {\n    \"typeAware\": true\n  },\n  \"plugins\": [\"effecttsgo\"],\n  \"rules\": {\n    \"effecttsgo/%s\": \"warn\"\n  }\n}\n```\n", slug)
 		docs[slug+".md"] = page.String()
 	}
 	return docs


### PR DESCRIPTION
## Summary

- add root-level `options.typeAware: true` to every generated Oxlint rule configuration example
- update the rule documentation generator so regenerated pages preserve the required setting
- add a patch changeset for the corrected documentation

Effect rules depend on type information, so these examples now enable Oxlint type-aware mode directly in the root configuration as documented by Oxlint.

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `UPDATE_RULE_DOCS=1 go test ./internal/rules -run TestUpdateRuleDocs`
- `git diff --check`