### PR TITLE
fix: enable long paths for Windows release builds

### DIFF
--- a/.changeset/fix-windows-long-paths.md
+++ b/.changeset/fix-windows-long-paths.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Enable long Git paths before Windows release builds check out recursive submodules.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,10 @@ jobs:
             os: ubuntu-latest
             rust_target: aarch64-unknown-linux-gnu
     steps:
+      - name: Enable long Git paths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Checkout
         uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary

- enable Git long-path support on Windows before the oxlint release job checks out recursive submodules
- prevent TypeScript baseline paths from aborting `actions/checkout` with `Filename too long`
- add a patch changeset

## Validation

- `git diff --check`
- `pnpm exec prettier --check .github/workflows/release.yml .changeset/fix-windows-long-paths.md`
- `pnpm exec changeset status`

The Go/TypeScript validation suite was skipped because this change only updates workflow YAML and a changeset.