### PR TITLE
Fix Windows repoctl commands and release fail-fast

### DIFF
--- a/.changeset/fix-windows-repoctl-commands.md
+++ b/.changeset/fix-windows-repoctl-commands.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix Windows release builds that invoke Node package-manager command shims.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,13 @@ jobs:
       github.event.pull_request.head.ref == 'changeset-release/main' &&
       github.repository_owner == 'Effect-TS'
     name: Build ${{ matrix.profile }} ${{ matrix.npm_target }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
     strategy:
+      fail-fast: true
       matrix:
         npm_target:
           - darwin-arm64
@@ -37,59 +41,31 @@ jobs:
         profile:
           - next
           - latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
-          submodules: recursive
-
-      - name: Setup ${{ matrix.profile }} repo
-        uses: ./.github/actions/setup-repo
-        with:
-          profile: ${{ matrix.profile }}
-
-      - name: Build ${{ matrix.profile }} ${{ matrix.npm_target }}
-        id: binary
-        run: pnpm exec repoctl build binary --profile ${{ matrix.profile }} --target ${{ matrix.npm_target }}
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.npm_target }}__${{ matrix.profile }}
-          path: ${{ steps.binary.outputs.binary_path }}
-
-  build-oxlint:
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.head.ref == 'changeset-release/main' &&
-      github.repository_owner == 'Effect-TS'
-    name: Build oxlint ${{ matrix.npm_target }}
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
+        os:
+          - ubuntu-latest
         include:
-          - npm_target: darwin-arm64
+          - profile: oxlint
+            npm_target: darwin-arm64
             os: macos-latest
             rust_target: aarch64-apple-darwin
-          - npm_target: darwin-x64
+          - profile: oxlint
+            npm_target: darwin-x64
             os: macos-latest
             rust_target: x86_64-apple-darwin
-          - npm_target: win32-x64
+          - profile: oxlint
+            npm_target: win32-x64
             os: windows-latest
             rust_target: x86_64-pc-windows-msvc
-          - npm_target: win32-arm64
+          - profile: oxlint
+            npm_target: win32-arm64
             os: windows-latest
             rust_target: aarch64-pc-windows-msvc
-          - npm_target: linux-x64
+          - profile: oxlint
+            npm_target: linux-x64
             os: ubuntu-latest
             rust_target: x86_64-unknown-linux-gnu
-          - npm_target: linux-arm64
+          - profile: oxlint
+            npm_target: linux-arm64
             os: ubuntu-latest
             rust_target: aarch64-unknown-linux-gnu
     steps:
@@ -104,18 +80,25 @@ jobs:
           submodules: recursive
 
       - name: Setup Rust
+        if: matrix.profile == 'oxlint'
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.93.0"
           components: rustfmt
           targets: ${{ matrix.rust_target }}
 
-      - name: Setup oxlint repo
+      - name: Setup ${{ matrix.profile }} repo
         uses: ./.github/actions/setup-repo
         with:
-          profile: oxlint
+          profile: ${{ matrix.profile }}
+
+      - name: Build ${{ matrix.profile }} ${{ matrix.npm_target }}
+        if: matrix.profile != 'oxlint'
+        id: binary
+        run: pnpm exec repoctl build binary --profile ${{ matrix.profile }} --target ${{ matrix.npm_target }}
 
       - name: Build oxlint ${{ matrix.npm_target }}
+        if: matrix.profile == 'oxlint'
         id: oxlint
         env:
           TARGET_CC: clang
@@ -124,8 +107,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.npm_target }}__oxlint
-          path: ${{ steps.oxlint.outputs.artifact_path }}
+          name: ${{ matrix.npm_target }}__${{ matrix.profile }}
+          path: ${{ matrix.profile == 'oxlint' && steps.oxlint.outputs.artifact_path || steps.binary.outputs.binary_path }}
 
   publish:
     if: >-
@@ -135,7 +118,7 @@ jobs:
       github.repository_owner == 'Effect-TS'
     name: Publish Packages
     runs-on: ubuntu-latest
-    needs: [build, build-oxlint]
+    needs: [build]
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/_tools/repoctl/src/oxlint.ts
+++ b/_tools/repoctl/src/oxlint.ts
@@ -149,15 +149,6 @@ export const prepareOxlintProfile = Effect.fnUntraced(function*(repositoryRoot: 
   }
 
   yield* runCommand("git", tsgolint, ["fetch", "--quiet", "--depth", "50", "--tags", "origin", profile.tsgolint.gitHead])
-  const tsgolintPackage = yield* parseJson<{ readonly version?: string }>(
-    yield* runCommandString("npm", repositoryRoot, ["view", `oxlint-tsgolint@${profile.tsgolint.npmVersion}`, "--json"]),
-    "oxlint-tsgolint npm metadata"
-  )
-  if (tsgolintPackage.version !== profile.tsgolint.npmVersion) {
-    return yield* new OxlintGenerationError({
-      reason: `tsgolint npm version ${String(tsgolintPackage.version)} does not match profile ${profile.tsgolint.npmVersion}`
-    })
-  }
   const oxlintPackage = yield* parseJson<{ readonly version?: string }>(
     yield* fs.readFileString(path.join(oxlint, "apps", "oxlint", "package.json")),
     path.join(oxlint, "apps", "oxlint", "package.json")

--- a/_tools/repoctl/src/process.ts
+++ b/_tools/repoctl/src/process.ts
@@ -17,6 +17,11 @@ export class CommandError extends Data.TaggedError("CommandError")<{
   }
 }
 
+const windowsCommandShims = new Set(["corepack", "npm", "pnpm"])
+
+export const resolveCommand = (command: string, platform: NodeJS.Platform = process.platform): string =>
+  platform === "win32" && windowsCommandShims.has(command) ? `${command}.cmd` : command
+
 export const runCommand = Effect.fnUntraced(function*(
   command: string,
   cwd: string,
@@ -25,7 +30,7 @@ export const runCommand = Effect.fnUntraced(function*(
   env?: Readonly<Record<string, string>>
 ) {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
-  const exitCode = yield* spawner.exitCode(ChildProcess.make(command, args, {
+  const exitCode = yield* spawner.exitCode(ChildProcess.make(resolveCommand(command), args, {
     cwd,
     stdin: "inherit",
     stdout: quiet ? "ignore" : "inherit",
@@ -58,7 +63,7 @@ export const runCommandCapture = Effect.fnUntraced(function*(
 ) {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
   return yield* Effect.scoped(Effect.gen(function*() {
-    const handle = yield* spawner.spawn(ChildProcess.make(command, args, {
+    const handle = yield* spawner.spawn(ChildProcess.make(resolveCommand(command), args, {
       cwd,
       stdin: "inherit"
     }))
@@ -78,7 +83,7 @@ export const runCommandCaptureSplit = Effect.fnUntraced(function*(
 ) {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
   return yield* Effect.scoped(Effect.gen(function*() {
-    const handle = yield* spawner.spawn(ChildProcess.make(command, args, {
+    const handle = yield* spawner.spawn(ChildProcess.make(resolveCommand(command), args, {
       cwd,
       stdin: "inherit",
       env,

--- a/_tools/repoctl/test/process.test.ts
+++ b/_tools/repoctl/test/process.test.ts
@@ -2,7 +2,15 @@ import * as NodeServices from "@effect/platform-node/NodeServices"
 import * as Effect from "effect/Effect"
 import assert from "node:assert/strict"
 import test from "node:test"
-import { runCommandString } from "../src/process.ts"
+import { resolveCommand, runCommandString } from "../src/process.ts"
+
+test("resolves Node command shims on Windows", () => {
+  assert.equal(resolveCommand("corepack", "win32"), "corepack.cmd")
+  assert.equal(resolveCommand("npm", "win32"), "npm.cmd")
+  assert.equal(resolveCommand("pnpm", "win32"), "pnpm.cmd")
+  assert.equal(resolveCommand("npm", "linux"), "npm")
+  assert.equal(resolveCommand("git", "win32"), "git")
+})
 
 test("captures successful command output", async() => {
   const output = await Effect.runPromise(


### PR DESCRIPTION
## Summary

- resolve `npm`, `pnpm`, and `corepack` through their `.cmd` shims when repoctl runs on Windows
- remove the redundant `npm view` check while materializing the pinned oxlint profile
- combine TypeScript and oxlint release builds into one fail-fast matrix so failures cancel both build families

## Root cause

The Windows oxlint release job failed with `spawn npm ENOENT` because Effect delegates directly to Node child-process spawning, which does not execute the `npm.cmd` shim from a bare `npm` command.

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm --filter @effect/tsgo-repoctl test`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release.yml`