### PR TITLE
fix: preserve LF endings for patches

### DIFF
--- a/.changeset/fix-windows-patch-line-endings.md
+++ b/.changeset/fix-windows-patch-line-endings.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Force patch files to use LF line endings so TypeScript-Go patches apply on Windows release runners.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sh text eol=lf
+*.patch text eol=lf


### PR DESCRIPTION
## Summary

- force all tracked `.patch` files to use LF line endings
- prevent Windows release runners from converting Effect TypeScript-Go patches to CRLF
- add a patch changeset for `@effect/tsgo`

## Root cause

Windows checked `_patches/typescript-go/001-cmd-tsgo-main.patch` out with CRLF endings, while TypeScript-Go forces `cmd/tsgo/main.go` to LF. The carriage returns became part of the patch context, so `git apply --check` could not match the import block. Tsgolint patches did not fail because that repository already forces all files to LF.

A fresh `core.autocrlf=true` checkout now retains LF patch bytes and the previously failing `git apply --check` succeeds.

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`