### PR TITLE
fix: install Oxlint release targets for pinned Rust

### DIFF
--- a/.changeset/fix-oxlint-rust-target.md
+++ b/.changeset/fix-oxlint-rust-target.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Install cross-compilation targets for the Rust toolchain pinned by Oxlint during release builds.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,11 @@ jobs:
         with:
           profile: ${{ matrix.profile }}
 
+      - name: Add Oxlint Rust target
+        if: matrix.profile == 'oxlint'
+        working-directory: oxlint
+        run: rustup target add ${{ matrix.rust_target }}
+
       - name: Build ${{ matrix.profile }} ${{ matrix.npm_target }}
         if: matrix.profile != 'oxlint'
         id: binary


### PR DESCRIPTION
## Summary

- install each Oxlint release target after materializing the Oxlint checkout
- run `rustup target add` from `oxlint/` so Oxlint’s pinned Rust toolchain receives the target
- add a patch changeset

## Why

The release workflow installed cross-compilation targets for Rust 1.93.0, while the pinned Oxlint checkout selected Rust 1.97.1. Cross-target builds such as `darwin-x64` then failed because `std` was unavailable for the active toolchain.

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm exec changeset status`
- Prettier workflow and changeset checks