### PR TITLE
fix: launch Windows command shims through shell

### DIFF
--- a/.changeset/fix-windows-command-shell.md
+++ b/.changeset/fix-windows-command-shell.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Run Node command shims through the Windows shell so Oxlint release builds can install and build their dependencies.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
         working-directory: oxlint
         run: rustup target add ${{ matrix.rust_target }}
 
-      - name: Build ${{ matrix.profile }} ${{ matrix.npm_target }}
+      - name: Build tsc ${{ matrix.profile }} ${{ matrix.npm_target }}
         if: matrix.profile != 'oxlint'
         id: binary
         run: pnpm exec repoctl build binary --profile ${{ matrix.profile }} --target ${{ matrix.npm_target }}

--- a/_tools/repoctl/src/process.ts
+++ b/_tools/repoctl/src/process.ts
@@ -19,8 +19,11 @@ export class CommandError extends Data.TaggedError("CommandError")<{
 
 const windowsCommandShims = new Set(["corepack", "npm", "pnpm"])
 
+export const isWindowsCommandShim = (command: string, platform: NodeJS.Platform = process.platform): boolean =>
+  platform === "win32" && windowsCommandShims.has(command)
+
 export const resolveCommand = (command: string, platform: NodeJS.Platform = process.platform): string =>
-  platform === "win32" && windowsCommandShims.has(command) ? `${command}.cmd` : command
+  isWindowsCommandShim(command, platform) ? `${command}.cmd` : command
 
 export const runCommand = Effect.fnUntraced(function*(
   command: string,
@@ -36,7 +39,8 @@ export const runCommand = Effect.fnUntraced(function*(
     stdout: quiet ? "ignore" : "inherit",
     stderr: quiet ? "ignore" : "inherit",
     env,
-    extendEnv: true
+    extendEnv: true,
+    shell: isWindowsCommandShim(command)
   }))
   if (exitCode !== ChildProcessSpawner.ExitCode(0)) {
     return yield* new CommandError({ command, args, exitCode })
@@ -65,7 +69,8 @@ export const runCommandCapture = Effect.fnUntraced(function*(
   return yield* Effect.scoped(Effect.gen(function*() {
     const handle = yield* spawner.spawn(ChildProcess.make(resolveCommand(command), args, {
       cwd,
-      stdin: "inherit"
+      stdin: "inherit",
+      shell: isWindowsCommandShim(command)
     }))
     const [output, exitCode] = yield* Effect.all([
       Stream.mkString(Stream.decodeText(handle.all)),
@@ -87,7 +92,8 @@ export const runCommandCaptureSplit = Effect.fnUntraced(function*(
       cwd,
       stdin: "inherit",
       env,
-      extendEnv: true
+      extendEnv: true,
+      shell: isWindowsCommandShim(command)
     }))
     const [stdout, stderr, exitCode] = yield* Effect.all([
       Stream.mkString(Stream.decodeText(handle.stdout)),

--- a/_tools/repoctl/test/process.test.ts
+++ b/_tools/repoctl/test/process.test.ts
@@ -2,7 +2,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices"
 import * as Effect from "effect/Effect"
 import assert from "node:assert/strict"
 import test from "node:test"
-import { resolveCommand, runCommandString } from "../src/process.ts"
+import { isWindowsCommandShim, resolveCommand, runCommandString } from "../src/process.ts"
 
 test("resolves Node command shims on Windows", () => {
   assert.equal(resolveCommand("corepack", "win32"), "corepack.cmd")
@@ -10,6 +10,14 @@ test("resolves Node command shims on Windows", () => {
   assert.equal(resolveCommand("pnpm", "win32"), "pnpm.cmd")
   assert.equal(resolveCommand("npm", "linux"), "npm")
   assert.equal(resolveCommand("git", "win32"), "git")
+})
+
+test("uses a shell for Node command shims on Windows", () => {
+  assert.equal(isWindowsCommandShim("corepack", "win32"), true)
+  assert.equal(isWindowsCommandShim("npm", "win32"), true)
+  assert.equal(isWindowsCommandShim("pnpm", "win32"), true)
+  assert.equal(isWindowsCommandShim("npm", "linux"), false)
+  assert.equal(isWindowsCommandShim("git", "win32"), false)
 })
 
 test("captures successful command output", async() => {


### PR DESCRIPTION
## Summary

- launch `corepack`, `npm`, and `pnpm` command shims through the Windows shell
- avoid `spawn EINVAL` while building the Oxlint N-API addon on Windows runners
- cover Windows shim detection and clarify the non-Oxlint release build step name

## Testing

- not rerun locally as part of the PR workflow; CI will validate the change