### PR TITLE
fix: increase release build timeout

### DIFF
--- a/.changeset/increase-release-build-timeout.md
+++ b/.changeset/increase-release-build-timeout.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Increase the release profile build timeout to 45 minutes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
     needs: select-mode
     if: needs.select-mode.outputs.mode == 'publish'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
     defaults:


### PR DESCRIPTION
## Summary

- increase the release profile build timeout from 30 to 45 minutes
- leave pack and publish timeout limits unchanged

## Testing

- Not run locally, per request.