### PR TITLE
fix: safely update automation branches

### DIFF
--- a/.changeset/fix-repoctl-force-with-lease.md
+++ b/.changeset/fix-repoctl-force-with-lease.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Safely replace stale automation pull request branches with force-with-lease.

--- a/_tools/repoctl/src/github.ts
+++ b/_tools/repoctl/src/github.ts
@@ -137,7 +137,19 @@ export const openPullRequestIfChanged = Effect.fnUntraced(function*(
       "-m",
       options.commitMessage
     ])
-    yield* runCommand("git", repositoryRoot, ["push", "origin", `${headSha}:refs/heads/${branch}`])
+    const remoteBranch = yield* commandString("git", repositoryRoot, [
+      "ls-remote",
+      "--heads",
+      "origin",
+      `refs/heads/${branch}`
+    ])
+    const remoteHeadSha = remoteBranch.split(/\s/, 1)[0]
+    yield* runCommand("git", repositoryRoot, [
+      "push",
+      `--force-with-lease=refs/heads/${branch}:${remoteHeadSha}`,
+      "origin",
+      `${headSha}:refs/heads/${branch}`
+    ])
   }
 
   if (existingNumber !== "") {


### PR DESCRIPTION
## Summary
- read the current remote automation branch tip before publishing generated commits
- update generated PR branches with an explicit force-with-lease
- prevent concurrent branch updates from being overwritten

## Testing
- not rerun during PR preparation, per request