### PR TITLE
ci: cache Oxlint Rust builds

### DIFF
--- a/.changeset/cache-oxlint-build.md
+++ b/.changeset/cache-oxlint-build.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Cache compiled Rust artifacts across Oxlint validation and release builds.

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -10,10 +10,54 @@ inputs:
     description: Whether to materialize the selected upstream profile
     required: false
     default: "true"
+  rust-target:
+    description: Rust target to install for Oxlint builds
+    required: false
+    default: ""
 
 runs:
   using: composite
   steps:
+    - name: Setup Rust
+      if: inputs.profile == 'oxlint'
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: "1.93.0"
+        components: rustfmt
+        targets: ${{ inputs.rust-target }}
+
+    - name: Install native build tools
+      if: inputs.profile == 'oxlint' && runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes cmake
+
+    - name: Configure Rust build cache
+      if: inputs.profile == 'oxlint'
+      shell: bash
+      run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/oxlint-target" >> "$GITHUB_ENV"
+
+    - name: Resolve Rust cache key
+      if: inputs.profile == 'oxlint'
+      id: rust-cache-key
+      shell: bash
+      run: |
+        node -e 'const upstream = require("./_packages/tsgo/upstream.json"); const profile = upstream.profiles.find(({ name }) => name === "oxlint"); if (!profile) process.exit(1); process.stdout.write(`revision=${profile.oxlint.gitHead}\n`)' >> "$GITHUB_OUTPUT"
+
+    - name: Cache Rust build
+      if: inputs.profile == 'oxlint'
+      uses: actions/cache@v6
+      with:
+        path: |
+          ~/.cargo/git
+          ~/.cargo/registry
+          ${{ runner.temp }}/oxlint-target
+        key: rust-build-oxlint-1.93.0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rust-target || 'host' }}-${{ steps.rust-cache-key.outputs.revision }}-${{ hashFiles('_patches/oxlint/**') }}
+        restore-keys: |
+          rust-build-oxlint-1.93.0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rust-target || 'host' }}-${{ steps.rust-cache-key.outputs.revision }}-
+          rust-build-oxlint-1.93.0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rust-target || 'host' }}-
+
     - name: Setup Go
       uses: actions/setup-go@v6
       with:

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -39,8 +39,20 @@ runs:
       run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/oxlint-target" >> "$GITHUB_ENV"
 
     - name: Cache Rust build
-      if: inputs.profile == 'oxlint'
+      if: inputs.profile == 'oxlint' && github.ref == 'refs/heads/main'
       uses: actions/cache@v6
+      with:
+        path: |
+          ~/.cargo/git
+          ~/.cargo/registry
+          ${{ runner.temp }}/oxlint-target
+        key: rust-build-oxlint-1.93.0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rust-target || 'host' }}-${{ hashFiles('_packages/tsgo/upstream.json', '_patches/oxlint/**') }}
+        restore-keys: |
+          rust-build-oxlint-1.93.0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rust-target || 'host' }}-
+
+    - name: Restore Rust build cache
+      if: inputs.profile == 'oxlint' && github.ref != 'refs/heads/main'
+      uses: actions/cache/restore@v6
       with:
         path: |
           ~/.cargo/git
@@ -64,7 +76,20 @@ runs:
         echo "modules=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
     - name: Cache Go build
+      if: github.ref == 'refs/heads/main'
       uses: actions/cache@v6
+      with:
+        path: |
+          ${{ steps.go-cache.outputs.build }}
+          ${{ steps.go-cache.outputs.modules }}
+        key: go-build-${{ inputs.profile }}-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
+        restore-keys: |
+          go-build-${{ inputs.profile }}-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
+          go-build-${{ inputs.profile }}-${{ runner.os }}-
+
+    - name: Restore Go build cache
+      if: github.ref != 'refs/heads/main'
+      uses: actions/cache/restore@v6
       with:
         path: |
           ${{ steps.go-cache.outputs.build }}

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -38,13 +38,6 @@ runs:
       shell: bash
       run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/oxlint-target" >> "$GITHUB_ENV"
 
-    - name: Resolve Rust cache key
-      if: inputs.profile == 'oxlint'
-      id: rust-cache-key
-      shell: bash
-      run: |
-        node -e 'const upstream = require("./_packages/tsgo/upstream.json"); const profile = upstream.profiles.find(({ name }) => name === "oxlint"); if (!profile) process.exit(1); process.stdout.write(`revision=${profile.oxlint.gitHead}\n`)' >> "$GITHUB_OUTPUT"
-
     - name: Cache Rust build
       if: inputs.profile == 'oxlint'
       uses: actions/cache@v6
@@ -53,9 +46,8 @@ runs:
           ~/.cargo/git
           ~/.cargo/registry
           ${{ runner.temp }}/oxlint-target
-        key: rust-build-oxlint-1.93.0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rust-target || 'host' }}-${{ steps.rust-cache-key.outputs.revision }}-${{ hashFiles('_patches/oxlint/**') }}
+        key: rust-build-oxlint-1.93.0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rust-target || 'host' }}-${{ hashFiles('_packages/tsgo/upstream.json', '_patches/oxlint/**') }}
         restore-keys: |
-          rust-build-oxlint-1.93.0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rust-target || 'host' }}-${{ steps.rust-cache-key.outputs.revision }}-
           rust-build-oxlint-1.93.0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rust-target || 'host' }}-
 
     - name: Setup Go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,23 +143,11 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - name: Setup Rust
-        if: matrix.profile == 'oxlint'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: "1.93.0"
-          components: rustfmt
-          targets: ${{ matrix.rust_target }}
-
       - name: Setup ${{ matrix.profile }} repo
         uses: ./.github/actions/setup-repo
         with:
           profile: ${{ matrix.profile }}
-
-      - name: Add Oxlint Rust target
-        if: matrix.profile == 'oxlint'
-        working-directory: oxlint
-        run: rustup target add ${{ matrix.rust_target }}
+          rust-target: ${{ matrix.rust_target }}
 
       - name: Build tsc ${{ matrix.profile }} ${{ matrix.npm_target }}
         if: matrix.profile != 'oxlint'

--- a/.github/workflows/validate-oxlint-profile.yml
+++ b/.github/workflows/validate-oxlint-profile.yml
@@ -27,32 +27,11 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v7
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: "1.93.0"
-          components: rustfmt
-
-      - name: Install native build tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes cmake
-
-      - name: Cache Rust build
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/git
-            ~/.cargo/registry
-          key: oxlint-rust-${{ runner.os }}-${{ hashFiles('_packages/tsgo/upstream.json', '_patches/oxlint/**') }}-${{ github.sha }}
-          restore-keys: |
-            oxlint-rust-${{ runner.os }}-${{ hashFiles('_packages/tsgo/upstream.json', '_patches/oxlint/**') }}-
-            oxlint-rust-${{ runner.os }}-
-
       - name: Setup Oxlint profile
         uses: ./.github/actions/setup-repo
         with:
           profile: oxlint
+          rust-target: x86_64-unknown-linux-gnu
 
       - name: Build Oxlint profile
         run: pnpm exec repoctl build oxlint --target linux-x64


### PR DESCRIPTION
## Summary
- centralize Oxlint Rust setup and native build dependencies in the shared setup action
- cache Cargo dependencies and compiled artifacts outside the generated checkout so profile cleanup does not remove them
- share the setup across validation and target-specific release builds
- restore Go and Rust caches on PRs, but only save refreshed caches from `main`

The first `main` run for each target and upstream revision will populate its Rust cache. PR workflows can consume default-branch caches without uploading large PR-scoped copies.

## Testing
- not run locally, per request