### PR TITLE
fix: install Oxlint cross targets

### DIFF
--- a/.changeset/fix-oxlint-cross-target.md
+++ b/.changeset/fix-oxlint-cross-target.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Install Oxlint cross-compilation targets for its pinned Rust toolchain.

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -24,7 +24,6 @@ runs:
       with:
         toolchain: "1.93.0"
         components: rustfmt
-        targets: ${{ inputs.rust-target }}
 
     - name: Install native build tools
       if: inputs.profile == 'oxlint' && runner.os == 'Linux'
@@ -117,3 +116,11 @@ runs:
       env:
         PROFILE: ${{ inputs.profile }}
       run: pnpm exec repoctl submodules setup --profile "$PROFILE"
+
+    - name: Install Oxlint Rust target
+      if: inputs.profile == 'oxlint' && inputs.materialize == 'true' && inputs.rust-target != ''
+      shell: bash
+      working-directory: oxlint
+      env:
+        RUST_TARGET: ${{ inputs.rust-target }}
+      run: rustup target add "$RUST_TARGET"


### PR DESCRIPTION
## Summary
- stop installing release cross targets against the preliminary Rust 1.93 toolchain
- install the requested target after the Oxlint profile is materialized
- run `rustup target add` from the Oxlint checkout so its pinned Rust toolchain receives the standard library

This fixes release cross-build failures such as `can't find crate for std` for `x86_64-apple-darwin` on ARM64 macOS runners.

## Testing
- not run locally, per request