### PR TITLE
ci: reduce platform cache usage

### DIFF
--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -74,29 +74,39 @@ runs:
         echo "build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
         echo "modules=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
-    - name: Cache Go build
+    - name: Cache Go modules
       if: github.ref == 'refs/heads/main'
       uses: actions/cache@v6
       with:
-        path: |
-          ${{ steps.go-cache.outputs.build }}
-          ${{ steps.go-cache.outputs.modules }}
-        key: go-build-${{ inputs.profile }}-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
-        restore-keys: |
-          go-build-${{ inputs.profile }}-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
-          go-build-${{ inputs.profile }}-${{ runner.os }}-
+        path: ${{ steps.go-cache.outputs.modules }}/cache/download
+        key: go-modules-1.26-${{ inputs.profile }}-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}
 
-    - name: Restore Go build cache
+    - name: Restore Go modules
       if: github.ref != 'refs/heads/main'
       uses: actions/cache/restore@v6
       with:
-        path: |
-          ${{ steps.go-cache.outputs.build }}
-          ${{ steps.go-cache.outputs.modules }}
-        key: go-build-${{ inputs.profile }}-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
+        path: ${{ steps.go-cache.outputs.modules }}/cache/download
+        key: go-modules-1.26-${{ inputs.profile }}-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}
+
+    - name: Cache Go build
+      if: runner.os == 'Linux' && github.ref == 'refs/heads/main'
+      uses: actions/cache@v6
+      with:
+        path: ${{ steps.go-cache.outputs.build }}
+        key: go-build-${{ inputs.profile }}-Linux-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}-${{ github.sha }}
         restore-keys: |
-          go-build-${{ inputs.profile }}-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
-          go-build-${{ inputs.profile }}-${{ runner.os }}-
+          go-build-${{ inputs.profile }}-Linux-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}-
+          go-build-${{ inputs.profile }}-Linux-
+
+    - name: Restore Go build cache
+      if: runner.os == 'Linux' && github.ref != 'refs/heads/main'
+      uses: actions/cache/restore@v6
+      with:
+        path: ${{ steps.go-cache.outputs.build }}
+        key: go-build-${{ inputs.profile }}-Linux-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}-${{ github.sha }}
+        restore-keys: |
+          go-build-${{ inputs.profile }}-Linux-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}-
+          go-build-${{ inputs.profile }}-Linux-
 
     - name: Setup Node
       uses: actions/setup-node@v6

--- a/.github/workflows/validate-nix.yml
+++ b/.github/workflows/validate-nix.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: [main]
 
 concurrency:
   group: validate-nix-${{ github.ref }}
@@ -34,9 +32,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@v3
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/flakehub-cache-action@e62e272c914d4ad8e4d1587a864e9c3ad2cba9de
 
       - name: Check flake
         run: nix flake check --no-write-lock-file


### PR DESCRIPTION
## Summary

- cache Go module downloads separately on every runner OS before profile materialization
- key module downloads from the profile, upstream metadata, patches, and Go manifests
- restore and save the Go build cache only on Linux to avoid slow Windows archive creation
- run Nix validation only after pushes to `main` instead of on pull requests
- remove the FlakeHub cache from Nix validation to preserve repository cache capacity

## Testing

- Not run locally, per request (workflow-only changes)

## Changeset

- Omitted, per request