### PR TITLE
Add Oxlint integration to setup

### DIFF
--- a/.changeset/setup-oxlint-integration.md
+++ b/.changeset/setup-oxlint-integration.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": minor
+---
+
+Add TypeScript and Oxlint integration selection to `effect-tsgo setup`, including supported Oxlint dependency pinning and integration-aware prepare scripts.

--- a/_packages/tsgo/src/cli/setup/assessment.ts
+++ b/_packages/tsgo/src/cli/setup/assessment.ts
@@ -11,8 +11,10 @@ import {
   LSP_PACKAGE_NAME,
   LSP_PLUGIN_NAME,
   isNativeTypescriptVersion,
-  PATCH_COMMAND
+  OXLINT_PACKAGE_NAME,
+  OXLINT_TSGOLINT_PACKAGE_NAME
 } from "./consts.js"
+import { getPatchIntegrations, hasPatchCommand } from "./patch-command.js"
 import type { RuleSeverity } from "./rule-info.js"
 
 /**
@@ -101,6 +103,8 @@ const assessPackageJson = (
   }
 
   const lspVersion = assessDependency(LSP_PACKAGE_NAME)
+  const oxlintVersion = assessDependency(OXLINT_PACKAGE_NAME)
+  const oxlintTsgolintVersion = assessDependency(OXLINT_TSGOLINT_PACKAGE_NAME)
   let typescriptVersion = Option.none<PackageDependency>()
   for (const packageName of defaultTypescriptPackageNames) {
     const typescriptDep = assessDependency(packageName)
@@ -114,7 +118,8 @@ const assessPackageJson = (
   const prepareScript = "prepare" in (parsed.scripts ?? {})
     ? Option.some({
       script: parsed.scripts!.prepare,
-      hasPatch: parsed.scripts!.prepare.toLowerCase().includes(PATCH_COMMAND)
+      hasPatch: hasPatchCommand(parsed.scripts!.prepare),
+      integrations: getPatchIntegrations(parsed.scripts!.prepare)
     })
     : Option.none()
 
@@ -125,6 +130,8 @@ const assessPackageJson = (
     text: input.text,
     lspVersion,
     typescriptVersion,
+    oxlintVersion,
+    oxlintTsgolintVersion,
     prepareScript
   }
 }

--- a/_packages/tsgo/src/cli/setup/changes.ts
+++ b/_packages/tsgo/src/cli/setup/changes.ts
@@ -12,8 +12,10 @@ import {
   defaultTypescriptPackageNames,
   LSP_PACKAGE_NAME,
   LSP_PLUGIN_NAME,
-  PATCH_COMMAND
+  OXLINT_PACKAGE_NAME,
+  OXLINT_TSGOLINT_PACKAGE_NAME
 } from "./consts.js"
+import { getPatchCommand, updatePatchCommand } from "./patch-command.js"
 import type { RuleSeverity } from "./rule-info.js"
 
 interface ComputeFileChangesResult {
@@ -259,6 +261,31 @@ const computePackageJsonChanges = (
         )
       }
 
+      const appendNewOxlintDependencies = (
+        dependencyProperties: Array<ts.PropertyAssignment>,
+        dependencyType: "dependencies" | "devDependencies"
+      ) => {
+        for (const [packageName, currentDependency, targetDependency] of [
+          [OXLINT_PACKAGE_NAME, current.oxlintVersion, target.oxlintVersion],
+          [OXLINT_TSGOLINT_PACKAGE_NAME, current.oxlintTsgolintVersion, target.oxlintTsgolintVersion]
+        ] as const) {
+          if (
+            target.integrations.includes("oxlint") &&
+            Option.isNone(currentDependency) &&
+            Option.isSome(targetDependency) &&
+            targetDependency.value.dependencyType === dependencyType
+          ) {
+            descriptions.push(`Add ${packageName}@${targetDependency.value.version} in ${dependencyType}`)
+            dependencyProperties.push(
+              ts.factory.createPropertyAssignment(
+                ts.factory.createStringLiteral(packageName),
+                ts.factory.createStringLiteral(targetDependency.value.version)
+              )
+            )
+          }
+        }
+      }
+
       const ensureTypescriptDependency = () => {
         if (Option.isNone(target.typescriptVersion) || Option.isSome(current.typescriptVersion)) {
           return
@@ -280,6 +307,32 @@ const computePackageJsonChanges = (
           `Add ${targetTypescriptPackageName}@${targetTypescript.version} to ${targetTypescript.dependencyType}`
         )
         upsertDependency(tracker, current.sourceFile, rootObj, targetTypescriptPackageName, targetTypescript)
+      }
+
+      const ensurePinnedDependency = (
+        packageName: string,
+        currentDependency: Option.Option<PackageDependency>,
+        targetDependency: Option.Option<PackageDependency>
+      ) => {
+        if (Option.isNone(targetDependency)) return
+        if (
+          Option.isSome(currentDependency) &&
+          currentDependency.value.version === targetDependency.value.version &&
+          currentDependency.value.dependencyType === targetDependency.value.dependencyType
+        ) return
+        if (
+          Option.isNone(currentDependency) &&
+          !findDependencyCollectionProperty(rootObj, targetDependency.value.dependencyType) &&
+          Option.isSome(target.lspVersion) &&
+          target.lspVersion.value.dependencyType === targetDependency.value.dependencyType
+        ) return
+
+        descriptions.push(
+          `${Option.isSome(currentDependency) ? "Update" : "Add"} ${packageName}@${targetDependency.value.version} in ${
+            targetDependency.value.dependencyType
+          }`
+        )
+        upsertDependency(tracker, current.sourceFile, rootObj, packageName, targetDependency.value)
       }
 
       // Handle @effect/tsgo dependency
@@ -318,6 +371,7 @@ const computePackageJsonChanges = (
               if (shouldAddTypescriptWithDependencyType(targetDepType)) {
                 appendTypescriptDependencyProperty(dependencyProperties)
               }
+              appendNewOxlintDependencies(dependencyProperties, targetDepType)
 
               const newDepsProp = ts.factory.createPropertyAssignment(
                 ts.factory.createStringLiteral(targetDepType),
@@ -368,6 +422,7 @@ const computePackageJsonChanges = (
             if (shouldAddTypescriptWithDependencyType(targetDepType)) {
               appendTypescriptDependencyProperty(dependencyProperties)
             }
+            appendNewOxlintDependencies(dependencyProperties, targetDepType)
 
             const newDepsProp = ts.factory.createPropertyAssignment(
               ts.factory.createStringLiteral(targetDepType),
@@ -388,6 +443,14 @@ const computePackageJsonChanges = (
         }
 
         ensureTypescriptDependency()
+        if (target.integrations.includes("oxlint")) {
+          ensurePinnedDependency(OXLINT_PACKAGE_NAME, current.oxlintVersion, target.oxlintVersion)
+          ensurePinnedDependency(
+            OXLINT_TSGOLINT_PACKAGE_NAME,
+            current.oxlintTsgolintVersion,
+            target.oxlintTsgolintVersion
+          )
+        }
       } else if (Option.isSome(current.lspVersion)) {
         // User wants to remove LSP
         descriptions.push(`Remove ${LSP_PACKAGE_NAME} from dependencies`)
@@ -404,7 +467,12 @@ const computePackageJsonChanges = (
       }
 
       // Handle prepare script
-      if (target.prepareScript && Option.isSome(target.lspVersion)) {
+      const patchCommand = target.prepareScript && Option.isSome(target.lspVersion)
+        ? getPatchCommand(target.integrations)
+        : undefined
+      if (!target.managePrepareScript) {
+        return
+      } else if (patchCommand !== undefined) {
         const scriptsProperty = findPropertyInObject(rootObj, "scripts")
 
         if (!scriptsProperty) {
@@ -413,9 +481,9 @@ const computePackageJsonChanges = (
           const newScriptsProp = ts.factory.createPropertyAssignment(
             ts.factory.createStringLiteral("scripts"),
             ts.factory.createObjectLiteralExpression([
-              ts.factory.createPropertyAssignment(
-                ts.factory.createStringLiteral("prepare"),
-                ts.factory.createStringLiteral(PATCH_COMMAND)
+                ts.factory.createPropertyAssignment(
+                  ts.factory.createStringLiteral("prepare"),
+                  ts.factory.createStringLiteral(patchCommand)
               )
             ], false)
           )
@@ -428,7 +496,7 @@ const computePackageJsonChanges = (
 
             const newPrepareProp = ts.factory.createPropertyAssignment(
               ts.factory.createStringLiteral("prepare"),
-              ts.factory.createStringLiteral(PATCH_COMMAND)
+              ts.factory.createStringLiteral(patchCommand)
             )
             insertNodeAtEndOfList(tracker, current.sourceFile, scriptsProperty.initializer.properties, newPrepareProp)
           } else if (Option.isSome(current.prepareScript) && !current.prepareScript.value.hasPatch) {
@@ -436,49 +504,50 @@ const computePackageJsonChanges = (
             descriptions.push("Update prepare script to include patch command")
 
             const currentScript = current.prepareScript.value.script
-            const newScript = `${currentScript} && ${PATCH_COMMAND}`
+            const newScript = `${currentScript} && ${patchCommand}`
             tracker.replaceNode(
               current.sourceFile,
               prepareProperty.initializer,
               ts.factory.createStringLiteral(newScript)
             )
+          } else if (Option.isSome(current.prepareScript)) {
+            const currentScript = current.prepareScript.value.script
+            const updated = updatePatchCommand(currentScript, target.integrations)
+            if (updated.found && updated.script !== currentScript) {
+              descriptions.push("Update effect-tsgo patch integrations in prepare script")
+              tracker.replaceNode(
+                current.sourceFile,
+                prepareProperty.initializer,
+                ts.factory.createStringLiteral(updated.script)
+              )
+            }
           }
         }
       } else if (
-        Option.isNone(target.lspVersion) && Option.isSome(current.prepareScript) &&
+        Option.isSome(current.prepareScript) &&
         current.prepareScript.value.hasPatch
       ) {
-        // User wants to remove LSP and prepare script has patch command
         const scriptsProperty = findPropertyInObject(rootObj, "scripts")
         if (scriptsProperty && ts.isObjectLiteralExpression(scriptsProperty.initializer)) {
           const prepareProperty = findPropertyInObject(scriptsProperty.initializer, "prepare")
           if (prepareProperty && ts.isStringLiteral(prepareProperty.initializer)) {
             const currentScript = current.prepareScript.value.script
-            const hasMultipleCommands = currentScript.includes("&&") || currentScript.includes(";")
-
-            if (hasMultipleCommands) {
+            const updated = updatePatchCommand(currentScript, [])
+            if (updated.found && updated.script.length > 0) {
               descriptions.push("Remove effect-tsgo patch command from prepare script")
-              messages.push(
-                "WARNING: Your prepare script contained multiple commands. " +
-                  "I attempted to automatically remove only the 'effect-tsgo patch' command. " +
-                  "Please verify that the prepare script is correct after this change."
-              )
-
-              const newScript = currentScript
-                .replace(/\s*&&\s*effect-tsgo\s+patch/g, "")
-                .replace(/effect-tsgo\s+patch\s*&&\s*/g, "")
-                .replace(/\s*;\s*effect-tsgo\s+patch/g, "")
-                .replace(/effect-tsgo\s+patch\s*;\s*/g, "")
-                .trim()
-
               tracker.replaceNode(
                 current.sourceFile,
                 prepareProperty.initializer,
-                ts.factory.createStringLiteral(newScript)
+                ts.factory.createStringLiteral(updated.script)
               )
-            } else {
+            } else if (updated.found) {
               descriptions.push("Remove prepare script with patch command")
               deleteNodeFromList(tracker, current.sourceFile, scriptsProperty.initializer.properties, prepareProperty)
+            } else {
+              messages.push(
+                "WARNING: The prepare script uses shell control flow that cannot be safely rewritten. " +
+                  "Remove the effect-tsgo patch command manually."
+              )
             }
           }
         }
@@ -522,11 +591,38 @@ const computeTsConfigChanges = (
     return emptyFileChangesResult()
   }
 
+  const isEffectSchemaProperty = (property: ts.PropertyAssignment | undefined) =>
+    property !== undefined &&
+    ts.isStringLiteral(property.initializer) &&
+    property.initializer.text.replaceAll("\\", "/").endsWith("node_modules/@effect/tsgo/schema.json")
+
   const compilerOptionsProperty = findPropertyInObject(rootObj, "compilerOptions")
   if (!compilerOptionsProperty || !ts.isObjectLiteralExpression(compilerOptionsProperty.initializer)) {
-    // No compilerOptions — if we're removing LSP there's nothing to do
     if (Option.isNone(lspVersion)) {
-      return emptyFileChangesResult()
+      if (!target.manageIntegration) return emptyFileChangesResult()
+
+      const schemaProperty = findPropertyInObject(rootObj, "$schema")
+      if (!isEffectSchemaProperty(schemaProperty)) return emptyFileChangesResult()
+
+      const ctx = createTrackerContext()
+      const fileChanges = tsInternal.textChanges.ChangeTracker.with(ctx, (tracker: any) => {
+        descriptions.push("Remove $schema from tsconfig")
+        deleteNodeFromList(tracker, current.sourceFile, rootObj.properties, schemaProperty!)
+      })
+      const fileChange = fileChanges.find((fc: ts.FileTextChanges) => fc.fileName === current.sourceFile.fileName)
+      return {
+        codeActions: fileChange
+          ? [{
+            description: descriptions.join("; "),
+            changes: [{
+              fileName: current.sourceFile.fileName,
+              textChanges: fileChange.textChanges,
+              isNewFile: false
+            }]
+          }]
+          : [],
+        messages
+      }
     }
 
     // Create compilerOptions with the plugin entry
@@ -575,7 +671,7 @@ const computeTsConfigChanges = (
         })
 
         if (shouldAddSchema && Option.isSome(schemaPropertyAssignment)) {
-          nextProperties.push(schemaPropertyAssignment.value)
+          nextProperties.unshift(schemaPropertyAssignment.value)
         }
         nextProperties.push(compilerOptionsAssignment)
 
@@ -621,25 +717,56 @@ const computeTsConfigChanges = (
           ts.factory.createStringLiteral(schemaPath)
         ))
 
+      const updateDiagnosticSeverity = (lspPluginElement: ts.ObjectLiteralExpression) => {
+        const diagnosticSeverityProperty = findPropertyInObject(lspPluginElement, "diagnosticSeverity")
+        if (Option.isSome(target.diagnosticSeverities)) {
+          const newDiagnosticSeverityValue = createDiagnosticSeverityObject(target.diagnosticSeverities.value)
+          if (!diagnosticSeverityProperty) {
+            descriptions.push(`Add diagnosticSeverity to ${LSP_PLUGIN_NAME} plugin`)
+            insertNodeAtEndOfList(tracker, current.sourceFile, lspPluginElement.properties, ts.factory.createPropertyAssignment(
+              ts.factory.createStringLiteral("diagnosticSeverity"),
+              newDiagnosticSeverityValue
+            ))
+          } else {
+            descriptions.push(`Update diagnosticSeverity in ${LSP_PLUGIN_NAME} plugin`)
+            tracker.replaceNode(current.sourceFile, diagnosticSeverityProperty.initializer, newDiagnosticSeverityValue)
+          }
+        } else if (diagnosticSeverityProperty) {
+          descriptions.push(`Remove diagnosticSeverity from ${LSP_PLUGIN_NAME} plugin`)
+          deleteNodeFromList(tracker, current.sourceFile, lspPluginElement.properties, diagnosticSeverityProperty)
+        }
+      }
+
+      const findLspPlugin = () => {
+        if (!pluginsProperty || !ts.isArrayLiteralExpression(pluginsProperty.initializer)) return undefined
+        return pluginsProperty.initializer.elements.find((element): element is ts.ObjectLiteralExpression => {
+          if (!ts.isObjectLiteralExpression(element)) return false
+          const nameProperty = findPropertyInObject(element, "name")
+          return nameProperty !== undefined && ts.isStringLiteral(nameProperty.initializer) &&
+            nameProperty.initializer.text === LSP_PLUGIN_NAME
+        })
+      }
+
+      if (!target.manageIntegration) {
+        const lspPluginElement = findLspPlugin()
+        if (lspPluginElement) {
+          updateDiagnosticSeverity(lspPluginElement)
+          return
+        }
+        if (Option.isNone(lspVersion)) return
+      }
+
       if (Option.isNone(lspVersion)) {
         // User wants to remove LSP
-        if (schemaProperty) {
+        if (isEffectSchemaProperty(schemaProperty)) {
           descriptions.push("Remove $schema from tsconfig")
-          deleteNodeFromList(tracker, current.sourceFile, rootObj.properties, schemaProperty)
+          deleteNodeFromList(tracker, current.sourceFile, rootObj.properties, schemaProperty!)
         }
 
         if (pluginsProperty && ts.isArrayLiteralExpression(pluginsProperty.initializer)) {
           const pluginsArray = pluginsProperty.initializer
 
-          const lspPluginElement = pluginsArray.elements.find((element) => {
-            if (ts.isObjectLiteralExpression(element)) {
-              const nameProperty = findPropertyInObject(element, "name")
-              if (nameProperty && ts.isStringLiteral(nameProperty.initializer)) {
-                return nameProperty.initializer.text === LSP_PLUGIN_NAME
-              }
-            }
-            return false
-          })
+          const lspPluginElement = findLspPlugin()
 
           if (lspPluginElement) {
             descriptions.push(`Remove ${LSP_PLUGIN_NAME} plugin from tsconfig`)
@@ -650,7 +777,7 @@ const computeTsConfigChanges = (
         // User wants to add/keep LSP
         if (!schemaProperty && Option.isSome(schemaPropertyAssignment)) {
           descriptions.push("Add $schema to tsconfig")
-          insertNodeAtEndOfList(tracker, current.sourceFile, rootObj.properties, schemaPropertyAssignment.value)
+          tracker.insertNodeAtObjectStart(current.sourceFile, rootObj, schemaPropertyAssignment.value)
         } else if (
           schemaProperty &&
           Option.isSome(target.schemaPath) &&
@@ -677,37 +804,13 @@ const computeTsConfigChanges = (
         } else if (ts.isArrayLiteralExpression(pluginsProperty.initializer)) {
           const pluginsArray = pluginsProperty.initializer
 
-          const lspPluginElement = pluginsArray.elements.find((element) => {
-            if (ts.isObjectLiteralExpression(element)) {
-              const nameProperty = findPropertyInObject(element, "name")
-              if (nameProperty && ts.isStringLiteral(nameProperty.initializer)) {
-                return nameProperty.initializer.text === LSP_PLUGIN_NAME
-              }
-            }
-            return false
-          })
+          const lspPluginElement = findLspPlugin()
 
           if (!lspPluginElement) {
             descriptions.push(`Add ${LSP_PLUGIN_NAME} plugin to existing plugins array`)
             insertNodeAtEndOfList(tracker, current.sourceFile, pluginsArray.elements, pluginObject)
           } else if (ts.isObjectLiteralExpression(lspPluginElement)) {
-            const diagnosticSeverityProperty = findPropertyInObject(lspPluginElement, "diagnosticSeverity")
-            if (Option.isSome(target.diagnosticSeverities)) {
-              const newDiagnosticSeverityValue = createDiagnosticSeverityObject(target.diagnosticSeverities.value)
-              if (!diagnosticSeverityProperty) {
-                descriptions.push(`Add diagnosticSeverity to ${LSP_PLUGIN_NAME} plugin`)
-                insertNodeAtEndOfList(tracker, current.sourceFile, lspPluginElement.properties, ts.factory.createPropertyAssignment(
-                  ts.factory.createStringLiteral("diagnosticSeverity"),
-                  newDiagnosticSeverityValue
-                ))
-              } else if (ts.isPropertyAssignment(diagnosticSeverityProperty)) {
-                descriptions.push(`Update diagnosticSeverity in ${LSP_PLUGIN_NAME} plugin`)
-                tracker.replaceNode(current.sourceFile, diagnosticSeverityProperty.initializer, newDiagnosticSeverityValue)
-              }
-            } else if (diagnosticSeverityProperty) {
-              descriptions.push(`Remove diagnosticSeverity from ${LSP_PLUGIN_NAME} plugin`)
-              deleteNodeFromList(tracker, current.sourceFile, lspPluginElement.properties, diagnosticSeverityProperty)
-            }
+            updateDiagnosticSeverity(lspPluginElement)
           }
         }
       }
@@ -837,7 +940,9 @@ export const computeChanges = (
   const tsconfigResult = computeTsConfigChanges(
     assessment.tsconfig,
     target.tsconfig,
-    target.packageJson.lspVersion
+    target.packageJson.integrations.includes("typescript")
+      ? target.packageJson.lspVersion
+      : Option.none()
   )
   codeActions = [...codeActions, ...tsconfigResult.codeActions]
   messages = [...messages, ...tsconfigResult.messages]
@@ -870,14 +975,20 @@ export const computeChanges = (
 
   // Add post-apply next-step messages
   if (Option.isSome(target.packageJson.lspVersion) && codeActions.length > 0) {
+    const patchCommand = getPatchCommand(target.packageJson.integrations)
     messages = [
       ...messages,
-      "Run `effect-tsgo patch` to complete the installation."
+      `Run \`${patchCommand ?? "effect-tsgo patch"}\` to complete the installation.`
     ]
   } else if (Option.isNone(target.packageJson.lspVersion) && Option.isSome(assessment.packageJson.lspVersion)) {
+    const integrations = Option.match(assessment.packageJson.prepareScript, {
+      onNone: () => ["typescript" as const],
+      onSome: (_) => _.integrations
+    })
+    const unpatchCommand = getPatchCommand(integrations)?.replace(" patch ", " unpatch ") ?? "effect-tsgo unpatch"
     messages = [
       ...messages,
-      "Run `effect-tsgo unpatch` to restore the original TypeScript-Go binary."
+      `Run \`${unpatchCommand}\` to restore the original integrations.`
     ]
   }
 

--- a/_packages/tsgo/src/cli/setup/consts.ts
+++ b/_packages/tsgo/src/cli/setup/consts.ts
@@ -4,6 +4,8 @@ export const LSP_PACKAGE_NAME = pkgJson.name
 export const LSP_PLUGIN_NAME = "@effect/language-service"
 export const defaultTypescriptPackageNames = ["typescript", "@typescript/native"] as const
 export const PATCH_COMMAND = "effect-tsgo patch"
+export const OXLINT_PACKAGE_NAME = "oxlint"
+export const OXLINT_TSGOLINT_PACKAGE_NAME = "oxlint-tsgolint"
 
 /**
  * `typescript` package versions >= 7 ship the native Go-ported binary that this

--- a/_packages/tsgo/src/cli/setup/index.ts
+++ b/_packages/tsgo/src/cli/setup/index.ts
@@ -12,6 +12,10 @@ const latestProfile = upstreamJson.profiles.find((profile) => profile.name === "
 if (latestProfile === undefined) {
   throw new Error("Missing latest profile in upstream.json")
 }
+const oxlintProfile = upstreamJson.profiles.find((profile) => profile.kind === "oxlint")
+if (oxlintProfile?.oxlint === undefined || oxlintProfile.tsgolint === undefined) {
+  throw new Error("Missing oxlint profile in upstream.json")
+}
 
 export const setupCommand = Command.make("setup").pipe(
   Command.withDescription("Setup @effect/tsgo for the given project using an interactive CLI."),
@@ -27,6 +31,8 @@ export const setupCommand = Command.make("setup").pipe(
       const targetState = yield* gatherTargetState(assessmentState, {
         defaultLspVersion: pkgJson.version,
         defaultTypescriptVersion: latestProfile.ts.npmVersion,
+        defaultOxlintVersion: oxlintProfile.oxlint.npmVersion,
+        defaultOxlintTsgolintVersion: oxlintProfile.tsgolint.npmVersion,
         defaultSchemaPath: path.resolve(currentDir, "node_modules", pkgJson.name, "schema.json")
       })
       const result = Changes.computeChanges(assessmentState, targetState)

--- a/_packages/tsgo/src/cli/setup/patch-command.ts
+++ b/_packages/tsgo/src/cli/setup/patch-command.ts
@@ -1,0 +1,230 @@
+import type { Integration } from "./types.js"
+
+interface Range {
+  readonly start: number
+  readonly end: number
+}
+
+interface CommandSegment extends Range {
+  readonly operator?: string
+}
+
+interface CommandRange extends Range {
+  readonly patchEnd: number
+  readonly integrationFlags: ReadonlyArray<Range & { readonly value: string }>
+}
+
+const integrationFlagNames = new Set([
+  "--typescript",
+  "--no-typescript",
+  "--oxlint",
+  "--no-oxlint"
+])
+
+export const getPatchCommand = (integrations: ReadonlyArray<Integration>): string | undefined => {
+  const typescript = integrations.includes("typescript")
+  const oxlint = integrations.includes("oxlint")
+  if (!typescript && !oxlint) return undefined
+
+  return `effect-tsgo patch ${typescript ? "--typescript" : "--no-typescript"} ${
+    oxlint ? "--oxlint" : "--no-oxlint"
+  }`
+}
+
+const splitCommands = (script: string): ReadonlyArray<CommandSegment> => {
+  const ranges: Array<CommandSegment> = []
+  let start = 0
+  let quote: "'" | "\"" | undefined
+  let escaped = false
+  let nesting = 0
+
+  for (let index = 0; index < script.length; index++) {
+    const char = script[index]
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true
+      continue
+    }
+    if (quote !== undefined) {
+      if (char === quote) quote = undefined
+      continue
+    }
+    if (char === "'" || char === "\"") {
+      quote = char
+      continue
+    }
+    if (char === "(") {
+      nesting++
+      continue
+    }
+    if (char === ")" && nesting > 0) {
+      nesting--
+      continue
+    }
+    if (nesting > 0) continue
+
+    const operatorLength = char === ";"
+      ? 1
+      : (char === "&" || char === "|") && script[index + 1] === char
+      ? 2
+      : char === "|" || char === "&"
+      ? 1
+      : 0
+    if (operatorLength === 0) continue
+
+    ranges.push({ start, end: index, operator: script.slice(index, index + operatorLength) })
+    start = index + operatorLength
+    index += operatorLength - 1
+  }
+
+  ranges.push({ start, end: script.length })
+  return ranges
+}
+
+const tokenize = (script: string, range: Range): ReadonlyArray<{ value: string; start: number; end: number }> | undefined => {
+  const tokens: Array<{ value: string; start: number; end: number }> = []
+  let index = range.start
+
+  while (index < range.end) {
+    while (index < range.end && /\s/.test(script[index])) index++
+    if (index >= range.end) break
+
+    const start = index
+    let value = ""
+    let quote: "'" | "\"" | undefined
+    let escaped = false
+
+    for (; index < range.end; index++) {
+      const char = script[index]
+      if (escaped) {
+        value += char
+        escaped = false
+        continue
+      }
+      if (char === "\\" && quote !== "'") {
+        escaped = true
+        continue
+      }
+      if (quote !== undefined) {
+        if (char === quote) quote = undefined
+        else value += char
+        continue
+      }
+      if (char === "'" || char === "\"") {
+        quote = char
+        continue
+      }
+      if (/\s/.test(char)) break
+      if ("<>`".includes(char) || (char === "$" && script[index + 1] === "(")) return undefined
+      value += char
+    }
+
+    if (quote !== undefined || escaped) return undefined
+    tokens.push({ value, start, end: index })
+  }
+
+  return tokens
+}
+
+const findPatchCommand = (script: string, range: Range): CommandRange | undefined => {
+  const tokens = tokenize(script, range)
+  if (tokens === undefined || tokens.length < 2) return undefined
+
+  let commandIndex = 0
+  while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[commandIndex]?.value ?? "")) commandIndex++
+
+  if (tokens[commandIndex]?.value === "pnpm" && tokens[commandIndex + 1]?.value === "exec") commandIndex += 2
+  else if (tokens[commandIndex]?.value === "npm" && tokens[commandIndex + 1]?.value === "exec") {
+    commandIndex += tokens[commandIndex + 2]?.value === "--" ? 3 : 2
+  } else if (tokens[commandIndex]?.value === "npx") commandIndex++
+
+  if (tokens[commandIndex]?.value !== "effect-tsgo" || tokens[commandIndex + 1]?.value !== "patch") {
+    return undefined
+  }
+
+  return {
+    start: range.start,
+    end: range.end,
+    patchEnd: tokens[commandIndex + 1].end,
+    integrationFlags: tokens.slice(commandIndex + 2)
+      .filter((token) => integrationFlagNames.has(token.value))
+      .map(({ value, start, end }) => ({ value, start, end }))
+  }
+}
+
+export const hasPatchCommand = (script: string): boolean =>
+  splitCommands(script).some((range) => findPatchCommand(script, range) !== undefined)
+
+export const getPatchIntegrations = (script: string): ReadonlyArray<Integration> => {
+  const match = splitCommands(script).flatMap((range) => {
+    const command = findPatchCommand(script, range)
+    return command === undefined ? [] : [command]
+  })[0]
+  if (match === undefined) return []
+
+  let typescript = true
+  let oxlint = false
+  for (const flag of match.integrationFlags) {
+    if (flag.value === "--typescript") typescript = true
+    else if (flag.value === "--no-typescript") typescript = false
+    else if (flag.value === "--oxlint") oxlint = true
+    else if (flag.value === "--no-oxlint") oxlint = false
+  }
+  return [
+    ...(typescript ? ["typescript" as const] : []),
+    ...(oxlint ? ["oxlint" as const] : [])
+  ]
+}
+
+export const updatePatchCommand = (
+  script: string,
+  integrations: ReadonlyArray<Integration>
+): { readonly script: string; readonly found: boolean } => {
+  const command = getPatchCommand(integrations)
+  const ranges = splitCommands(script)
+  const matches = ranges.flatMap((range) => {
+    const match = findPatchCommand(script, range)
+    return match === undefined ? [] : [match]
+  })
+  if (matches.length === 0) return { script, found: false }
+
+  if (command !== undefined) {
+    const flags = command.slice("effect-tsgo patch".length)
+    let updated = script
+    for (const match of [...matches].reverse()) {
+      let suffix = updated.slice(match.patchEnd, match.end)
+      for (const flag of [...match.integrationFlags].reverse()) {
+        const relativeStart = flag.start - match.patchEnd
+        const relativeEnd = flag.end - match.patchEnd
+        const whitespaceStart = suffix.slice(0, relativeStart).search(/\s+$/)
+        suffix = suffix.slice(0, whitespaceStart < 0 ? relativeStart : whitespaceStart) + suffix.slice(relativeEnd)
+      }
+      updated = updated.slice(0, match.patchEnd) + flags + suffix + updated.slice(match.end)
+    }
+    return { script: updated, found: true }
+  }
+
+  if (ranges.some((range) => range.operator === "||" || range.operator === "|" || range.operator === "&")) {
+    return { script, found: false }
+  }
+
+  let updated = script
+  for (const match of [...matches].reverse()) {
+    const before = updated.slice(0, match.start)
+    const after = updated.slice(match.end)
+    const previousOperator = /\s*(?:&&|\|\||[;|&])\s*$/.exec(before)
+    const nextOperator = /^\s*(?:&&|\|\||[;|&])\s*/.exec(after)
+    if (previousOperator !== null && nextOperator?.[0].trim() !== "&&") {
+      updated = before.slice(0, previousOperator.index) + after
+    } else if (nextOperator !== null) {
+      const leadingWhitespace = /^\s*/.exec(updated.slice(match.start, match.end))?.[0] ?? ""
+      updated = before + leadingWhitespace + after.slice(nextOperator[0].length)
+    } else {
+      updated = before + after
+    }
+  }
+  return { script: updated.trim(), found: true }
+}

--- a/_packages/tsgo/src/cli/setup/target-prompt.ts
+++ b/_packages/tsgo/src/cli/setup/target-prompt.ts
@@ -5,8 +5,7 @@ import type * as Terminal from "effect/Terminal"
 import * as Prompt from "effect/unstable/cli/Prompt"
 import { applyPresetDiagnosticSeverities, type DiagnosticPresetName, isPresetEnabled } from "../presets.js"
 import { defaultTypescriptPackageNames } from "./consts.js"
-import type { Assessment } from "./types.js"
-import type { Editor, Target } from "./target.js"
+import type { Assessment, Editor, Integration, Target } from "./types.js"
 import { getAllPresets, getAllRules } from "./rule-info.js"
 import { createRulePrompt } from "./rule-prompt.js"
 
@@ -16,6 +15,8 @@ import { createRulePrompt } from "./rule-prompt.js"
 export interface GatherTargetContext {
   readonly defaultLspVersion: string
   readonly defaultTypescriptVersion: string
+  readonly defaultOxlintVersion: string
+  readonly defaultOxlintTsgolintVersion: string
   readonly defaultSchemaPath: string
 }
 
@@ -29,15 +30,56 @@ export const gatherTargetState = (
   Effect.gen(function*() {
     const path = yield* Path.Path
 
+    const integrations = yield* Prompt.multiSelect({
+      message: "Which integrations would you like to configure?",
+      choices: [
+        {
+          title: "TypeScript language service",
+          value: "typescript" as Integration,
+          selected: true
+        },
+        {
+          title: "Oxlint type-aware rules",
+          value: "oxlint" as Integration,
+          selected: Option.isSome(assessment.packageJson.oxlintVersion) ||
+            Option.isSome(assessment.packageJson.oxlintTsgolintVersion)
+        }
+      ]
+    })
+
+    const useTypescript = integrations.includes("typescript")
+    const useOxlint = integrations.includes("oxlint")
+
+    if (integrations.length === 0) {
+      return {
+        packageJson: {
+          lspVersion: Option.none(),
+          typescriptVersion: assessment.packageJson.typescriptVersion,
+          oxlintVersion: assessment.packageJson.oxlintVersion,
+          oxlintTsgolintVersion: assessment.packageJson.oxlintTsgolintVersion,
+          prepareScript: false,
+          managePrepareScript: true,
+          integrations
+        },
+        tsconfig: {
+          schemaPath: Option.none(),
+          diagnosticSeverities: Option.none(),
+          manageIntegration: true
+        },
+        vscodeSettings: Option.none(),
+        editors: []
+      } satisfies Target.State
+    }
+
     // Determine current LSP installation state
     const currentLspState = Option.match(assessment.packageJson.lspVersion, {
       onNone: () => "no" as const,
       onSome: (lsp) => lsp.dependencyType
     })
 
-    // Ask what user wants to do with the language service
+    // Ask where to install the CLI used by either integration.
     const lspDependencyType = yield* Prompt.select({
-      message: "Language service installation:",
+      message: "@effect/tsgo installation:",
       choices: [
         {
           title: "Install in devDependencies",
@@ -50,38 +92,16 @@ export const gatherTargetState = (
           description: "We usually don't recommend this, but if you need it for any reason",
           value: "dependencies" as const,
           selected: currentLspState === "dependencies"
-        },
-        {
-          title: "Uninstall",
-          description: "Language service won't be installed or will be removed if already present",
-          value: "no" as const
         }
       ]
     })
-
-    // If user doesn't want to install the language service, return early with everything disabled
-    if (lspDependencyType === "no") {
-      return {
-        packageJson: {
-          lspVersion: Option.none(),
-          typescriptVersion: assessment.packageJson.typescriptVersion,
-          prepareScript: false
-        },
-        tsconfig: {
-          schemaPath: Option.none(),
-          diagnosticSeverities: Option.none()
-        },
-        vscodeSettings: Option.none(),
-        editors: []
-      } satisfies Target.State
-    }
 
     const currentDiagnosticSeverities = Option.match(assessment.tsconfig.currentDiagnosticSeverities, {
       onNone: () => ({}),
       onSome: (diagnosticSeverities) => diagnosticSeverities
     })
 
-    const selectedDiagnosticModes = yield* Prompt.multiSelect({
+    const selectedDiagnosticModes = useTypescript ? yield* Prompt.multiSelect({
       message: "Which diagnostic presets would you like to use?",
       choices: [
         {
@@ -96,7 +116,7 @@ export const gatherTargetState = (
           selected: isPresetEnabled(preset.name as DiagnosticPresetName, currentDiagnosticSeverities)
         }))
       ]
-    })
+    }) : []
 
     const shouldCustomizeDiagnostics = selectedDiagnosticModes.includes("custom")
     const selectedPresetNames = selectedDiagnosticModes.filter((value): value is DiagnosticPresetName =>
@@ -119,7 +139,7 @@ export const gatherTargetState = (
     // Pre-select VSCode if .vscode/settings.json exists
     const hasVscodeSettings = Option.isSome(assessment.vscodeSettings)
 
-    const editors = yield* Prompt.multiSelect({
+    const editors = useTypescript ? yield* Prompt.multiSelect({
       message: "Which editors do you use?",
       choices: [
         {
@@ -136,7 +156,7 @@ export const gatherTargetState = (
           value: "emacs" as Editor
         }
       ]
-    })
+    }) : []
 
     // Build target state
     const defaultTypescriptPackageName = defaultTypescriptPackageNames[0]
@@ -157,19 +177,41 @@ export const gatherTargetState = (
     return {
       packageJson: {
         lspVersion: Option.some({ dependencyType: lspDependencyType, version: context.defaultLspVersion }),
-        typescriptVersion: Option.orElse(
-          assessment.packageJson.typescriptVersion,
-          () => Option.some({
+        typescriptVersion: useTypescript
+          ? Option.orElse(assessment.packageJson.typescriptVersion, () => Option.some({
             dependencyType: lspDependencyType,
             version: context.defaultTypescriptVersion,
             packageName: defaultTypescriptPackageName
+          }))
+          : assessment.packageJson.typescriptVersion,
+        oxlintVersion: useOxlint
+          ? Option.some({
+            dependencyType: Option.match(assessment.packageJson.oxlintVersion, {
+              onNone: () => lspDependencyType,
+              onSome: (dependency) => dependency.dependencyType
+            }),
+            version: context.defaultOxlintVersion
           })
-        ),
-        prepareScript: true
+          : assessment.packageJson.oxlintVersion,
+        oxlintTsgolintVersion: useOxlint
+          ? Option.some({
+            dependencyType: Option.match(assessment.packageJson.oxlintTsgolintVersion, {
+              onNone: () => lspDependencyType,
+              onSome: (dependency) => dependency.dependencyType
+            }),
+            version: context.defaultOxlintTsgolintVersion
+          })
+          : assessment.packageJson.oxlintTsgolintVersion,
+        prepareScript: true,
+        managePrepareScript: true,
+        integrations
       },
       tsconfig: {
-        schemaPath: Option.some(relativeSchemaPath.startsWith(".") ? relativeSchemaPath : `./${relativeSchemaPath}`),
-        diagnosticSeverities
+        schemaPath: useTypescript
+          ? Option.some(relativeSchemaPath.startsWith(".") ? relativeSchemaPath : `./${relativeSchemaPath}`)
+          : Option.none(),
+        diagnosticSeverities,
+        manageIntegration: true
       },
       vscodeSettings,
       editors

--- a/_packages/tsgo/src/cli/setup/target.ts
+++ b/_packages/tsgo/src/cli/setup/target.ts
@@ -9,13 +9,21 @@ export const fromAssessment = (inputState: Assessment.State): Target.State => ({
   packageJson: {
     lspVersion: inputState.packageJson.lspVersion,
     typescriptVersion: inputState.packageJson.typescriptVersion,
+    oxlintVersion: inputState.packageJson.oxlintVersion,
+    oxlintTsgolintVersion: inputState.packageJson.oxlintTsgolintVersion,
     prepareScript: Option.map(inputState.packageJson.prepareScript, (_) => _.hasPatch).pipe(
       Option.getOrElse(() => false)
-    )
+    ),
+    managePrepareScript: false,
+    integrations: Option.match(inputState.packageJson.prepareScript, {
+      onNone: () => Option.isSome(inputState.packageJson.lspVersion) ? ["typescript"] : [],
+      onSome: (_) => _.integrations
+    })
   },
   tsconfig: {
     schemaPath: inputState.tsconfig.currentSchemaPath,
-    diagnosticSeverities: inputState.tsconfig.currentDiagnosticSeverities
+    diagnosticSeverities: inputState.tsconfig.currentDiagnosticSeverities,
+    manageIntegration: false
   },
   vscodeSettings: Option.map(inputState.vscodeSettings, (settings) => ({
     settings: settings.parsed

--- a/_packages/tsgo/src/cli/setup/types.ts
+++ b/_packages/tsgo/src/cli/setup/types.ts
@@ -17,6 +17,7 @@ export interface FileInput {
 }
 
 export type Editor = "vscode" | "nvim" | "emacs"
+export type Integration = "typescript" | "oxlint"
 
 export interface PackageDependency {
   readonly dependencyType: "dependencies" | "devDependencies"
@@ -41,9 +42,12 @@ export namespace Assessment {
     readonly text: string
     readonly lspVersion: Option.Option<PackageDependency>
     readonly typescriptVersion: Option.Option<PackageDependency>
+    readonly oxlintVersion: Option.Option<PackageDependency>
+    readonly oxlintTsgolintVersion: Option.Option<PackageDependency>
     readonly prepareScript: Option.Option<{
       readonly script: string
       readonly hasPatch: boolean
+      readonly integrations: ReadonlyArray<Integration>
     }>
   }
 
@@ -76,12 +80,17 @@ export namespace Target {
   export interface PackageJson {
     readonly lspVersion: Option.Option<PackageDependency>
     readonly typescriptVersion: Option.Option<PackageDependency>
+    readonly oxlintVersion: Option.Option<PackageDependency>
+    readonly oxlintTsgolintVersion: Option.Option<PackageDependency>
     readonly prepareScript: boolean
+    readonly managePrepareScript: boolean
+    readonly integrations: ReadonlyArray<Integration>
   }
 
   export interface TsConfig {
     readonly schemaPath: Option.Option<string>
     readonly diagnosticSeverities: Option.Option<Record<string, RuleSeverity>>
+    readonly manageIntegration: boolean
   }
 
   export interface VSCodeSettings {

--- a/_packages/tsgo/test/config-cli.test.ts
+++ b/_packages/tsgo/test/config-cli.test.ts
@@ -66,6 +66,7 @@ describe("Config CLI", () => {
 
     expect(targetState.packageJson.lspVersion).toEqual(assessmentState.packageJson.lspVersion)
     expect(targetState.packageJson.prepareScript).toBe(true)
+    expect(targetState.packageJson.integrations).toEqual(["typescript"])
     expect(targetState.editors).toEqual([])
     expect(targetState.vscodeSettings).toEqual(Option.map(assessmentState.vscodeSettings, (settings) => ({
       settings: settings.parsed
@@ -80,5 +81,39 @@ describe("Config CLI", () => {
     expect(
       result.codeActions.some((action) => action.changes.some((change) => change.fileName === ".vscode/settings.json"))
     ).toBe(false)
+  })
+
+  it("does not remove integration configuration when prepare is missing", () => {
+    const assessmentState = assess(createAssessmentInput(
+      {
+        devDependencies: { "@effect/tsgo": "^0.1.0" }
+      },
+      {
+        $schema: "./node_modules/@effect/tsgo/schema.json",
+        compilerOptions: {
+          plugins: [{ name: "@effect/language-service" }]
+        }
+      }
+    ))
+    const targetState = Target.withDiagnosticSeverities(Target.fromAssessment(assessmentState), {
+      floatingEffect: "error"
+    })
+    const result = computeChanges(assessmentState, targetState)
+
+    expect(result.codeActions.some((action) => action.description.includes("Remove $schema"))).toBe(false)
+    expect(result.codeActions.some((action) => action.description.includes("Remove @effect/language-service"))).toBe(false)
+  })
+
+  it("adds the plugin when configuring an installed integration", () => {
+    const assessmentState = assess(createAssessmentInput(
+      { devDependencies: { "@effect/tsgo": "^0.1.0" } },
+      { compilerOptions: {} }
+    ))
+    const targetState = Target.withDiagnosticSeverities(Target.fromAssessment(assessmentState), {
+      floatingEffect: "error"
+    })
+    const result = computeChanges(assessmentState, targetState)
+
+    expect(result.codeActions.some((action) => action.description.includes("@effect/language-service plugin"))).toBe(true)
   })
 })

--- a/_packages/tsgo/test/setup/__snapshots__/setup-cli.test.ts.snap
+++ b/_packages/tsgo/test/setup/__snapshots__/setup-cli.test.ts.snap
@@ -15,7 +15,7 @@ exports[`Setup CLI > should add LSP plugin alongside existing plugins > change s
 
 exports[`Setup CLI > should add LSP plugin alongside existing plugins > messages 1`] = `
 [
-  "Run \`effect-tsgo patch\` to complete the installation.",
+  "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
 
@@ -30,6 +30,7 @@ exports[`Setup CLI > should add LSP plugin alongside existing plugins > package.
 
 exports[`Setup CLI > should add LSP plugin alongside existing plugins > tsconfig.json 1`] = `
 "{
+	"$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -41,8 +42,7 @@ exports[`Setup CLI > should add LSP plugin alongside existing plugins > tsconfig
 	"name": "@effect/language-service"
 }
     ]
-  },
-"$schema": "./node_modules/@effect/tsgo/schema.json"
+  }
 }"
 `;
 
@@ -77,7 +77,7 @@ exports[`Setup CLI > should add LSP with VS Code editor selected and create new 
 
 exports[`Setup CLI > should add LSP with VS Code editor selected and create new settings file > messages 1`] = `
 [
-  "Run \`effect-tsgo patch\` to complete the installation.",
+  "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
   "",
   "VS Code / Cursor / VS Code-based editors:",
   "  1. Install the TypeScript 7 extension",
@@ -98,6 +98,7 @@ exports[`Setup CLI > should add LSP with VS Code editor selected and create new 
 
 exports[`Setup CLI > should add LSP with VS Code editor selected and create new settings file > tsconfig.json 1`] = `
 "{
+	"$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -106,8 +107,7 @@ exports[`Setup CLI > should add LSP with VS Code editor selected and create new 
 		"name": "@effect/language-service"
 	}
 ]
-  },
-"$schema": "./node_modules/@effect/tsgo/schema.json"
+  }
 }"
 `;
 
@@ -126,7 +126,7 @@ exports[`Setup CLI > should add LSP with custom diagnostic severities when no pl
 
 exports[`Setup CLI > should add LSP with custom diagnostic severities when no plugin exists > messages 1`] = `
 [
-  "Run \`effect-tsgo patch\` to complete the installation.",
+  "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
 
@@ -141,6 +141,7 @@ exports[`Setup CLI > should add LSP with custom diagnostic severities when no pl
 
 exports[`Setup CLI > should add LSP with custom diagnostic severities when no plugin exists > tsconfig.json 1`] = `
 "{
+	"$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -153,8 +154,7 @@ exports[`Setup CLI > should add LSP with custom diagnostic severities when no pl
 		}
 	}
 ]
-  },
-"$schema": "./node_modules/@effect/tsgo/schema.json"
+  }
 }"
 `;
 
@@ -173,7 +173,7 @@ exports[`Setup CLI > should add custom diagnostic severities when plugin exists 
 
 exports[`Setup CLI > should add custom diagnostic severities when plugin exists without custom values > messages 1`] = `
 [
-  "Run \`effect-tsgo patch\` to complete the installation.",
+  "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
 
@@ -191,6 +191,7 @@ exports[`Setup CLI > should add custom diagnostic severities when plugin exists 
 
 exports[`Setup CLI > should add custom diagnostic severities when plugin exists without custom values > tsconfig.json 1`] = `
 "{
+	"$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -203,8 +204,7 @@ exports[`Setup CLI > should add custom diagnostic severities when plugin exists 
 }
       }
     ]
-  },
-"$schema": "./node_modules/@effect/tsgo/schema.json"
+  }
 }"
 `;
 
@@ -223,14 +223,14 @@ exports[`Setup CLI > should generate changes for Astro-style configs using the l
 
 exports[`Setup CLI > should generate changes for Astro-style configs using the legacy prepare command > messages 1`] = `
 [
-  "Run \`effect-tsgo patch\` to complete the installation.",
+  "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
 
 exports[`Setup CLI > should generate changes for Astro-style configs using the legacy prepare command > package.json 1`] = `
 "{
   "scripts": {
-    "prepare": "effect-language-service patch && effect-tsgo patch",
+    "prepare": "effect-language-service patch && effect-tsgo patch --typescript --no-oxlint",
     "dev": "astro dev"
   },
   "dependencies": {},
@@ -244,6 +244,7 @@ exports[`Setup CLI > should generate changes for Astro-style configs using the l
 
 exports[`Setup CLI > should generate changes for Astro-style configs using the legacy prepare command > tsconfig.json 1`] = `
 "{
+	"$schema": "./node_modules/@effect/tsgo/schema.json",
   "extends": "astro/tsconfigs/strictest",
   "include": [
     ".astro/types.d.ts",
@@ -270,8 +271,7 @@ exports[`Setup CLI > should generate changes for Astro-style configs using the l
         ]
       }
     ]
-  },
-"$schema": "./node_modules/@effect/tsgo/schema.json"
+  }
 }"
 `;
 
@@ -290,7 +290,7 @@ exports[`Setup CLI > should generate changes for adding LSP with defaults > chan
 
 exports[`Setup CLI > should generate changes for adding LSP with defaults > messages 1`] = `
 [
-  "Run \`effect-tsgo patch\` to complete the installation.",
+  "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
 
@@ -305,6 +305,7 @@ exports[`Setup CLI > should generate changes for adding LSP with defaults > pack
 
 exports[`Setup CLI > should generate changes for adding LSP with defaults > tsconfig.json 1`] = `
 "{
+	"$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -313,8 +314,7 @@ exports[`Setup CLI > should generate changes for adding LSP with defaults > tsco
 		"name": "@effect/language-service"
 	}
 ]
-  },
-"$schema": "./node_modules/@effect/tsgo/schema.json"
+  }
 }"
 `;
 
@@ -333,7 +333,7 @@ exports[`Setup CLI > should generate changes for adding LSP with prepare script 
 
 exports[`Setup CLI > should generate changes for adding LSP with prepare script > messages 1`] = `
 [
-  "Run \`effect-tsgo patch\` to complete the installation.",
+  "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
 
@@ -342,13 +342,14 @@ exports[`Setup CLI > should generate changes for adding LSP with prepare script 
   "name": "test-project",
   "version": "1.0.0",
   "dependencies": {},
-"scripts": { "prepare": "effect-tsgo patch" },
+"scripts": { "prepare": "effect-tsgo patch --typescript --no-oxlint" },
 "devDependencies": { "@effect/tsgo": "^0.0.5","typescript": "7.1.0-dev.test" }
 }"
 `;
 
 exports[`Setup CLI > should generate changes for adding LSP with prepare script > tsconfig.json 1`] = `
 "{
+	"$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -357,8 +358,7 @@ exports[`Setup CLI > should generate changes for adding LSP with prepare script 
 		"name": "@effect/language-service"
 	}
 ]
-  },
-"$schema": "./node_modules/@effect/tsgo/schema.json"
+  }
 }"
 `;
 
@@ -377,7 +377,7 @@ exports[`Setup CLI > should generate changes for removing LSP and prepare script
 
 exports[`Setup CLI > should generate changes for removing LSP and prepare script > messages 1`] = `
 [
-  "Run \`effect-tsgo unpatch\` to restore the original TypeScript-Go binary.",
+  "Run \`effect-tsgo unpatch --typescript --no-oxlint\` to restore the original integrations.",
 ]
 `;
 
@@ -419,7 +419,7 @@ exports[`Setup CLI > should generate changes for removing LSP when already insta
 
 exports[`Setup CLI > should generate changes for removing LSP when already installed > messages 1`] = `
 [
-  "Run \`effect-tsgo unpatch\` to restore the original TypeScript-Go binary.",
+  "Run \`effect-tsgo unpatch --typescript --no-oxlint\` to restore the original integrations.",
 ]
 `;
 
@@ -460,7 +460,7 @@ exports[`Setup CLI > should not override existing plugins when adding LSP plugin
 
 exports[`Setup CLI > should not override existing plugins when adding LSP plugin > messages 1`] = `
 [
-  "Run \`effect-tsgo patch\` to complete the installation.",
+  "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
 
@@ -475,6 +475,7 @@ exports[`Setup CLI > should not override existing plugins when adding LSP plugin
 
 exports[`Setup CLI > should not override existing plugins when adding LSP plugin > tsconfig.json 1`] = `
 "{
+	"$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -492,8 +493,7 @@ exports[`Setup CLI > should not override existing plugins when adding LSP plugin
 	"name": "@effect/language-service"
 }
     ]
-  },
-"$schema": "./node_modules/@effect/tsgo/schema.json"
+  }
 }"
 `;
 
@@ -540,7 +540,7 @@ exports[`Setup CLI > should preserve all existing VS Code settings from a real r
 
 exports[`Setup CLI > should preserve all existing VS Code settings from a real repository config > messages 1`] = `
 [
-  "Run \`effect-tsgo patch\` to complete the installation.",
+  "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
   "",
   "VS Code / Cursor / VS Code-based editors:",
   "  1. Install the TypeScript 7 extension",
@@ -561,6 +561,7 @@ exports[`Setup CLI > should preserve all existing VS Code settings from a real r
 
 exports[`Setup CLI > should preserve all existing VS Code settings from a real repository config > tsconfig.json 1`] = `
 "{
+	"$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -569,8 +570,7 @@ exports[`Setup CLI > should preserve all existing VS Code settings from a real r
 		"name": "@effect/language-service"
 	}
 ]
-  },
-"$schema": "./node_modules/@effect/tsgo/schema.json"
+  }
 }"
 `;
 
@@ -605,7 +605,7 @@ exports[`Setup CLI > should preserve existing VS Code settings when adding LSP-s
 
 exports[`Setup CLI > should preserve existing VS Code settings when adding LSP-specific settings > messages 1`] = `
 [
-  "Run \`effect-tsgo patch\` to complete the installation.",
+  "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
   "",
   "VS Code / Cursor / VS Code-based editors:",
   "  1. Install the TypeScript 7 extension",
@@ -626,6 +626,7 @@ exports[`Setup CLI > should preserve existing VS Code settings when adding LSP-s
 
 exports[`Setup CLI > should preserve existing VS Code settings when adding LSP-specific settings > tsconfig.json 1`] = `
 "{
+	"$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -634,8 +635,7 @@ exports[`Setup CLI > should preserve existing VS Code settings when adding LSP-s
 		"name": "@effect/language-service"
 	}
 ]
-  },
-"$schema": "./node_modules/@effect/tsgo/schema.json"
+  }
 }"
 `;
 
@@ -654,8 +654,7 @@ exports[`Setup CLI > should remove only LSP patch command from prepare script wi
 
 exports[`Setup CLI > should remove only LSP patch command from prepare script with multiple commands > messages 1`] = `
 [
-  "WARNING: Your prepare script contained multiple commands. I attempted to automatically remove only the 'effect-tsgo patch' command. Please verify that the prepare script is correct after this change.",
-  "Run \`effect-tsgo unpatch\` to restore the original TypeScript-Go binary.",
+  "Run \`effect-tsgo unpatch --typescript --no-oxlint\` to restore the original integrations.",
 ]
 `;
 
@@ -699,7 +698,7 @@ exports[`Setup CLI > should remove only LSP plugin while preserving other plugin
 
 exports[`Setup CLI > should remove only LSP plugin while preserving other plugins > messages 1`] = `
 [
-  "Run \`effect-tsgo unpatch\` to restore the original TypeScript-Go binary.",
+  "Run \`effect-tsgo unpatch --typescript --no-oxlint\` to restore the original integrations.",
 ]
 `;
 
@@ -743,7 +742,7 @@ exports[`Setup CLI > should replace existing tsconfig schema when adding LSP > c
 
 exports[`Setup CLI > should replace existing tsconfig schema when adding LSP > messages 1`] = `
 [
-  "Run \`effect-tsgo patch\` to complete the installation.",
+  "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
 
@@ -786,7 +785,7 @@ exports[`Setup CLI > should update LSP version when already installed with older
 
 exports[`Setup CLI > should update LSP version when already installed with older version > messages 1`] = `
 [
-  "Run \`effect-tsgo patch\` to complete the installation.",
+  "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
 
@@ -804,6 +803,7 @@ exports[`Setup CLI > should update LSP version when already installed with older
 
 exports[`Setup CLI > should update LSP version when already installed with older version > tsconfig.json 1`] = `
 "{
+	"$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -812,8 +812,7 @@ exports[`Setup CLI > should update LSP version when already installed with older
         "name": "@effect/language-service"
       }
     ]
-  },
-"$schema": "./node_modules/@effect/tsgo/schema.json"
+  }
 }"
 `;
 
@@ -832,7 +831,7 @@ exports[`Setup CLI > should update custom diagnostic severities when plugin alre
 
 exports[`Setup CLI > should update custom diagnostic severities when plugin already has custom values > messages 1`] = `
 [
-  "Run \`effect-tsgo patch\` to complete the installation.",
+  "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
 
@@ -850,6 +849,7 @@ exports[`Setup CLI > should update custom diagnostic severities when plugin alre
 
 exports[`Setup CLI > should update custom diagnostic severities when plugin already has custom values > tsconfig.json 1`] = `
 "{
+	"$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -863,7 +863,6 @@ exports[`Setup CLI > should update custom diagnostic severities when plugin alre
 				}
       }
     ]
-  },
-"$schema": "./node_modules/@effect/tsgo/schema.json"
+  }
 }"
 `;

--- a/_packages/tsgo/test/setup/changes.test.ts
+++ b/_packages/tsgo/test/setup/changes.test.ts
@@ -7,6 +7,17 @@ import type { Assessment } from "../../src/cli/setup/types.js"
 const TEST_TYPESCRIPT_VERSION = "7.1.0-dev.test"
 const TEST_SCHEMA_PATH = "./node_modules/@effect/tsgo/schema.json"
 
+const applyTextChanges = (
+  text: string,
+  changes: ReadonlyArray<{ span: { start: number; length: number }; newText: string }>
+) => [...changes]
+  .sort((left, right) => right.span.start - left.span.start)
+  .reduce(
+    (result, change) =>
+      result.slice(0, change.span.start) + change.newText + result.slice(change.span.start + change.span.length),
+    text
+  )
+
 /**
  * Helper to create an Assessment.Input and run assess() + computeChanges()
  */
@@ -17,6 +28,9 @@ function runComputeChanges(opts: {
   editors?: ReadonlyArray<"vscode" | "nvim" | "emacs">
   lspVersion?: { dependencyType: "dependencies" | "devDependencies"; version: string } | null
   typescriptVersion?: { dependencyType: "dependencies" | "devDependencies"; version: string; packageName?: string } | null
+  oxlintVersion?: { dependencyType: "dependencies" | "devDependencies"; version: string } | null
+  oxlintTsgolintVersion?: { dependencyType: "dependencies" | "devDependencies"; version: string } | null
+  integrations?: ReadonlyArray<"typescript" | "oxlint">
   prepareScript?: boolean
   vscodeTargetSettings?: Record<string, unknown> | null
   diagnosticSeverities?: Record<string, "off" | "suggestion" | "message" | "warning" | "error"> | null
@@ -68,7 +82,15 @@ function runComputeChanges(opts: {
     packageJson: {
       lspVersion,
       typescriptVersion,
-      prepareScript: opts.prepareScript ?? true
+      oxlintVersion: opts.oxlintVersion === undefined
+        ? assessment.packageJson.oxlintVersion
+        : opts.oxlintVersion === null ? Option.none() : Option.some(opts.oxlintVersion),
+      oxlintTsgolintVersion: opts.oxlintTsgolintVersion === undefined
+        ? assessment.packageJson.oxlintTsgolintVersion
+        : opts.oxlintTsgolintVersion === null ? Option.none() : Option.some(opts.oxlintTsgolintVersion),
+      prepareScript: opts.prepareScript ?? true,
+      managePrepareScript: true,
+      integrations: opts.integrations ?? (Option.isSome(lspVersion) ? ["typescript" as const] : [])
     },
     tsconfig: {
       schemaPath: Option.match(lspVersion, {
@@ -79,7 +101,8 @@ function runComputeChanges(opts: {
         ? Option.none()
         : opts.diagnosticSeverities === null
         ? Option.none()
-        : Option.some(opts.diagnosticSeverities)
+        : Option.some(opts.diagnosticSeverities),
+      manageIntegration: true
     },
     vscodeSettings: vscodeTargetSettings,
     editors: opts.editors ?? ["vscode"]
@@ -198,6 +221,125 @@ describe("computeChanges", () => {
       version: "npm:typescript@^7.0.2",
       packageName: "@typescript/native"
     }))
+  })
+
+  it("should assess Oxlint dependencies independently", () => {
+    const assessment = assess({
+      packageJson: {
+        fileName: "/test/package.json",
+        text: JSON.stringify({
+          dependencies: { oxlint: "^1.0.0" },
+          devDependencies: { "oxlint-tsgolint": "^7.0.0" }
+        })
+      },
+      tsconfig: { fileName: "/test/tsconfig.json", text: "{}" },
+      vscodeSettings: Option.none()
+    })
+
+    expect(assessment.packageJson.oxlintVersion).toEqual(Option.some({
+      dependencyType: "dependencies",
+      version: "^1.0.0"
+    }))
+    expect(assessment.packageJson.oxlintTsgolintVersion).toEqual(Option.some({
+      dependencyType: "devDependencies",
+      version: "^7.0.0"
+    }))
+  })
+
+  it("should pin both Oxlint dependencies when enabling the integration", () => {
+    const result = runComputeChanges({
+      integrations: ["oxlint"],
+      typescriptVersion: null,
+      oxlintVersion: { dependencyType: "devDependencies", version: "1.77.0" },
+      oxlintTsgolintVersion: { dependencyType: "devDependencies", version: "7.0.2001" }
+    })
+    const packageJsonChange = result.codeActions
+      .flatMap((action) => action.changes)
+      .find((change) => change.fileName === "/test/package.json")
+    const insertedText = packageJsonChange?.textChanges.map((change) => change.newText).join("\n") ?? ""
+
+    expect(insertedText).toContain('"oxlint": "1.77.0"')
+    expect(insertedText).toContain('"oxlint-tsgolint": "7.0.2001"')
+    expect(insertedText).toContain("effect-tsgo patch --no-typescript --oxlint")
+  })
+
+  it("should remove TypeScript configuration for an Oxlint-only setup", () => {
+    const result = runComputeChanges({
+      tsconfigText: JSON.stringify({
+        $schema: "./node_modules/@effect/tsgo/schema.json",
+        compilerOptions: {
+          plugins: [{ name: "@effect/language-service" }]
+        }
+      }, null, 2),
+      integrations: ["oxlint"],
+      typescriptVersion: null,
+      oxlintVersion: { dependencyType: "devDependencies", version: "1.77.0" },
+      oxlintTsgolintVersion: { dependencyType: "devDependencies", version: "7.0.2001" }
+    })
+    const tsconfigChange = result.codeActions
+      .flatMap((action) => action.changes)
+      .find((change) => change.fileName === "/test/tsconfig.json")
+    const changedText = tsconfigChange?.textChanges.map((change) => change.newText).join("\n") ?? ""
+
+    expect(tsconfigChange).toBeDefined()
+    expect(changedText).not.toContain("@effect/language-service")
+  })
+
+  it("should insert a new $schema as the first tsconfig property", () => {
+    const tsconfigText = JSON.stringify({
+      extends: "./tsconfig.base.json",
+      compilerOptions: { strict: true }
+    }, null, 2)
+    const result = runComputeChanges({ tsconfigText })
+    const tsconfigChange = result.codeActions
+      .flatMap((action) => action.changes)
+      .find((change) => change.fileName === "/test/tsconfig.json")
+
+    expect(tsconfigChange).toBeDefined()
+    const updated = JSON.parse(applyTextChanges(tsconfigText, tsconfigChange!.textChanges))
+    expect(Object.keys(updated)[0]).toBe("$schema")
+  })
+
+  it("should preserve an unrelated tsconfig $schema when disabling TypeScript", () => {
+    const result = runComputeChanges({
+      tsconfigText: JSON.stringify({
+        $schema: "https://json.schemastore.org/tsconfig",
+        compilerOptions: {
+          plugins: [{ name: "@effect/language-service" }]
+        }
+      }, null, 2),
+      lspVersion: null,
+      integrations: []
+    })
+    const tsconfigChange = result.codeActions
+      .flatMap((action) => action.changes)
+      .find((change) => change.fileName === "/test/tsconfig.json")
+
+    expect(tsconfigChange).toBeDefined()
+    expect(applyTextChanges(JSON.stringify({
+      $schema: "https://json.schemastore.org/tsconfig",
+      compilerOptions: {
+        plugins: [{ name: "@effect/language-service" }]
+      }
+    }, null, 2), tsconfigChange!.textChanges)).toContain("https://json.schemastore.org/tsconfig")
+  })
+
+  it("should remove the Effect schema when compilerOptions is missing", () => {
+    const tsconfigText = JSON.stringify({
+      $schema: TEST_SCHEMA_PATH,
+      extends: "./tsconfig.base.json"
+    }, null, 2)
+    const result = runComputeChanges({
+      tsconfigText,
+      lspVersion: null,
+      integrations: []
+    })
+    const tsconfigChange = result.codeActions
+      .flatMap((action) => action.changes)
+      .find((change) => change.fileName === "/test/tsconfig.json")
+
+    expect(tsconfigChange).toBeDefined()
+    expect(applyTextChanges(tsconfigText, tsconfigChange!.textChanges)).not.toContain("$schema")
   })
 
   it("should not assess typescript < 7 as the native backend", () => {
@@ -489,7 +631,7 @@ describe("computeChanges", () => {
       const result = runComputeChanges({})
 
       expect(result.messages).toContain(
-        "Run `effect-tsgo patch` to complete the installation."
+        "Run `effect-tsgo patch --typescript --no-oxlint` to complete the installation."
       )
     })
 
@@ -510,7 +652,7 @@ describe("computeChanges", () => {
       })
 
       expect(result.messages).toContain(
-        "Run `effect-tsgo unpatch` to restore the original TypeScript-Go binary."
+        "Run `effect-tsgo unpatch --typescript --no-oxlint` to restore the original integrations."
       )
     })
 

--- a/_packages/tsgo/test/setup/diff-renderer.test.ts
+++ b/_packages/tsgo/test/setup/diff-renderer.test.ts
@@ -82,6 +82,8 @@ function makeAssessmentState(opts?: {
       text: pkgJsonText,
       lspVersion: Option.none(),
       typescriptVersion: Option.none(),
+      oxlintVersion: Option.none(),
+      oxlintTsgolintVersion: Option.none(),
       prepareScript: Option.none()
     },
     tsconfig: {

--- a/_packages/tsgo/test/setup/patch-command.test.ts
+++ b/_packages/tsgo/test/setup/patch-command.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+import { getPatchIntegrations, hasPatchCommand, updatePatchCommand } from "../../src/cli/setup/patch-command.js"
+
+describe("setup patch command", () => {
+  it.each([
+    [["typescript"] as const, "effect-tsgo patch --typescript --no-oxlint"],
+    [["oxlint"] as const, "effect-tsgo patch --no-typescript --oxlint"],
+    [["typescript", "oxlint"] as const, "effect-tsgo patch --typescript --oxlint"]
+  ])("updates integration flags for %j", (integrations, expected) => {
+    expect(updatePatchCommand("effect-tsgo patch --oxlint", integrations)).toEqual({
+      script: expected,
+      found: true
+    })
+  })
+
+  it("preserves wrappers, unrelated commands, and unrelated flags", () => {
+    expect(updatePatchCommand(
+      "husky && pnpm exec effect-tsgo patch --oxlint --force && echo ready",
+      ["typescript"]
+    )).toEqual({
+      script: "husky && pnpm exec effect-tsgo patch --typescript --no-oxlint --force && echo ready",
+      found: true
+    })
+  })
+
+  it("removes only the patch invocation from a command list", () => {
+    expect(updatePatchCommand("husky && effect-tsgo patch --typescript --oxlint", [])).toEqual({
+      script: "husky",
+      found: true
+    })
+  })
+
+  it("preserves command order when removing from the middle of a list", () => {
+    expect(updatePatchCommand("lint; effect-tsgo patch --oxlint && build", [])).toEqual({
+      script: "lint; build",
+      found: true
+    })
+  })
+
+  it("refuses to remove commands from ambiguous control flow", () => {
+    const script = "lint && effect-tsgo patch --oxlint || recover"
+    expect(updatePatchCommand(script, [])).toEqual({ script, found: false })
+  })
+
+  it("does not treat command arguments as an invocation", () => {
+    expect(hasPatchCommand("echo effect-tsgo patch && echo done")).toBe(false)
+  })
+
+  it("detects explicit and default integrations", () => {
+    expect(getPatchIntegrations("effect-tsgo patch")).toEqual(["typescript"])
+    expect(getPatchIntegrations("effect-tsgo patch --no-typescript --oxlint")).toEqual(["oxlint"])
+  })
+})

--- a/_packages/tsgo/test/setup/setup-cli.test.ts
+++ b/_packages/tsgo/test/setup/setup-cli.test.ts
@@ -56,10 +56,17 @@ function applyTextChanges(
 function expectSetupChanges(
   assessmentInput: Assessment.Input,
   targetState: {
-    readonly packageJson: Target.PackageJson
+    readonly packageJson: Omit<
+      Target.PackageJson,
+      "oxlintVersion" | "oxlintTsgolintVersion" | "managePrepareScript" | "integrations"
+    > & Partial<Pick<
+      Target.PackageJson,
+      "oxlintVersion" | "oxlintTsgolintVersion" | "managePrepareScript" | "integrations"
+    >>
     readonly tsconfig: {
       readonly schemaPath?: Option.Option<string>
       readonly diagnosticSeverities: Option.Option<Record<string, string>>
+      readonly manageIntegration?: boolean
     }
     readonly vscodeSettings: Option.Option<Target.VSCodeSettings>
     readonly editors: ReadonlyArray<string>
@@ -67,6 +74,14 @@ function expectSetupChanges(
 ) {
   const normalizedTargetState: Target.State = {
     ...targetState,
+    packageJson: {
+      ...targetState.packageJson,
+      oxlintVersion: targetState.packageJson.oxlintVersion ?? Option.none(),
+      oxlintTsgolintVersion: targetState.packageJson.oxlintTsgolintVersion ?? Option.none(),
+      managePrepareScript: targetState.packageJson.managePrepareScript ?? true,
+      integrations: targetState.packageJson.integrations ??
+        (Option.isSome(targetState.packageJson.lspVersion) ? ["typescript"] : [])
+    },
     editors: targetState.editors.filter((editor): editor is Editor =>
       editor === "vscode" || editor === "nvim" || editor === "emacs"
     ),
@@ -76,7 +91,8 @@ function expectSetupChanges(
         onNone: () => Option.none(),
         onSome: () => Option.some(TEST_SCHEMA_PATH)
       }),
-      diagnosticSeverities: targetState.tsconfig.diagnosticSeverities as Target.TsConfig["diagnosticSeverities"]
+      diagnosticSeverities: targetState.tsconfig.diagnosticSeverities as Target.TsConfig["diagnosticSeverities"],
+      manageIntegration: targetState.tsconfig.manageIntegration ?? true
     }
   }
 


### PR DESCRIPTION
## Summary

- assess existing `oxlint` and `oxlint-tsgolint` dependencies and preselect the Oxlint setup option when detected
- let users configure TypeScript, Oxlint, both, or neither while pinning selected Oxlint packages to supported upstream versions
- generate explicit integration flags in prepare scripts and preserve unrelated compound-script commands when they can be rewritten safely
- insert new tsconfig `$schema` entries first, update existing entries in place, and only remove Effect-owned schemas

## Generated commands

- TypeScript: `effect-tsgo patch --typescript --no-oxlint`
- Oxlint: `effect-tsgo patch --no-typescript --oxlint`
- Both: `effect-tsgo patch --typescript --oxlint`

## Testing

- Not rerun during PR preparation, per request.