### PR TITLE
ci: split Oxlint release builds

### DIFF
--- a/.changeset/split-oxlint-release-builds.md
+++ b/.changeset/split-oxlint-release-builds.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": minor
+---
+
+Split release builds for TSC, tsgolint, and the Oxlint native binding so Go artifacts can be cross-compiled on Linux independently of the platform-specific Rust builds.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,11 +78,11 @@ jobs:
           github-token: ${{ github.token }}
           script: pnpm exec repoctl changeset version
 
-  build:
-    name: Build ${{ matrix.profile }} ${{ matrix.npm_target }}
+  build-tsc:
+    name: Build TSC ${{ matrix.profile }} ${{ matrix.npm_target }}
     needs: select-mode
     if: needs.select-mode.outputs.mode == 'publish'
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
       contents: read
@@ -103,31 +103,106 @@ jobs:
         profile:
           - next
           - latest
-        os:
-          - ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Setup ${{ matrix.profile }} repo
+        uses: ./.github/actions/setup-repo
+        with:
+          profile: ${{ matrix.profile }}
+
+      - name: Build TSC ${{ matrix.profile }} ${{ matrix.npm_target }}
+        id: tsc
+        run: pnpm exec repoctl build tsc --profile ${{ matrix.profile }} --target ${{ matrix.npm_target }}
+
+      - name: Upload TSC artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.npm_target }}__${{ matrix.profile }}
+          path: ${{ steps.tsc.outputs.binary_path }}
+          if-no-files-found: error
+
+  build-tsgolint:
+    name: Build tsgolint ${{ matrix.npm_target }}
+    needs: select-mode
+    if: needs.select-mode.outputs.mode == 'publish'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: true
+      matrix:
+        npm_target:
+          - darwin-arm64
+          - darwin-x64
+          - win32-x64
+          - win32-arm64
+          - linux-x64
+          - linux-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Setup Oxlint repo
+        uses: ./.github/actions/setup-repo
+        with:
+          profile: oxlint
+
+      - name: Build tsgolint ${{ matrix.npm_target }}
+        id: tsgolint
+        run: pnpm exec repoctl build tsgolint --target ${{ matrix.npm_target }}
+
+      - name: Upload tsgolint artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.npm_target }}__tsgolint
+          path: ${{ steps.tsgolint.outputs.artifact_path }}
+          if-no-files-found: error
+
+  build-oxlint-binding:
+    name: Build Oxlint binding ${{ matrix.npm_target }}
+    needs: select-mode
+    if: needs.select-mode.outputs.mode == 'publish'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: true
+      matrix:
         include:
-          - profile: oxlint
-            npm_target: darwin-arm64
+          - npm_target: darwin-arm64
             os: macos-latest
             rust_target: aarch64-apple-darwin
-          - profile: oxlint
-            npm_target: darwin-x64
+          - npm_target: darwin-x64
             os: macos-latest
             rust_target: x86_64-apple-darwin
-          - profile: oxlint
-            npm_target: win32-x64
+          - npm_target: win32-x64
             os: windows-latest
             rust_target: x86_64-pc-windows-msvc
-          - profile: oxlint
-            npm_target: win32-arm64
+          - npm_target: win32-arm64
             os: windows-latest
             rust_target: aarch64-pc-windows-msvc
-          - profile: oxlint
-            npm_target: linux-x64
+          - npm_target: linux-x64
             os: ubuntu-latest
             rust_target: x86_64-unknown-linux-gnu
-          - profile: oxlint
-            npm_target: linux-arm64
+          - npm_target: linux-arm64
             os: ubuntu-latest
             rust_target: aarch64-unknown-linux-gnu
     steps:
@@ -142,34 +217,28 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - name: Setup ${{ matrix.profile }} repo
+      - name: Setup Oxlint repo
         uses: ./.github/actions/setup-repo
         with:
-          profile: ${{ matrix.profile }}
+          profile: oxlint
           rust-target: ${{ matrix.rust_target }}
 
-      - name: Build tsc ${{ matrix.profile }} ${{ matrix.npm_target }}
-        if: matrix.profile != 'oxlint'
-        id: binary
-        run: pnpm exec repoctl build binary --profile ${{ matrix.profile }} --target ${{ matrix.npm_target }}
-
-      - name: Build oxlint ${{ matrix.npm_target }}
-        if: matrix.profile == 'oxlint'
-        id: oxlint
+      - name: Build Oxlint binding ${{ matrix.npm_target }}
+        id: oxlint_binding
         env:
           TARGET_CC: clang
-        run: pnpm exec repoctl build oxlint --target ${{ matrix.npm_target }}
+        run: pnpm exec repoctl build oxlint-binding --target ${{ matrix.npm_target }}
 
-      - name: Upload artifact
+      - name: Upload Oxlint binding artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.npm_target }}__${{ matrix.profile }}
-          path: ${{ matrix.profile == 'oxlint' && steps.oxlint.outputs.artifact_path || steps.binary.outputs.binary_path }}
+          name: ${{ matrix.npm_target }}__oxlint-binding
+          path: ${{ steps.oxlint_binding.outputs.artifact_path }}
           if-no-files-found: error
 
   pack:
     name: Pack Packages
-    needs: [select-mode, build]
+    needs: [select-mode, build-tsc, build-tsgolint, build-oxlint-binding]
     if: needs.select-mode.outputs.mode == 'publish'
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/validate-oxlint-profile.yml
+++ b/.github/workflows/validate-oxlint-profile.yml
@@ -33,8 +33,11 @@ jobs:
           profile: oxlint
           rust-target: x86_64-unknown-linux-gnu
 
-      - name: Build Oxlint profile
-        run: pnpm exec repoctl build oxlint --target linux-x64
+      - name: Build tsgolint
+        run: pnpm exec repoctl build tsgolint --target linux-x64
+
+      - name: Build Oxlint binding
+        run: pnpm exec repoctl build oxlint-binding --target linux-x64
 
       - name: Smoke test Oxlint profile
         run: node testdata/tests/oxlint/smoke.mjs "$GITHUB_WORKSPACE"

--- a/_tools/repoctl/src/build.ts
+++ b/_tools/repoctl/src/build.ts
@@ -146,30 +146,16 @@ export const buildLocal = Effect.fnUntraced(function*(repositoryRoot: string) {
   yield* buildCli(repositoryRoot)
 })
 
-export const buildOxlint = Effect.fnUntraced(function*(repositoryRoot: string, targetName: OxlintBuildTarget) {
+export const buildTsgolint = Effect.fnUntraced(function*(repositoryRoot: string, targetName: OxlintBuildTarget) {
   const fs = yield* FileSystem.FileSystem
   const path = yield* Path.Path
   const tsgolintSource = path.join(repositoryRoot, "tsgolint", "cmd", "tsgolint", "effect_rules_generated.go")
-  const oxlintSource = path.join(
-    repositoryRoot,
-    "oxlint",
-    "crates",
-    "oxc_linter",
-    "src",
-    "rules",
-    "effecttsgo",
-    "floating_effect.rs"
-  )
-  for (const generated of [tsgolintSource, oxlintSource]) {
-    if (!(yield* fs.exists(generated))) {
-      return yield* new BuildError({ reason: `Missing generated source ${generated}; run profile codegen first` })
-    }
+  if (!(yield* fs.exists(tsgolintSource))) {
+    return yield* new BuildError({ reason: `Missing generated source ${tsgolintSource}; run profile codegen first` })
   }
 
   const target = oxlintBuildTargets[targetName]
   const artifacts = oxlintArtifacts(repositoryRoot, targetName)
-  const oxlint = path.join(repositoryRoot, "oxlint")
-  const oxlintApp = path.join(oxlint, "apps", "oxlint")
   yield* fs.makeDirectory(artifacts.packageDirectory, { recursive: true })
   yield* Console.log(`Building tsgolint for ${targetName}`)
   yield* runCommand("go", repositoryRoot, [
@@ -187,6 +173,37 @@ export const buildOxlint = Effect.fnUntraced(function*(repositoryRoot: string, t
   })
   yield* validateArtifact(artifacts.tsgolintPath)
 
+  if (process.env.GITHUB_OUTPUT !== undefined) {
+    yield* Effect.tryPromise(() => appendFile(
+      process.env.GITHUB_OUTPUT!,
+      `artifact_path=${artifacts.tsgolintPath}\n`
+    ))
+  }
+  return artifacts.tsgolintPath
+})
+
+export const buildOxlintBinding = Effect.fnUntraced(function*(repositoryRoot: string, targetName: OxlintBuildTarget) {
+  const fs = yield* FileSystem.FileSystem
+  const path = yield* Path.Path
+  const oxlintSource = path.join(
+    repositoryRoot,
+    "oxlint",
+    "crates",
+    "oxc_linter",
+    "src",
+    "rules",
+    "effecttsgo",
+    "floating_effect.rs"
+  )
+  if (!(yield* fs.exists(oxlintSource))) {
+    return yield* new BuildError({ reason: `Missing generated source ${oxlintSource}; run profile codegen first` })
+  }
+
+  const target = oxlintBuildTargets[targetName]
+  const artifacts = oxlintArtifacts(repositoryRoot, targetName)
+  const oxlint = path.join(repositoryRoot, "oxlint")
+  const oxlintApp = path.join(oxlint, "apps", "oxlint")
+  yield* fs.makeDirectory(artifacts.packageDirectory, { recursive: true })
   yield* Console.log(`Building Oxlint N-API addon for ${targetName}`)
   yield* runCommand("corepack", oxlint, ["pnpm", "install", "--frozen-lockfile"])
   yield* runCommand("corepack", oxlintApp, [
@@ -207,13 +224,13 @@ export const buildOxlint = Effect.fnUntraced(function*(repositoryRoot: string, t
   if (process.env.GITHUB_OUTPUT !== undefined) {
     yield* Effect.tryPromise(() => appendFile(
       process.env.GITHUB_OUTPUT!,
-      `artifact_path=${artifacts.packageDirectory}\n`
+      `artifact_path=${artifacts.bindingPath}\n`
     ))
   }
-  return artifacts
+  return artifacts.bindingPath
 })
 
-export const buildBinary = Effect.fnUntraced(function*(
+export const buildTsc = Effect.fnUntraced(function*(
   repositoryRoot: string,
   profileName: BuildProfile,
   targetName: BuildTarget

--- a/_tools/repoctl/src/main.ts
+++ b/_tools/repoctl/src/main.ts
@@ -8,7 +8,7 @@ import * as Command from "effect/unstable/cli/Command"
 import * as Flag from "effect/unstable/cli/Flag"
 import * as Option from "effect/Option"
 import { fileURLToPath } from "node:url"
-import { buildBinary, buildCli, buildLocal, buildOxlint, verifyReleaseArtifacts } from "./build.ts"
+import { buildCli, buildLocal, buildOxlintBinding, buildTsc, buildTsgolint, verifyReleaseArtifacts } from "./build.ts"
 import { runChecks } from "./checks.ts"
 import { addChangeset, publishChangeset, versionChangeset } from "./changesets.ts"
 import {
@@ -82,20 +82,28 @@ const buildCliCommand = Command.make("cli", {}, () => buildCli(repositoryRoot)).
   Command.withDescription("Build the CLI package")
 )
 
-const buildOxlintCommand = Command.make("oxlint", {
-  target: Flag.choice("target", [
-    "darwin-arm64",
-    "darwin-x64",
-    "win32-x64",
-    "win32-arm64",
-    "linux-x64",
-    "linux-arm64"
-  ])
-}, ({ target }) => buildOxlint(repositoryRoot, target)).pipe(
-  Command.withDescription("Build packaged tsgolint and Oxlint N-API artifacts")
+const oxlintTargets = [
+  "darwin-arm64",
+  "darwin-x64",
+  "win32-x64",
+  "win32-arm64",
+  "linux-x64",
+  "linux-arm64"
+] as const
+
+const buildTsgolintCommand = Command.make("tsgolint", {
+  target: Flag.choice("target", oxlintTargets)
+}, ({ target }) => buildTsgolint(repositoryRoot, target)).pipe(
+  Command.withDescription("Cross-compile packaged tsgolint")
 )
 
-const buildBinaryCommand = Command.make("binary", {
+const buildOxlintBindingCommand = Command.make("oxlint-binding", {
+  target: Flag.choice("target", oxlintTargets)
+}, ({ target }) => buildOxlintBinding(repositoryRoot, target)).pipe(
+  Command.withDescription("Build the packaged Oxlint N-API binding")
+)
+
+const buildTscCommand = Command.make("tsc", {
   profile: Flag.choice("profile", ["next", "latest"]),
   target: Flag.choice("target", [
     "darwin-arm64",
@@ -106,8 +114,8 @@ const buildBinaryCommand = Command.make("binary", {
     "linux-arm64",
     "linux-arm"
   ])
-}, ({ profile, target }) => buildBinary(repositoryRoot, profile, target)).pipe(
-  Command.withDescription("Cross-compile a profile binary into its platform package")
+}, ({ profile, target }) => buildTsc(repositoryRoot, profile, target)).pipe(
+  Command.withDescription("Cross-compile a TSC profile into its platform package")
 )
 
 const verifyReleaseBuildCommand = Command.make("verify-release", {}, () => verifyReleaseArtifacts(repositoryRoot)).pipe(
@@ -117,10 +125,11 @@ const verifyReleaseBuildCommand = Command.make("verify-release", {}, () => verif
 const build = Command.make("build").pipe(
   Command.withDescription("Build repository artifacts"),
   Command.withSubcommands([
-    buildBinaryCommand,
     buildCliCommand,
     buildLocalCommand,
-    buildOxlintCommand,
+    buildOxlintBindingCommand,
+    buildTscCommand,
+    buildTsgolintCommand,
     verifyReleaseBuildCommand
   ])
 )


### PR DESCRIPTION
## Summary

- split repoctl release commands into `build tsc`, `build tsgolint`, and `build oxlint-binding`
- cross-compile tsgolint in a dedicated Ubuntu matrix while retaining the shared target-agnostic Oxlint Go cache
- keep Oxlint bindings in their platform-specific Rust matrix and merge the separate artifacts during packaging
- update Oxlint profile validation to exercise both independent build commands

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- Full local tests intentionally not run, per request