### PR TITLE
Add contextual fixes for floating Effects and catchReason

### DIFF
--- a/.changeset/floating-effect-yield-catch-reason.md
+++ b/.changeset/floating-effect-yield-catch-reason.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": minor
+---
+
+Add a `yield*` quick fix for floating Effects in yieldable Effect contexts, and preserve narrowed wrapper error references when converting hand-rolled reason dispatch to `Effect.catchReason` or `Effect.catchReasons`.

--- a/_packages/tsgo/src/metadata.json
+++ b/_packages/tsgo/src/metadata.json
@@ -157,7 +157,7 @@
       "group": "correctness",
       "description": "Detects Effect values that are neither yielded nor assigned",
       "defaultSeverity": "error",
-      "fixable": false,
+      "fixable": true,
       "supportedEffect": [
         "v3",
         "v4"

--- a/docs/rules/floating-effect.md
+++ b/docs/rules/floating-effect.md
@@ -8,7 +8,7 @@ Detects Effect values that are neither yielded nor assigned
 | --- | --- |
 | Category | Correctness |
 | Default severity | `error` |
-| Fixable | No |
+| Fixable | Yes |
 | Effect versions | v3, v4 |
 | Diagnostic codes | `TS377001`, `TS377058` |
 | Language Service name | `floatingEffect` |

--- a/internal/fixables/catch_tag_to_catch_reason.go
+++ b/internal/fixables/catch_tag_to_catch_reason.go
@@ -66,7 +66,7 @@ func buildCatchTagToCatchReasonReplacement(tracker *rewriter.Tracker, match rule
 	arguments := []*ast.Node{tracker.DeepCloneNode(match.OuterTag)}
 	if len(match.Branches) == 1 {
 		branch := match.Branches[0]
-		arguments = append(arguments, tracker.NewStringLiteral(branch.ReasonTag, 0), newCatchReasonHandler(tracker, branch.Result))
+		arguments = append(arguments, tracker.NewStringLiteral(branch.ReasonTag, 0), newCatchReasonHandler(tracker, match.ParameterName, branch))
 	} else {
 		properties := make([]*ast.Node, 0, len(match.Branches))
 		for _, branch := range match.Branches {
@@ -75,7 +75,7 @@ func buildCatchTagToCatchReasonReplacement(tracker *rewriter.Tracker, match rule
 				tracker.NewStringLiteral(branch.ReasonTag, 0),
 				nil,
 				nil,
-				newCatchReasonHandler(tracker, branch.Result),
+				newCatchReasonHandler(tracker, match.ParameterName, branch),
 			))
 		}
 		arguments = append(arguments, tracker.NewObjectLiteralExpression(tracker.NewNodeList(properties), false))
@@ -84,14 +84,21 @@ func buildCatchTagToCatchReasonReplacement(tracker *rewriter.Tracker, match rule
 	return tracker.NewCallExpression(method, nil, nil, tracker.NewNodeList(arguments), ast.NodeFlagsNone)
 }
 
-func newCatchReasonHandler(tracker *rewriter.Tracker, expression *ast.Node) *ast.Node {
+func newCatchReasonHandler(tracker *rewriter.Tracker, parameterName string, branch rules.CatchTagToCatchReasonBranch) *ast.Node {
+	var parameters []*ast.Node
+	if branch.UsesParameter {
+		parameters = []*ast.Node{
+			tracker.NewParameterDeclaration(nil, nil, tracker.NewIdentifier(branch.ReasonParameterName), nil, nil, nil),
+			tracker.NewParameterDeclaration(nil, nil, tracker.NewIdentifier(parameterName), nil, nil, nil),
+		}
+	}
 	return tracker.NewArrowFunction(
 		nil,
 		nil,
-		tracker.NewNodeList([]*ast.Node{}),
+		tracker.NewNodeList(parameters),
 		nil,
 		nil,
 		tracker.NewToken(ast.KindEqualsGreaterThanToken),
-		tracker.DeepCloneNode(expression),
+		tracker.DeepCloneNode(branch.Result),
 	)
 }

--- a/internal/fixables/fixables.go
+++ b/internal/fixables/fixables.go
@@ -11,7 +11,7 @@ var All = []fixable.Fixable{
 	EffectDisable,
 	// Add future fixables here:
 	// POCRuleFix,
-	// FloatingEffectYieldFix,
+	FloatingEffectYieldFix,
 	MissingReturnYieldStarFix,
 	MissingStarInYieldEffectGenFix,
 	CatchAllToMapErrorFix,

--- a/internal/fixables/floating_effect_yield.go
+++ b/internal/fixables/floating_effect_yield.go
@@ -1,0 +1,52 @@
+package fixables
+
+import (
+	"github.com/effect-ts/tsgo/internal/fixable"
+	"github.com/effect-ts/tsgo/internal/rewriter"
+	"github.com/effect-ts/tsgo/internal/rules"
+	"github.com/effect-ts/tsgo/internal/typeparser"
+	"github.com/microsoft/typescript-go/shim/ast"
+	tsdiag "github.com/microsoft/typescript-go/shim/diagnostics"
+	"github.com/microsoft/typescript-go/shim/ls"
+)
+
+// FloatingEffectYieldFix yields a floating Effect when it occurs in an Effect generator.
+var FloatingEffectYieldFix = fixable.Fixable{
+	Name:        "floatingEffectYield",
+	Description: "Add yield* statement",
+	ErrorCodes: []int32{
+		tsdiag.This_Effect_value_is_neither_yielded_nor_used_in_an_assignment_effect_floatingEffect.Code(),
+		tsdiag.This_Effect_able_0_value_is_neither_yielded_nor_assigned_to_a_variable_effect_floatingEffect.Code(),
+	},
+	FixIDs: []string{"floatingEffectYield_fix"},
+	Run:    runFloatingEffectYieldFix,
+}
+
+func runFloatingEffectYieldFix(ctx *fixable.Context) []ls.CodeAction {
+	for _, match := range rules.AnalyzeFloatingEffect(ctx.TypeParser, ctx.Checker, ctx.SourceFile) {
+		if !match.Location.Intersects(ctx.Span) && !ctx.Span.ContainedBy(match.Location) {
+			continue
+		}
+		if ctx.TypeParser.GetEffectContextFlags(match.Expression)&typeparser.EffectContextFlagCanYieldEffect == 0 {
+			return nil
+		}
+		exprType := ctx.TypeParser.GetTypeAtLocation(match.Expression)
+		if ctx.TypeParser.EffectYieldableType(exprType, match.Expression) == nil {
+			return nil
+		}
+
+		if action := ctx.NewFixAction(fixable.FixAction{
+			Description: "Add yield* statement",
+			Run: func(tracker *rewriter.Tracker) {
+				clonedExpr := tracker.DeepCloneNode(match.Expression)
+				yieldExpr := tracker.NewYieldExpression(tracker.NewToken(ast.KindAsteriskToken), clonedExpr)
+				ast.SetParentInChildren(yieldExpr)
+				tracker.ReplaceNode(ctx.SourceFile, match.Expression, yieldExpr, nil)
+			},
+		}); action != nil {
+			return []ls.CodeAction{*action}
+		}
+		return nil
+	}
+	return nil
+}

--- a/internal/rules/catch_tag_to_catch_reason.go
+++ b/internal/rules/catch_tag_to_catch_reason.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"strconv"
+
 	"github.com/effect-ts/tsgo/etscore"
 	"github.com/effect-ts/tsgo/internal/rule"
 	"github.com/effect-ts/tsgo/internal/typeparser"
@@ -31,8 +33,10 @@ var CatchTagToCatchReason = rule.Rule{
 }
 
 type CatchTagToCatchReasonBranch struct {
-	ReasonTag string
-	Result    *ast.Node
+	ReasonTag           string
+	Result              *ast.Node
+	UsesParameter       bool
+	ReasonParameterName string
 }
 
 type CatchTagToCatchReasonMatch struct {
@@ -226,15 +230,21 @@ func analyzeCatchTagToCatchReasonHandler(tp *typeparser.TypeParser, c *checker.C
 		return catchTagToCatchReasonHandler{}, false
 	}
 
-	usesReason, validUses := validateCatchTagParameterUses(tp, c, body, parameterSymbol, branches, fallbackParam, dispatchRefs)
+	branchParameterUses, validUses := validateCatchTagParameterUses(tp, c, body, parameterSymbol, branches, fallbackParam, dispatchRefs)
 	if !validUses {
 		return catchTagToCatchReasonHandler{}, false
+	}
+	for i := range branches {
+		branches[i].UsesParameter = branchParameterUses[i]
+		if branches[i].UsesParameter {
+			branches[i].ReasonParameterName = uniqueCatchReasonParameterName(c, branches[i].Result)
+		}
 	}
 
 	return catchTagToCatchReasonHandler{
 		parameterName: parameter.Name().AsIdentifier().Text,
 		branches:      branches,
-		canFix:        handlerNode.Kind == ast.KindArrowFunction && !usesReason,
+		canFix:        handlerNode.Kind == ast.KindArrowFunction && !checker.Checker_isSymbolAssigned(c, parameterSymbol),
 	}, true
 }
 
@@ -325,7 +335,7 @@ func validateCatchTagParameterUses(
 	branches []CatchTagToCatchReasonBranch,
 	fallbackParam *ast.Node,
 	dispatchRefs map[*ast.Node]struct{},
-) (bool, bool) {
+) ([]bool, bool) {
 	allowed := make(map[*ast.Node]struct{}, len(dispatchRefs)+1)
 	for node := range dispatchRefs {
 		allowed[node] = struct{}{}
@@ -334,7 +344,7 @@ func validateCatchTagParameterUses(
 		allowed[fallbackParam] = struct{}{}
 	}
 
-	usesReason := false
+	branchUses := make([]bool, len(branches))
 	valid := true
 	var walkBody ast.Visitor
 	walkBody = func(node *ast.Node) bool {
@@ -345,8 +355,8 @@ func validateCatchTagParameterUses(
 			if _, ok := allowed[node]; ok {
 				return false
 			}
-			if isCatchReasonRootReference(node) && isCatchReasonRecoveryReference(node, branches) {
-				usesReason = true
+			if branchIndex := catchReasonRecoveryBranchIndex(node, branches); branchIndex >= 0 {
+				branchUses[branchIndex] = true
 				return false
 			}
 			valid = false
@@ -356,25 +366,33 @@ func validateCatchTagParameterUses(
 		return false
 	}
 	walkBody(body)
-	return usesReason, valid
+	return branchUses, valid
 }
 
-func isCatchReasonRecoveryReference(node *ast.Node, branches []CatchTagToCatchReasonBranch) bool {
-	for _, branch := range branches {
+func catchReasonRecoveryBranchIndex(node *ast.Node, branches []CatchTagToCatchReasonBranch) int {
+	for i, branch := range branches {
 		expression := branch.Result
 		if expression != nil && node.Pos() >= expression.Pos() && node.End() <= expression.End() {
-			return true
+			return i
 		}
 	}
-	return false
+	return -1
 }
 
-func isCatchReasonRootReference(node *ast.Node) bool {
-	if node == nil || node.Parent == nil || node.Parent.Kind != ast.KindPropertyAccessExpression {
-		return false
+func uniqueCatchReasonParameterName(c *checker.Checker, location *ast.Node) string {
+	used := make(map[string]struct{})
+	for _, symbol := range c.GetSymbolsInScope(location, ast.SymbolFlagsValue) {
+		used[c.SymbolToString(symbol)] = struct{}{}
 	}
-	access := node.Parent.AsPropertyAccessExpression()
-	return access != nil && access.Expression == node && access.Name() != nil && access.Name().Text() == "reason"
+	for i := -1; ; i++ {
+		name := "_"
+		if i >= 0 {
+			name = "_" + strconv.Itoa(i)
+		}
+		if _, exists := used[name]; !exists {
+			return name
+		}
+	}
 }
 
 func isEffectExpression(tp *typeparser.TypeParser, expression *ast.Node) bool {

--- a/internal/rules/floating_effect.go
+++ b/internal/rules/floating_effect.go
@@ -7,7 +7,9 @@ import (
 	"github.com/effect-ts/tsgo/internal/typeparser"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
 	tsdiag "github.com/microsoft/typescript-go/shim/diagnostics"
+	"github.com/microsoft/typescript-go/shim/scanner"
 )
 
 // floatingEffectResult holds information about a detected floating Effect expression.
@@ -31,46 +33,55 @@ var FloatingEffect = rule.Rule{
 		tsdiag.This_Effect_able_0_value_is_neither_yielded_nor_assigned_to_a_variable_effect_floatingEffect.Code(),
 	},
 	Run: func(ctx *rule.Context) []*ast.Diagnostic {
-		var diags []*ast.Diagnostic
-
-		// Walk the entire AST using ForEachChild
-		var walk ast.Visitor
-		walk = func(n *ast.Node) bool {
-			if n == nil {
-				return false
+		matches := AnalyzeFloatingEffect(ctx.TypeParser, ctx.Checker, ctx.SourceFile)
+		diags := make([]*ast.Diagnostic, len(matches))
+		for i, match := range matches {
+			if match.isStrict {
+				diags[i] = ctx.NewDiagnostic(match.SourceFile, match.Location, tsdiag.This_Effect_value_is_neither_yielded_nor_used_in_an_assignment_effect_floatingEffect, nil)
+			} else {
+				typeName := ctx.Checker.TypeToString(match.exprType)
+				diags[i] = ctx.NewDiagnostic(match.SourceFile, match.Location, tsdiag.This_Effect_able_0_value_is_neither_yielded_nor_assigned_to_a_variable_effect_floatingEffect, nil, typeName)
 			}
+		}
+		return diags
+	},
+}
 
-			// Check if this node is a floating Effect expression statement
-			if result := detectFloatingEffect(ctx.TypeParser, ctx.Checker, n); result != nil {
-				// Use the expression's position if this is an expression statement
-				// to avoid including leading trivia in the span
-				expr := n
-				if n.Kind == ast.KindExpressionStatement {
-					exprStmt := n.AsExpressionStatement()
-					if exprStmt != nil && exprStmt.Expression != nil {
-						expr = exprStmt.Expression
-					}
-				}
+// FloatingEffectMatch holds the diagnostic location and expression needed by
+// both the diagnostic rule and its quick-fix.
+type FloatingEffectMatch struct {
+	SourceFile *ast.SourceFile
+	Location   core.TextRange
+	Expression *ast.Node
+	isStrict   bool
+	exprType   *checker.Type
+}
 
-				var diag *ast.Diagnostic
-				if result.isStrict {
-					diag = ctx.NewDiagnostic(ctx.SourceFile, ctx.GetErrorRange(expr), tsdiag.This_Effect_value_is_neither_yielded_nor_used_in_an_assignment_effect_floatingEffect, nil)
-				} else {
-					typeName := ctx.Checker.TypeToString(result.exprType)
-					diag = ctx.NewDiagnostic(ctx.SourceFile, ctx.GetErrorRange(expr), tsdiag.This_Effect_able_0_value_is_neither_yielded_nor_assigned_to_a_variable_effect_floatingEffect, nil, typeName)
-				}
-				diags = append(diags, diag)
-			}
-
-			// Recurse into all children
-			n.ForEachChild(walk)
+// AnalyzeFloatingEffect finds Effect values used as standalone expression statements.
+func AnalyzeFloatingEffect(tp *typeparser.TypeParser, c *checker.Checker, sf *ast.SourceFile) []FloatingEffectMatch {
+	var matches []FloatingEffectMatch
+	var walk ast.Visitor
+	walk = func(node *ast.Node) bool {
+		if node == nil {
 			return false
 		}
 
-		walk(ctx.SourceFile.AsNode())
+		if result := detectFloatingEffect(tp, c, node); result != nil {
+			expression := node.AsExpressionStatement().Expression
+			matches = append(matches, FloatingEffectMatch{
+				SourceFile: sf,
+				Location:   scanner.GetErrorRangeForNode(sf, expression),
+				Expression: expression,
+				isStrict:   result.isStrict,
+				exprType:   result.exprType,
+			})
+		}
 
-		return diags
-	},
+		node.ForEachChild(walk)
+		return false
+	}
+	walk(sf.AsNode())
+	return matches
 }
 
 // detectFloatingEffect checks if a node is an expression statement containing an Effect type

--- a/testdata/baselines/reference/effect-v3/floatingEffect.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/floatingEffect.quickfixes.txt
@@ -17,6 +17,7 @@
 [D5] (12:3-12:15) TS377001: This Effect value is neither yielded nor used in an assignment. effect(floatingEffect)
   Fix 0: "Disable floatingEffect for this line"
   Fix 1: "Disable floatingEffect for entire file"
+  Fix 2: "Add yield* statement"
 
 [D6] (15:19-18:3) TS377017: This Effect.gen contains a single return statement. effect(unnecessaryEffectGen)
   Fix 0: "Disable unnecessaryEffectGen for this line"
@@ -50,6 +51,39 @@ skipped by default
 
 === [D5] Fix 1: "Disable floatingEffect for entire file" ===
 skipped by default
+
+=== [D5] Fix 2: "Add yield* statement" ===
+
+--- file:///.src/floatingEffect.ts ---
+// @effect-v3
+import * as Effect from "effect/Effect"
+
+const noError = Effect.succeed(1)
+
+Effect.succeed("floating")
+
+Effect.never
+
+Effect.runPromise(Effect.gen(function*() {
+  const thisIsFine = Effect.succeed(1)
+  yield* Effect.never
+}))
+
+Effect.runPromise(Effect.gen(function*() {
+  yield* Effect.succeed(1).pipe(Effect.fork)
+  // ^- This is fine, returns a fiber runtime
+}))
+
+export function constructorFunction(this: { boot: Effect.Effect<void> }) {
+  this.boot = Effect.void
+  // ^- This is fine, its another way to perform an assignment
+}
+
+const main = Effect.gen(function*() {
+  yield* Effect.exit(Effect.void)
+  // ^- This is fine, returns an exit
+})
+
 
 === [D6] Fix 0: "Disable unnecessaryEffectGen for this line" ===
 skipped by default

--- a/testdata/baselines/reference/effect-v3/floatingEffect_stream.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/floatingEffect_stream.quickfixes.txt
@@ -3,6 +3,7 @@
 [D1] (6:3-6:21) TS377058: This Effect-able `Stream<number, never, never>` value is neither yielded nor assigned to a variable. effect(floatingEffect)
   Fix 0: "Disable floatingEffect for this line"
   Fix 1: "Disable floatingEffect for entire file"
+  Fix 2: "Add yield* statement"
 
 === Quick Fix Application Results ===
 
@@ -11,3 +12,15 @@ skipped by default
 
 === [D1] Fix 1: "Disable floatingEffect for entire file" ===
 skipped by default
+
+=== [D1] Fix 2: "Add yield* statement" ===
+
+--- file:///.src/floatingEffect_stream.ts ---
+// @effect-v3
+import * as Effect from "effect/Effect"
+import * as Stream from "effect/Stream"
+
+export const shouldWarn = Effect.gen(function*() {
+  yield* Stream.succeed(42)
+})
+

--- a/testdata/baselines/reference/effect-v4/catchTagToCatchReason.errors.txt
+++ b/testdata/baselines/reference/effect-v4/catchTagToCatchReason.errors.txt
@@ -148,8 +148,8 @@ Effect version: 4.0.0
 !!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
     )
     
-    // Should trigger without a fix: the recovery needs the narrowed reason value.
-    export const reasonUseIsDiagnosticOnly = program.pipe(
+    // Should trigger and preserve wrapper uses through catchReason's second parameter.
+    export const reasonUsePreservesWrapper = program.pipe(
       Fx.catchTag("OuterError", (error) => {
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         switch (error.reason._tag) {

--- a/testdata/baselines/reference/effect-v4/catchTagToCatchReason.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/catchTagToCatchReason.quickfixes.txt
@@ -32,6 +32,7 @@
 [D7] (96:3-103:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
   Fix 1: "Disable catchTagToCatchReason for entire file"
+  Fix 2: "Replace with Effect.catchReason or Effect.catchReasons"
 
 [D8] (108:3-118:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTags` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
@@ -138,8 +139,8 @@ export const functionArguments = program.pipe(
   })
 )
 
-// Should trigger without a fix: the recovery needs the narrowed reason value.
-export const reasonUseIsDiagnosticOnly = program.pipe(
+// Should trigger and preserve wrapper uses through catchReason's second parameter.
+export const reasonUsePreservesWrapper = program.pipe(
   Fx.catchTag("OuterError", (error) => {
     switch (error.reason._tag) {
       case "ReasonB":
@@ -398,8 +399,8 @@ export const functionArguments = program.pipe(
   })
 )
 
-// Should trigger without a fix: the recovery needs the narrowed reason value.
-export const reasonUseIsDiagnosticOnly = program.pipe(
+// Should trigger and preserve wrapper uses through catchReason's second parameter.
+export const reasonUsePreservesWrapper = program.pipe(
   Fx.catchTag("OuterError", (error) => {
     switch (error.reason._tag) {
       case "ReasonB":
@@ -654,8 +655,8 @@ export const functionArguments = program.pipe(
   })
 )
 
-// Should trigger without a fix: the recovery needs the narrowed reason value.
-export const reasonUseIsDiagnosticOnly = program.pipe(
+// Should trigger and preserve wrapper uses through catchReason's second parameter.
+export const reasonUsePreservesWrapper = program.pipe(
   Fx.catchTag("OuterError", (error) => {
     switch (error.reason._tag) {
       case "ReasonB":
@@ -916,8 +917,8 @@ export const functionArguments = program.pipe(
   })
 )
 
-// Should trigger without a fix: the recovery needs the narrowed reason value.
-export const reasonUseIsDiagnosticOnly = program.pipe(
+// Should trigger and preserve wrapper uses through catchReason's second parameter.
+export const reasonUsePreservesWrapper = program.pipe(
   Fx.catchTag("OuterError", (error) => {
     switch (error.reason._tag) {
       case "ReasonB":
@@ -1174,8 +1175,8 @@ export const functionArguments = program.pipe(
   })
 )
 
-// Should trigger without a fix: the recovery needs the narrowed reason value.
-export const reasonUseIsDiagnosticOnly = program.pipe(
+// Should trigger and preserve wrapper uses through catchReason's second parameter.
+export const reasonUsePreservesWrapper = program.pipe(
   Fx.catchTag("OuterError", (error) => {
     switch (error.reason._tag) {
       case "ReasonB":
@@ -1347,6 +1348,257 @@ skipped by default
 
 === [D7] Fix 1: "Disable catchTagToCatchReason for entire file" ===
 skipped by default
+
+=== [D7] Fix 2: "Replace with Effect.catchReason or Effect.catchReasons" ===
+
+--- file:///.src/catchTagToCatchReason.ts ---
+// @effect-diagnostics *:off
+// @effect-diagnostics catchTagToCatchReason:suggestion
+import { Channel, Effect as Fx, pipe, Stream } from "effect"
+
+class ReasonA {
+  readonly _tag = "ReasonA"
+}
+
+class ReasonB {
+  readonly _tag = "ReasonB"
+  constructor(readonly detail: string) {}
+}
+
+class OuterError {
+  readonly _tag = "OuterError"
+  constructor(
+    readonly reason: ReasonA | ReasonB,
+    readonly context: string
+  ) {}
+  get alternateReason(): ReasonA | ReasonB {
+    return this.reason
+  }
+}
+
+class OtherError {
+  readonly _tag = "OtherError"
+  constructor(readonly reason: ReasonA | ReasonB) {}
+}
+
+declare const program: Fx.Effect<number, OuterError | OtherError>
+declare const otherOuterError: OuterError
+
+// Should trigger and offer catchReason: canonical switch with explicit re-fail.
+export const switchSingle = program.pipe(
+  Fx.catchTag("OuterError", (error) => {
+    switch (error.reason._tag) {
+      case "ReasonA":
+        return Fx.succeed(1)
+      default:
+        return Fx.fail(error)
+    }
+  })
+)
+
+// Should trigger and offer catchReasons: sequential ifs in pipe(...) style.
+export const ifMultiple = pipe(
+  program,
+  Fx.catchTag("OuterError", (error) => {
+    if (error.reason._tag === "ReasonA") return Fx.succeed(1)
+    if ("ReasonB" === error.reason._tag) return Fx.succeed(2)
+    return Fx.fail(error)
+  })
+)
+
+// Should trigger and offer catchReasons: an if/else-if chain.
+export const ifElseMultiple = program.pipe(
+  Fx.catchTag("OuterError", (error) => {
+    if (error.reason._tag === "ReasonA") {
+      return Fx.succeed(1)
+    } else if (error.reason._tag === "ReasonB") {
+      return Fx.succeed(2)
+    } else {
+      return Fx.fail(error)
+    }
+  })
+)
+
+// Should trigger and offer catchReason: conditional-expression dispatch.
+export const ternarySingle = program.pipe(
+  Fx.catchTag("OuterError", (error) =>
+    error.reason._tag === "ReasonA" ? Fx.succeed(1) : Fx.fail(error)
+  )
+)
+
+// Should trigger and offer catchReasons under conditional-expression narrowing.
+export const ternaryMultiple = program.pipe(
+  Fx.catchTag("OuterError", (error) =>
+    error.reason._tag === "ReasonA"
+      ? Fx.succeed(1)
+      : error.reason._tag === "ReasonB"
+        ? Fx.succeed(2)
+        : Fx.fail(error)
+  )
+)
+
+// Should trigger without a fix: extracting a function body could change arguments.
+export const functionArguments = program.pipe(
+  Fx.catchTag("OuterError", function(error) {
+    if (error.reason._tag === "ReasonA") return Fx.succeed(arguments.length)
+    return Fx.fail(error)
+  })
+)
+
+// Should trigger and preserve wrapper uses through catchReason's second parameter.
+export const reasonUsePreservesWrapper = program.pipe(
+  Fx.catchReason("OuterError", "ReasonB", (_, error) => Fx.succeed(error.reason.detail.length))
+)
+
+// Should trigger on the containing catchTags transformation, without a fix.
+export const catchTagsCase = program.pipe(
+  Fx.catchTags({
+    OuterError: (error) => {
+      switch (error.reason._tag) {
+        case "ReasonA":
+          return Fx.succeed(1)
+        default:
+          return Fx.fail(error)
+      }
+    },
+    OtherError: () => Fx.succeed(2)
+  })
+)
+
+// Should trigger without a fix: catchTags cases that need the narrowed reason.
+export const catchTagsReasonUse = program.pipe(
+  Fx.catchTags({
+    OuterError: (error) => {
+      if (error.reason._tag === "ReasonB") return Fx.succeed(error.reason.detail.length)
+      return Fx.fail(error)
+    }
+  })
+)
+
+// Should NOT trigger: the wrapper parameter is used outside reason dispatch.
+export const wrapperContextUse = program.pipe(
+  Fx.catchTag("OuterError", (error) => {
+    if (error.reason._tag === "ReasonA") return Fx.succeed(1)
+    return Fx.fail(new OuterError(error.reason, error.context))
+  })
+)
+
+// Should NOT trigger: logging the wrapper is outside pure reason dispatch.
+export const loggingUse = program.pipe(
+  Fx.catchTag("OuterError", (error) => {
+    console.log(error)
+    if (error.reason._tag === "ReasonA") return Fx.succeed(1)
+    return Fx.fail(error)
+  })
+)
+
+// Should NOT trigger: a nested alias obscures the canonical dispatch shape.
+export const reasonAlias = program.pipe(
+  Fx.catchTag("OuterError", (error) => {
+    const reason = error.reason
+    if (reason._tag === "ReasonA") return Fx.succeed(1)
+    return Fx.fail(error)
+  })
+)
+
+// Should NOT trigger: a different value with the same type is not the caught error.
+export const differentRoot = program.pipe(
+  Fx.catchTag("OuterError", (error) => {
+    if (otherOuterError.reason._tag === "ReasonA") return Fx.succeed(1)
+    return Fx.fail(error)
+  })
+)
+
+// Should NOT trigger: the catch rule requires the exact error.reason._tag chain.
+export const alternateReasonChain = program.pipe(
+  Fx.catchTag("OuterError", (error) => {
+    if (error.alternateReason._tag === "ReasonA") return Fx.succeed(1)
+    return Fx.fail(error)
+  })
+)
+
+// Should NOT trigger: the compared tag must be a string literal in the branch.
+const computedReasonTag = "ReasonA" as const
+
+export const computedTag = program.pipe(
+  Fx.catchTag("OuterError", (error) => {
+    if (error.reason._tag === computedReasonTag) return Fx.succeed(1)
+    return Fx.fail(error)
+  })
+)
+
+// Should NOT trigger: implicit falloff is already rejected by TypeScript.
+export const implicitFalloff = program.pipe(
+  Fx.catchTag(
+    "OuterError",
+    // @ts-expect-error the handler can return undefined
+    (error) => {
+      if (error.reason._tag === "ReasonA") return Fx.succeed(1)
+    }
+  )
+)
+
+// Should NOT trigger: a defect or non-terminating fallback is not a successful recovery.
+export const defectFallback = program.pipe(
+  Fx.catchTag("OuterError", (error) => {
+    if (error.reason._tag === "ReasonA") return Fx.succeed(1)
+    return Fx.die("fatal")
+  })
+)
+
+export const neverFallback = program.pipe(
+  Fx.catchTag("OuterError", (error) => {
+    if (error.reason._tag === "ReasonA") return Fx.succeed(1)
+    return Fx.never
+  })
+)
+
+// Should NOT trigger: non-literal reason tags are not a reason-class union.
+declare const nonLiteralProgram: Fx.Effect<number, {
+  readonly _tag: "NonLiteralError"
+  readonly reason: { readonly _tag: string }
+}>
+
+export const nonLiteralReason = nonLiteralProgram.pipe(
+  Fx.catchTag("NonLiteralError", (error) => {
+    if (error.reason._tag === "ReasonA") return Fx.succeed(1)
+    return Fx.fail(error)
+  })
+)
+
+// Should NOT trigger: the reason property must be an actual union.
+declare const singleReasonProgram: Fx.Effect<number, {
+  readonly _tag: "SingleReasonError"
+  readonly reason: ReasonA
+}>
+
+export const singleReason = singleReasonProgram.pipe(
+  Fx.catchTag("SingleReasonError", (error) => {
+    if (error.reason._tag === "ReasonA") return Fx.succeed(1)
+    return Fx.fail(error)
+  })
+)
+
+// Should NOT trigger: Stream.catchTag is outside the conservative Effect-only scope.
+declare const stream: Stream.Stream<number, OuterError>
+
+export const streamCatchTag = stream.pipe(
+  Stream.catchTag("OuterError", (error) => {
+    if (error.reason._tag === "ReasonA") return Stream.succeed(1)
+    return Stream.fail(error)
+  })
+)
+
+// Should NOT trigger: Channel.catchTag is also outside the Effect-only scope.
+declare const channel: Channel.Channel<number, OuterError>
+
+export const channelCatchTag = channel.pipe(
+  Channel.catchTag("OuterError", (error) => {
+    if (error.reason._tag === "ReasonA") return Channel.succeed(1)
+    return Channel.fail(error)
+  })
+)
+
 
 === [D8] Fix 0: "Disable catchTagToCatchReason for this line" ===
 skipped by default

--- a/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.errors.txt
+++ b/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.errors.txt
@@ -1,0 +1,98 @@
+=== Metadata ===
+Effect version: 4.0.0
+
+/.src/catchTagToCatchReasonParameterUse.ts(27,3): suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+/.src/catchTagToCatchReasonParameterUse.ts(38,3): suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+/.src/catchTagToCatchReasonParameterUse.ts(49,3): suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+
+
+==== /.src/catchTagToCatchReasonParameterUse.ts (3 errors) ====
+    // @effect-diagnostics *:off
+    // @effect-diagnostics catchTagToCatchReason:suggestion
+    import { Effect } from "effect"
+    
+    class ReasonA {
+      readonly _tag = "ReasonA"
+      constructor(readonly detail: string) {}
+    }
+    
+    class ReasonB {
+      readonly _tag = "ReasonB"
+    }
+    
+    class OuterError {
+      readonly _tag = "OuterError"
+      constructor(
+        readonly reason: ReasonA | ReasonB,
+        readonly context: string
+      ) {}
+    }
+    
+    declare const program: Effect.Effect<number, OuterError>
+    declare const otherError: OuterError
+    const _ = "outer"
+    
+    export const parameterUse = program.pipe(
+      Effect.catchTag("OuterError", (error) => {
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        switch (error.reason._tag) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          case "ReasonA":
+    ~~~~~~~~~~~~~~~~~~~~~
+            return Effect.succeed(`${_}: ${error.context}: ${error.reason.detail}`)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          default:
+    ~~~~~~~~~~~~~~
+            return Effect.fail(error)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        }
+    ~~~~~
+      })
+    ~~~~
+!!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+    )
+    
+    export const reassignedParameter = program.pipe(
+      Effect.catchTag("OuterError", (error) => {
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        switch (error.reason._tag) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          case "ReasonA":
+    ~~~~~~~~~~~~~~~~~~~~~
+            return (error = otherError, Effect.succeed(1))
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          default:
+    ~~~~~~~~~~~~~~
+            return Effect.fail(error)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        }
+    ~~~~~
+      })
+    ~~~~
+!!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+    )
+    
+    export const multipleBranches = program.pipe(
+      Effect.catchTag("OuterError", (error) => {
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        switch (error.reason._tag) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          case "ReasonA":
+    ~~~~~~~~~~~~~~~~~~~~~
+            return Effect.succeed(error.reason.detail)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          case "ReasonB":
+    ~~~~~~~~~~~~~~~~~~~~~
+            return Effect.succeed("reason b")
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          default:
+    ~~~~~~~~~~~~~~
+            return Effect.fail(error)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        }
+    ~~~~~
+      })
+    ~~~~
+!!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+    )
+    

--- a/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.flows.catchTagToCatchReasonParameterUse.mermaid
+++ b/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.flows.catchTagToCatchReasonParameterUse.mermaid
@@ -1,0 +1,85 @@
+flowchart TB
+  0[/"type: #quot;ReasonA#quot;<br/>node: #quot;ReasonA#quot;"/]
+  1[["type: any<br/>node: constructor#40;readonly detail: string#41; #123;#125;"]]
+  2[/"type: #quot;ReasonB#quot;<br/>node: #quot;ReasonB#quot;"/]
+  3[/"type: #quot;OuterError#quot;<br/>node: #quot;OuterError#quot;"/]
+  4[["type: any<br/>node: constructor#40;#92;n    readonly reason: ReasonA #124; ReasonB,#92;n    readonly context: string#92;n  #41; #123;#125;"]]
+  5[/"type: #quot;outer#quot;<br/>node: #quot;outer#quot;"/]
+  6[/"type: Effect#lt;number, OuterError, never#gt;<br/>node: program"/]
+  7["type: Effect#lt;string #124; number, OuterError, never#gt;<br/>callee: Effect.catchTag<br/>args: #91;#quot;OuterError#quot;, #40;error#41; =#gt; #123;#92;n    switch #40;error.reason._tag#41; #123;#92;n      case #quot;ReasonA#quot;:#92;n        return Effect.succeed#40;`$#123;_#125;: $#123;error.context#125;: $#123;error.reason.detail#125;`#41;#92;n      default:#92;n        return Effect.fail#40;error#41;#92;n    #125;#92;n  #125;#93;"]
+  8[/"type: #123; #lt;const K extends Tags#lt;E#gt; #124; Arr.NonEmptyReadonlyArray#lt;Tags#lt;E#gt;#gt;, E, A1, E1, R1, A2 = unassigned, E2 = never, R2 = never#gt;#40;k: K, f: #40;e: ExtractTag#lt;NoInfer#lt;E#gt;, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt;#41; =#gt; Effect#lt;A1, E1, R1#gt;, orElse?: #40;#40;e: ExcludeTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt;#41; =#gt; Effect#lt;A2, E2, R2#gt;#41; #124; undefined#41;: #lt;A, R#gt;#40;self: Effect#lt;A, E, R#gt;#41; =#gt; Effect#lt;A #124; A1 #124; Exclude#lt;A2, unassigned#gt;, E1 #124; E2 #124; #40;A2 extends unassigned ? ExcludeTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt; : never#41;, R #124; R1 #124; R2#gt;; #lt;A, E, R, const K extends Tags#lt;E#gt; #124; Arr.NonEmptyReadonlyArray#lt;Tags#lt;E#gt;#gt;, R1, E1, A1, A2 = unassigned, E2 = never, R2 = never#gt;#40;self: Effect#lt;A, E, R#gt;, k: K, f: #40;e: ExtractTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt;#41; =#gt; Effect#lt;A1, E1, R1#gt;, orElse?: #40;#40;e: ExcludeTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt;#41; =#gt; Effect#lt;A2, E2, R2#gt;#41; #124; undefined#41;: Effect#lt;A #124; A1 #124; Exclude#lt;A2, unassigned#gt;, E1 #124; E2 #124; #40;A2 extends unassigned ? ExcludeTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt; : never#41;, R #124; R1 #124; R2#gt;; #125;<br/>node: Effect.catchTag"/]
+  9[/"type: #quot;OuterError#quot;<br/>node: #quot;OuterError#quot;"/]
+  10[["type: #40;error: OuterError#41; =#gt; Effect#lt;string, never, never#gt; #124; Effect#lt;never, OuterError, never#gt;<br/>node: #40;error#41; =#gt; #123;#92;n    switch #40;error.reason._tag#41; #123;#92;n      case #quot;ReasonA#quot;:#92;n        return Effect.succeed#40;`$#123;_#125;: $#123;error.context#125;: $#123;error.reason.detail#125;`#41;#92;n      default:#92;n        return Effect.fail#40;error#41;#92;n    #125;#92;n  #125;"]]
+  11[/"type: string<br/>node: `$#123;_#125;: $#123;error.context#125;: $#123;error.reason.detail#125;`"/]
+  12["type: Effect#lt;string, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  13[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  14[/"type: OuterError<br/>node: error"/]
+  15["type: Effect#lt;never, OuterError, never#gt;<br/>callee: Effect.fail<br/>args: #91;#93;"]
+  16[/"type: #lt;E#gt;#40;error: E#41; =#gt; Effect#lt;never, E, never#gt;<br/>node: Effect.fail"/]
+  17[/"type: Effect#lt;number, OuterError, never#gt;<br/>node: program"/]
+  18["type: Effect#lt;number, OuterError, never#gt;<br/>callee: Effect.catchTag<br/>args: #91;#quot;OuterError#quot;, #40;error#41; =#gt; #123;#92;n    switch #40;error.reason._tag#41; #123;#92;n      case #quot;ReasonA#quot;:#92;n        return #40;error = otherError, Effect.succeed#40;1#41;#41;#92;n      default:#92;n        return Effect.fail#40;error#41;#92;n    #125;#92;n  #125;#93;"]
+  19[/"type: #123; #lt;const K extends Tags#lt;E#gt; #124; Arr.NonEmptyReadonlyArray#lt;Tags#lt;E#gt;#gt;, E, A1, E1, R1, A2 = unassigned, E2 = never, R2 = never#gt;#40;k: K, f: #40;e: ExtractTag#lt;NoInfer#lt;E#gt;, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt;#41; =#gt; Effect#lt;A1, E1, R1#gt;, orElse?: #40;#40;e: ExcludeTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt;#41; =#gt; Effect#lt;A2, E2, R2#gt;#41; #124; undefined#41;: #lt;A, R#gt;#40;self: Effect#lt;A, E, R#gt;#41; =#gt; Effect#lt;A #124; A1 #124; Exclude#lt;A2, unassigned#gt;, E1 #124; E2 #124; #40;A2 extends unassigned ? ExcludeTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt; : never#41;, R #124; R1 #124; R2#gt;; #lt;A, E, R, const K extends Tags#lt;E#gt; #124; Arr.NonEmptyReadonlyArray#lt;Tags#lt;E#gt;#gt;, R1, E1, A1, A2 = unassigned, E2 = never, R2 = never#gt;#40;self: Effect#lt;A, E, R#gt;, k: K, f: #40;e: ExtractTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt;#41; =#gt; Effect#lt;A1, E1, R1#gt;, orElse?: #40;#40;e: ExcludeTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt;#41; =#gt; Effect#lt;A2, E2, R2#gt;#41; #124; undefined#41;: Effect#lt;A #124; A1 #124; Exclude#lt;A2, unassigned#gt;, E1 #124; E2 #124; #40;A2 extends unassigned ? ExcludeTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt; : never#41;, R #124; R1 #124; R2#gt;; #125;<br/>node: Effect.catchTag"/]
+  20[/"type: #quot;OuterError#quot;<br/>node: #quot;OuterError#quot;"/]
+  21[["type: #40;error: OuterError#41; =#gt; Effect#lt;number, never, never#gt; #124; Effect#lt;never, OuterError, never#gt;<br/>node: #40;error#41; =#gt; #123;#92;n    switch #40;error.reason._tag#41; #123;#92;n      case #quot;ReasonA#quot;:#92;n        return #40;error = otherError, Effect.succeed#40;1#41;#41;#92;n      default:#92;n        return Effect.fail#40;error#41;#92;n    #125;#92;n  #125;"]]
+  22[/"type: Effect#lt;number, never, never#gt;<br/>node: #40;error = otherError, Effect.succeed#40;1#41;#41;"/]
+  23[/"type: 1<br/>node: 1"/]
+  24["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  25[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  26[/"type: OuterError<br/>node: error"/]
+  27["type: Effect#lt;never, OuterError, never#gt;<br/>callee: Effect.fail<br/>args: #91;#93;"]
+  28[/"type: #lt;E#gt;#40;error: E#41; =#gt; Effect#lt;never, E, never#gt;<br/>node: Effect.fail"/]
+  29[/"type: Effect#lt;number, OuterError, never#gt;<br/>node: program"/]
+  30["type: Effect#lt;string #124; number, OuterError, never#gt;<br/>callee: Effect.catchTag<br/>args: #91;#quot;OuterError#quot;, #40;error#41; =#gt; #123;#92;n    switch #40;error.reason._tag#41; #123;#92;n      case #quot;ReasonA#quot;:#92;n        return Effect.succeed#40;error.reason.detail#41;#92;n      case #quot;ReasonB#quot;:#92;n        return Effect.succeed#40;#quot;reason b#quot;#41;#92;n      default:#92;n        return Effect.fail#40;error#41;#92;n    #125;#92;n  #125;#93;"]
+  31[/"type: #123; #lt;const K extends Tags#lt;E#gt; #124; Arr.NonEmptyReadonlyArray#lt;Tags#lt;E#gt;#gt;, E, A1, E1, R1, A2 = unassigned, E2 = never, R2 = never#gt;#40;k: K, f: #40;e: ExtractTag#lt;NoInfer#lt;E#gt;, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt;#41; =#gt; Effect#lt;A1, E1, R1#gt;, orElse?: #40;#40;e: ExcludeTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt;#41; =#gt; Effect#lt;A2, E2, R2#gt;#41; #124; undefined#41;: #lt;A, R#gt;#40;self: Effect#lt;A, E, R#gt;#41; =#gt; Effect#lt;A #124; A1 #124; Exclude#lt;A2, unassigned#gt;, E1 #124; E2 #124; #40;A2 extends unassigned ? ExcludeTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt; : never#41;, R #124; R1 #124; R2#gt;; #lt;A, E, R, const K extends Tags#lt;E#gt; #124; Arr.NonEmptyReadonlyArray#lt;Tags#lt;E#gt;#gt;, R1, E1, A1, A2 = unassigned, E2 = never, R2 = never#gt;#40;self: Effect#lt;A, E, R#gt;, k: K, f: #40;e: ExtractTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt;#41; =#gt; Effect#lt;A1, E1, R1#gt;, orElse?: #40;#40;e: ExcludeTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt;#41; =#gt; Effect#lt;A2, E2, R2#gt;#41; #124; undefined#41;: Effect#lt;A #124; A1 #124; Exclude#lt;A2, unassigned#gt;, E1 #124; E2 #124; #40;A2 extends unassigned ? ExcludeTag#lt;E, K extends readonly #91;string, ...string#91;#93;#93; ? K#91;number#93; : K#gt; : never#41;, R #124; R1 #124; R2#gt;; #125;<br/>node: Effect.catchTag"/]
+  32[/"type: #quot;OuterError#quot;<br/>node: #quot;OuterError#quot;"/]
+  33[["type: #40;error: OuterError#41; =#gt; Effect#lt;string, never, never#gt; #124; Effect#lt;never, OuterError, never#gt;<br/>node: #40;error#41; =#gt; #123;#92;n    switch #40;error.reason._tag#41; #123;#92;n      case #quot;ReasonA#quot;:#92;n        return Effect.succeed#40;error.reason.detail#41;#92;n      case #quot;ReasonB#quot;:#92;n        return Effect.succeed#40;#quot;reason b#quot;#41;#92;n      default:#92;n        return Effect.fail#40;error#41;#92;n    #125;#92;n  #125;"]]
+  34[/"type: string<br/>node: error.reason.detail"/]
+  35["type: Effect#lt;string, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  36[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  37[/"type: #quot;reason b#quot;<br/>node: #quot;reason b#quot;"/]
+  38["type: Effect#lt;string, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  39[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  40[/"type: OuterError<br/>node: error"/]
+  41["type: Effect#lt;never, OuterError, never#gt;<br/>callee: Effect.fail<br/>args: #91;#93;"]
+  42[/"type: #lt;E#gt;#40;error: E#41; =#gt; Effect#lt;never, E, never#gt;<br/>node: Effect.fail"/]
+  8 -->|"kind: transformCallee"| 7
+  9 -->|"kind: transformArg"| 7
+  11 -->|"kind: pipe"| 12
+  13 -->|"kind: transformCallee"| 12
+  12 -->|"kind: potentialReturn"| 10
+  14 -->|"kind: pipe"| 15
+  16 -->|"kind: transformCallee"| 15
+  15 -->|"kind: potentialReturn"| 10
+  12 -->|"kind: usedBy"| 10
+  15 -->|"kind: usedBy"| 10
+  10 -->|"kind: transformArg"| 7
+  6 -->|"kind: pipe"| 7
+  19 -->|"kind: transformCallee"| 18
+  20 -->|"kind: transformArg"| 18
+  23 -->|"kind: pipe"| 24
+  25 -->|"kind: transformCallee"| 24
+  24 -->|"kind: usedBy"| 22
+  22 -->|"kind: potentialReturn"| 21
+  26 -->|"kind: pipe"| 27
+  28 -->|"kind: transformCallee"| 27
+  27 -->|"kind: potentialReturn"| 21
+  22 -->|"kind: usedBy"| 21
+  27 -->|"kind: usedBy"| 21
+  21 -->|"kind: transformArg"| 18
+  17 -->|"kind: pipe"| 18
+  31 -->|"kind: transformCallee"| 30
+  32 -->|"kind: transformArg"| 30
+  34 -->|"kind: pipe"| 35
+  36 -->|"kind: transformCallee"| 35
+  35 -->|"kind: potentialReturn"| 33
+  37 -->|"kind: pipe"| 38
+  39 -->|"kind: transformCallee"| 38
+  38 -->|"kind: potentialReturn"| 33
+  40 -->|"kind: pipe"| 41
+  42 -->|"kind: transformCallee"| 41
+  41 -->|"kind: potentialReturn"| 33
+  35 -->|"kind: usedBy"| 33
+  38 -->|"kind: usedBy"| 33
+  41 -->|"kind: usedBy"| 33
+  33 -->|"kind: transformArg"| 30
+  29 -->|"kind: pipe"| 30

--- a/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.flows.txt
+++ b/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.flows.txt
@@ -1,0 +1,1 @@
+/.src/catchTagToCatchReasonParameterUse.ts -> catchTagToCatchReasonParameterUse.flows.catchTagToCatchReasonParameterUse.mermaid

--- a/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.layers.txt
+++ b/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.layers.txt
@@ -1,0 +1,1 @@
+==== /.src/catchTagToCatchReasonParameterUse.ts (0 layer exports) ====

--- a/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.pipings.txt
@@ -1,0 +1,141 @@
+==== /.src/catchTagToCatchReasonParameterUse.ts (10 flows) ====
+
+=== Piping Flow ===
+Location: 26:28 - 35:2
+Node: program.pipe(\n  Effect.catchTag("OuterError", (error) => {\n    switch (error.reason._tag) {\n      case "ReasonA":\n        return Effect.succeed(`${_}: ${error.context}: ${error.reason.detail}`)\n      default:\n        return Effect.fail(error)\n    }\n  })\n)
+Node Kind: KindCallExpression
+
+Subject: program
+Subject Type: Effect<number, OuterError, never>
+
+Transformations (1):
+  [0] kind: pipeable
+      callee: Effect.catchTag
+      args: ["OuterError", (error) => {\n    switch (error.reason._tag) {\n      case "ReasonA":\n        return Effect.succeed(`${_}: ${error.context}: ${error.reason.detail}`)\n      default:\n        return Effect.fail(error)\n    }\n  }]
+      outType: Effect<string | number, OuterError, never>
+
+=== Piping Flow ===
+Location: 30:15 - 30:80
+Node: Effect.succeed(`${_}: ${error.context}: ${error.reason.detail}`)
+Node Kind: KindCallExpression
+
+Subject: `${_}: ${error.context}: ${error.reason.detail}`
+Subject Type: string
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<string, never, never>
+
+=== Piping Flow ===
+Location: 32:15 - 32:34
+Node: Effect.fail(error)
+Node Kind: KindCallExpression
+
+Subject: error
+Subject Type: OuterError
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.fail
+      args: (constant)
+      outType: Effect<never, OuterError, never>
+
+=== Piping Flow ===
+Location: 37:35 - 46:2
+Node: program.pipe(\n  Effect.catchTag("OuterError", (error) => {\n    switch (error.reason._tag) {\n      case "ReasonA":\n        return (error = otherError, Effect.succeed(1))\n      default:\n        return Effect.fail(error)\n    }\n  })\n)
+Node Kind: KindCallExpression
+
+Subject: program
+Subject Type: Effect<number, OuterError, never>
+
+Transformations (1):
+  [0] kind: pipeable
+      callee: Effect.catchTag
+      args: ["OuterError", (error) => {\n    switch (error.reason._tag) {\n      case "ReasonA":\n        return (error = otherError, Effect.succeed(1))\n      default:\n        return Effect.fail(error)\n    }\n  }]
+      outType: Effect<number, OuterError, never>
+
+=== Piping Flow ===
+Location: 41:36 - 41:54
+Node: Effect.succeed(1)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 43:15 - 43:34
+Node: Effect.fail(error)
+Node Kind: KindCallExpression
+
+Subject: error
+Subject Type: OuterError
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.fail
+      args: (constant)
+      outType: Effect<never, OuterError, never>
+
+=== Piping Flow ===
+Location: 48:32 - 59:2
+Node: program.pipe(\n  Effect.catchTag("OuterError", (error) => {\n    switch (error.reason._tag) {\n      case "ReasonA":\n        return Effect.succeed(error.reason.detail)\n      case "ReasonB":\n        return Effect.succeed("reason b")\n      default:\n        return Effect.fail(error)\n    }\n  })\n)
+Node Kind: KindCallExpression
+
+Subject: program
+Subject Type: Effect<number, OuterError, never>
+
+Transformations (1):
+  [0] kind: pipeable
+      callee: Effect.catchTag
+      args: ["OuterError", (error) => {\n    switch (error.reason._tag) {\n      case "ReasonA":\n        return Effect.succeed(error.reason.detail)\n      case "ReasonB":\n        return Effect.succeed("reason b")\n      default:\n        return Effect.fail(error)\n    }\n  }]
+      outType: Effect<string | number, OuterError, never>
+
+=== Piping Flow ===
+Location: 52:15 - 52:51
+Node: Effect.succeed(error.reason.detail)
+Node Kind: KindCallExpression
+
+Subject: error.reason.detail
+Subject Type: string
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<string, never, never>
+
+=== Piping Flow ===
+Location: 54:15 - 54:42
+Node: Effect.succeed("reason b")
+Node Kind: KindCallExpression
+
+Subject: "reason b"
+Subject Type: "reason b"
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<string, never, never>
+
+=== Piping Flow ===
+Location: 56:15 - 56:34
+Node: Effect.fail(error)
+Node Kind: KindCallExpression
+
+Subject: error
+Subject Type: OuterError
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.fail
+      args: (constant)
+      outType: Effect<never, OuterError, never>

--- a/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.quickfixes.txt
@@ -1,0 +1,147 @@
+=== Quick Fix Inventory ===
+
+[D1] (27:3-34:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+  Fix 0: "Disable catchTagToCatchReason for this line"
+  Fix 1: "Disable catchTagToCatchReason for entire file"
+  Fix 2: "Replace with Effect.catchReason or Effect.catchReasons"
+
+[D2] (38:3-45:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+  Fix 0: "Disable catchTagToCatchReason for this line"
+  Fix 1: "Disable catchTagToCatchReason for entire file"
+
+[D3] (49:3-58:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+  Fix 0: "Disable catchTagToCatchReason for this line"
+  Fix 1: "Disable catchTagToCatchReason for entire file"
+  Fix 2: "Replace with Effect.catchReason or Effect.catchReasons"
+
+=== Quick Fix Application Results ===
+
+=== [D1] Fix 0: "Disable catchTagToCatchReason for this line" ===
+skipped by default
+
+=== [D1] Fix 1: "Disable catchTagToCatchReason for entire file" ===
+skipped by default
+
+=== [D1] Fix 2: "Replace with Effect.catchReason or Effect.catchReasons" ===
+
+--- file:///.src/catchTagToCatchReasonParameterUse.ts ---
+// @effect-diagnostics *:off
+// @effect-diagnostics catchTagToCatchReason:suggestion
+import { Effect } from "effect"
+
+class ReasonA {
+  readonly _tag = "ReasonA"
+  constructor(readonly detail: string) {}
+}
+
+class ReasonB {
+  readonly _tag = "ReasonB"
+}
+
+class OuterError {
+  readonly _tag = "OuterError"
+  constructor(
+    readonly reason: ReasonA | ReasonB,
+    readonly context: string
+  ) {}
+}
+
+declare const program: Effect.Effect<number, OuterError>
+declare const otherError: OuterError
+const _ = "outer"
+
+export const parameterUse = program.pipe(
+  Effect.catchReason("OuterError", "ReasonA", (_0, error) => Effect.succeed(`${_}: ${error.context}: ${error.reason.detail}`))
+)
+
+export const reassignedParameter = program.pipe(
+  Effect.catchTag("OuterError", (error) => {
+    switch (error.reason._tag) {
+      case "ReasonA":
+        return (error = otherError, Effect.succeed(1))
+      default:
+        return Effect.fail(error)
+    }
+  })
+)
+
+export const multipleBranches = program.pipe(
+  Effect.catchTag("OuterError", (error) => {
+    switch (error.reason._tag) {
+      case "ReasonA":
+        return Effect.succeed(error.reason.detail)
+      case "ReasonB":
+        return Effect.succeed("reason b")
+      default:
+        return Effect.fail(error)
+    }
+  })
+)
+
+
+=== [D2] Fix 0: "Disable catchTagToCatchReason for this line" ===
+skipped by default
+
+=== [D2] Fix 1: "Disable catchTagToCatchReason for entire file" ===
+skipped by default
+
+=== [D3] Fix 0: "Disable catchTagToCatchReason for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable catchTagToCatchReason for entire file" ===
+skipped by default
+
+=== [D3] Fix 2: "Replace with Effect.catchReason or Effect.catchReasons" ===
+
+--- file:///.src/catchTagToCatchReasonParameterUse.ts ---
+// @effect-diagnostics *:off
+// @effect-diagnostics catchTagToCatchReason:suggestion
+import { Effect } from "effect"
+
+class ReasonA {
+  readonly _tag = "ReasonA"
+  constructor(readonly detail: string) {}
+}
+
+class ReasonB {
+  readonly _tag = "ReasonB"
+}
+
+class OuterError {
+  readonly _tag = "OuterError"
+  constructor(
+    readonly reason: ReasonA | ReasonB,
+    readonly context: string
+  ) {}
+}
+
+declare const program: Effect.Effect<number, OuterError>
+declare const otherError: OuterError
+const _ = "outer"
+
+export const parameterUse = program.pipe(
+  Effect.catchTag("OuterError", (error) => {
+    switch (error.reason._tag) {
+      case "ReasonA":
+        return Effect.succeed(`${_}: ${error.context}: ${error.reason.detail}`)
+      default:
+        return Effect.fail(error)
+    }
+  })
+)
+
+export const reassignedParameter = program.pipe(
+  Effect.catchTag("OuterError", (error) => {
+    switch (error.reason._tag) {
+      case "ReasonA":
+        return (error = otherError, Effect.succeed(1))
+      default:
+        return Effect.fail(error)
+    }
+  })
+)
+
+export const multipleBranches = program.pipe(
+  Effect.catchReasons("OuterError", { "ReasonA": (_0, error) => Effect.succeed(error.reason.detail), "ReasonB": () => Effect.succeed("reason b") })
+)
+

--- a/testdata/baselines/reference/effect-v4/floatingEffectGen.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/floatingEffectGen.quickfixes.txt
@@ -3,6 +3,7 @@
 [D1] (4:4-4:23) TS377001: This Effect value is neither yielded nor used in an assignment. effect(floatingEffect)
   Fix 0: "Disable floatingEffect for this line"
   Fix 1: "Disable floatingEffect for entire file"
+  Fix 2: "Add yield* statement"
 
 === Quick Fix Application Results ===
 
@@ -11,3 +12,12 @@ skipped by default
 
 === [D1] Fix 1: "Disable floatingEffect for entire file" ===
 skipped by default
+
+=== [D1] Fix 2: "Add yield* statement" ===
+
+--- file:///.src/floatingEffectGen.ts ---
+import { Effect } from "effect"
+
+export const program = Effect.gen(function*(){
+   yield* Effect.log("hello") // <- this should be yielded instead
+})

--- a/testdata/tests/effect-v4/catchTagToCatchReason.ts
+++ b/testdata/tests/effect-v4/catchTagToCatchReason.ts
@@ -91,8 +91,8 @@ export const functionArguments = program.pipe(
   })
 )
 
-// Should trigger without a fix: the recovery needs the narrowed reason value.
-export const reasonUseIsDiagnosticOnly = program.pipe(
+// Should trigger and preserve wrapper uses through catchReason's second parameter.
+export const reasonUsePreservesWrapper = program.pipe(
   Fx.catchTag("OuterError", (error) => {
     switch (error.reason._tag) {
       case "ReasonB":

--- a/testdata/tests/effect-v4/catchTagToCatchReasonParameterUse.ts
+++ b/testdata/tests/effect-v4/catchTagToCatchReasonParameterUse.ts
@@ -1,0 +1,59 @@
+// @effect-diagnostics *:off
+// @effect-diagnostics catchTagToCatchReason:suggestion
+import { Effect } from "effect"
+
+class ReasonA {
+  readonly _tag = "ReasonA"
+  constructor(readonly detail: string) {}
+}
+
+class ReasonB {
+  readonly _tag = "ReasonB"
+}
+
+class OuterError {
+  readonly _tag = "OuterError"
+  constructor(
+    readonly reason: ReasonA | ReasonB,
+    readonly context: string
+  ) {}
+}
+
+declare const program: Effect.Effect<number, OuterError>
+declare const otherError: OuterError
+const _ = "outer"
+
+export const parameterUse = program.pipe(
+  Effect.catchTag("OuterError", (error) => {
+    switch (error.reason._tag) {
+      case "ReasonA":
+        return Effect.succeed(`${_}: ${error.context}: ${error.reason.detail}`)
+      default:
+        return Effect.fail(error)
+    }
+  })
+)
+
+export const reassignedParameter = program.pipe(
+  Effect.catchTag("OuterError", (error) => {
+    switch (error.reason._tag) {
+      case "ReasonA":
+        return (error = otherError, Effect.succeed(1))
+      default:
+        return Effect.fail(error)
+    }
+  })
+)
+
+export const multipleBranches = program.pipe(
+  Effect.catchTag("OuterError", (error) => {
+    switch (error.reason._tag) {
+      case "ReasonA":
+        return Effect.succeed(error.reason.detail)
+      case "ReasonB":
+        return Effect.succeed("reason b")
+      default:
+        return Effect.fail(error)
+    }
+  })
+)


### PR DESCRIPTION
## Summary

- add a `yield*` quick fix for floating Effects when the enclosing Effect context can yield
- preserve narrowed wrapper error references when rewriting hand-rolled reason dispatch to `Effect.catchReason` or `Effect.catchReasons`
- avoid unsafe catch-reason rewrites when the caught parameter is reassigned and generate collision-free unused reason parameter names

## Examples

```ts
Effect.gen(function*() {
  Effect.log("hello")
})
```

becomes:

```ts
Effect.gen(function*() {
  yield* Effect.log("hello")
})
```

A reason handler that uses the wrapper:

```ts
Effect.catchTag("AiError", (error) => {
  switch (error.reason._tag) {
    case "RateLimitError":
      return Effect.succeed(`Retry after ${error.reason.retryAfter}s`)
    default:
      return Effect.fail(error)
  }
})
```

becomes:

```ts
Effect.catchReason("AiError", "RateLimitError", (_, error) =>
  Effect.succeed(`Retry after ${error.reason.retryAfter}s`)
)
```

## Validation

- local tests were not rerun during the PR workflow, as requested
- CI should perform repository validation