### PR TITLE
Patch Oxlint TypeScript declarations

### DIFF
--- a/.changeset/patch-oxlint-declarations.md
+++ b/.changeset/patch-oxlint-declarations.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": minor
+---
+
+Patch Oxlint's TypeScript declarations with the `effecttsgo` plugin and rule names.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,8 @@ jobs:
     needs: select-mode
     if: needs.select-mode.outputs.mode == 'publish'
     uses: ./.github/workflows/repoctl-matrix.yml
+    permissions:
+      contents: read
     with:
       name: release
 

--- a/_packages/tsgo/src/cli/index.ts
+++ b/_packages/tsgo/src/cli/index.ts
@@ -73,7 +73,7 @@ const patchCommand = Command.make("patch", {
   typescriptPackage: typescriptPackageFlag
 }).pipe(
   Command.withDescription("Patch the selected Effect integrations"),
-  Command.withHandler(({ oxlint, skipMissing, typescript, typescriptPackage }) => Effect.gen(function*() {
+  Command.withHandler(({ oxlint, skipMissing, typescript, typescriptPackage }) => Effect.scoped(Effect.gen(function*() {
     yield* ensureIntegrationSelected(typescript, oxlint)
     if (!typescript && Option.isSome(typescriptPackage)) {
       return yield* new IntegrationSelectionError({
@@ -93,7 +93,7 @@ const patchCommand = Command.make("patch", {
       (target) => Console.log(`Patched ${target.component} at ${target.binaryPath}`),
       { discard: true }
     )
-  }))
+  })))
 )
 
 const unpatchCommand = Command.make("unpatch", {
@@ -123,11 +123,11 @@ const unpatchCommand = Command.make("unpatch", {
   }))
 )
 
-const resolveTypeScriptExecutable = Effect.gen(function*() {
+const resolveTypeScriptExecutable = Effect.scoped(Effect.gen(function*() {
   const components = new Set<Component>(["typescript"])
   const targets = yield* discoverSelected(components, defaultTypescriptPackageNames[0])
   return yield* resolveReplacement(targets[0]!)
-})
+}))
 
 const getExePathCommand = Command.make("get-exe-path").pipe(
   Command.withDescription("Print the Effect Language Service executable path"),

--- a/_packages/tsgo/src/patcher/discovery.ts
+++ b/_packages/tsgo/src/patcher/discovery.ts
@@ -133,6 +133,12 @@ const discoverOxlint: (
         packageVersion: binding.version,
         binaryPath: path.join(path.dirname(binding.packageJsonPath), binding.main)
       })
+      discovered.push({
+        component: "oxlint-dts",
+        packageName: "oxlint",
+        packageVersion: oxlint.version,
+        binaryPath: path.join(path.dirname(oxlint.packageJsonPath), "dist", "index.d.ts")
+      })
     }
     if (tsgolint !== undefined) {
       const nativePackage = yield* readPackage(

--- a/_packages/tsgo/src/patcher/index.ts
+++ b/_packages/tsgo/src/patcher/index.ts
@@ -4,6 +4,8 @@ import * as Data from "effect/Data"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
+import * as Scope from "effect/Scope"
+import metadataJson from "../metadata.json" with { type: "json" }
 import { discoverBinaries, requireComponents, selectComponents } from "./discovery.js"
 import type {
   Component,
@@ -42,7 +44,81 @@ export interface ResolvedReplacement {
 
 export type ReplacementResolver = (
   target: DiscoveredBinary
-) => Effect.Effect<ResolvedReplacement, PatcherError | ReplacementUnavailableError, FileSystem.FileSystem | Path.Path>
+) => Effect.Effect<
+  ResolvedReplacement,
+  PatcherError | ReplacementUnavailableError,
+  FileSystem.FileSystem | Path.Path | Scope.Scope
+>
+
+const toKebabCase = (value: string): string => {
+  let result = ""
+  const characters = [...value]
+  for (let index = 0; index < characters.length; index++) {
+    const current = characters[index]!
+    if (current >= "A" && current <= "Z") {
+      const previous = characters[index - 1]
+      const next = characters[index + 1]
+      const previousIsLower = previous !== undefined && previous >= "a" && previous <= "z"
+      const nextIsLower = next !== undefined && next >= "a" && next <= "z"
+      if (index > 0 && (previousIsLower || nextIsLower)) result += "-"
+      result += current.toLowerCase()
+    } else {
+      result += current
+    }
+  }
+  return result
+}
+
+export const renderOxlintDeclarations = (source: string): string => {
+  const pluginDeclaration = /^type LintPluginOptionsSchema = ([^;\n]+);$/m
+  const pluginMatches = source.match(new RegExp(pluginDeclaration.source, "gm"))
+  if (pluginMatches?.length !== 1) {
+    throw new PatcherError({ reason: "Unable to locate the Oxlint plugin declaration." })
+  }
+  if (pluginMatches[0]!.includes('"effecttsgo"')) {
+    throw new PatcherError({ reason: "The Oxlint declaration already contains the effecttsgo plugin." })
+  }
+
+  const ruleMapMarker = "interface DummyRuleMap {\n"
+  if (source.split(ruleMapMarker).length !== 2) {
+    throw new PatcherError({ reason: "Unable to locate the Oxlint rule map declaration." })
+  }
+  const effectRules = metadataJson.rules
+    .map(({ name }) => `  "effecttsgo/${toKebabCase(name)}"?: RuleNoConfig;`)
+    .sort()
+    .join("\n")
+
+  return source
+    .replace(pluginDeclaration, 'type LintPluginOptionsSchema = "effecttsgo" | $1;')
+    .replace(ruleMapMarker, `${ruleMapMarker}${effectRules}\n`)
+}
+
+const resolveOxlintDeclarations = (target: DiscoveredBinary) => Effect.gen(function*() {
+  const fs = yield* FileSystem.FileSystem
+  const path = yield* Path.Path
+  const source = yield* fs.readFileString(target.binaryPath).pipe(
+    Effect.mapError((error) => new PatcherError({
+      reason: `Unable to read Oxlint declarations at ${target.binaryPath}: ${error.message}`
+    }))
+  )
+  const replacement = yield* Effect.try({
+    try: () => renderOxlintDeclarations(source),
+    catch: (error) => error instanceof PatcherError
+      ? error
+      : new PatcherError({ reason: `Unable to generate Oxlint declarations: ${String(error)}` })
+  })
+  const replacementPath = yield* fs.makeTempFileScoped({ prefix: "effect-tsgo-oxlint-", suffix: ".d.ts" }).pipe(
+    Effect.mapError((error) => new PatcherError({
+      reason: `Unable to create a temporary Oxlint declaration file: ${error.message}`
+    }))
+  )
+  yield* fs.writeFileString(replacementPath, replacement).pipe(
+    Effect.mapError((error) => new PatcherError({
+      reason: `Unable to write generated Oxlint declarations at ${replacementPath}: ${error.message}`
+    }))
+  )
+  return { path: replacementPath }
+})
 
 const resolvePlatformPackage = (target: DiscoveredBinary) => Effect.gen(function*() {
   const path = yield* Path.Path
@@ -61,6 +137,7 @@ const resolvePlatformPackage = (target: DiscoveredBinary) => Effect.gen(function
 export const resolveReplacement: ReplacementResolver = (target) => Effect.gen(function*() {
   const fs = yield* FileSystem.FileSystem
   const path = yield* Path.Path
+  if (target.component === "oxlint-dts") return yield* resolveOxlintDeclarations(target)
   const platform = yield* resolvePlatformPackage(target)
   const replacementPath = path.join(
     platform.packageDir,
@@ -129,7 +206,7 @@ export const preparePatch = (
       sourcePath: replacementPath,
       destinationPath: target.binaryPath
     })
-    if (!target.binaryPath.endsWith(".node")) {
+    if (!target.binaryPath.endsWith(".node") && target.component !== "oxlint-dts") {
       operations.push({ _tag: "Chmod", path: target.binaryPath, mode: 0o755 })
     }
   }
@@ -271,7 +348,9 @@ const discoverSelected = (
   preferredTypescriptPackage?: string
 ) => Effect.gen(function*() {
   const discovered = yield* discoverBinaries(cwd, preferredTypescriptPackage)
-  return yield* requireComponents(selectComponents(discovered, components), components)
+  const selectedComponents = new Set(components)
+  if (selectedComponents.has("oxlint")) selectedComponents.add("oxlint-dts")
+  return yield* requireComponents(selectComponents(discovered, selectedComponents), selectedComponents)
 })
 
 const changedTargets = (targets: ReadonlyArray<DiscoveredBinary>, skipped: ReadonlyArray<SkippedTarget>) => {

--- a/_packages/tsgo/src/patcher/types.ts
+++ b/_packages/tsgo/src/patcher/types.ts
@@ -1,4 +1,4 @@
-export type Component = "typescript" | "oxlint" | "oxlint-tsgolint"
+export type Component = "typescript" | "oxlint" | "oxlint-dts" | "oxlint-tsgolint"
 
 export interface DiscoveredBinary {
   readonly component: Component

--- a/_packages/tsgo/test/experimental-oxlint.test.ts
+++ b/_packages/tsgo/test/experimental-oxlint.test.ts
@@ -46,7 +46,7 @@ describe("experimental Oxlint discovery", () => {
   it("returns normalized binaries without resolving Effect artifacts", async () => {
     const directory = await makeTemporaryDirectory()
     const platform = experimentalOxlintTarget(process.platform, process.arch, true)
-    await writePackage(directory, "oxlint", { version: "1.0.0" })
+    const oxlintDirectory = await writePackage(directory, "oxlint", { version: "1.0.0" })
     await writePackage(directory, "oxlint-tsgolint", { version: "2.0.0" })
     const bindingDirectory = await writePackage(directory, platform.oxlintPackage, {
       version: "1.0.1",
@@ -63,6 +63,12 @@ describe("experimental Oxlint discovery", () => {
         packageName: platform.oxlintPackage,
         packageVersion: "1.0.1",
         binaryPath: join(bindingDirectory, "oxlint.node")
+      },
+      {
+        component: "oxlint-dts",
+        packageName: "oxlint",
+        packageVersion: "1.0.0",
+        binaryPath: join(oxlintDirectory, "dist", "index.d.ts")
       },
       {
         component: "oxlint-tsgolint",
@@ -94,7 +100,7 @@ describe("experimental Oxlint discovery", () => {
     const directory = await makeTemporaryDirectory()
     const platform = experimentalOxlintTarget(process.platform, process.arch, true)
     const vitePlusDirectory = await writePackage(directory, "vite-plus", { version: "1.0.0" })
-    await writePackage(vitePlusDirectory, "oxlint", { version: "1.0.0" })
+    const oxlintDirectory = await writePackage(vitePlusDirectory, "oxlint", { version: "1.0.0" })
     await writePackage(vitePlusDirectory, "oxlint-tsgolint", { version: "2.0.0" })
     const bindingDirectory = await writePackage(vitePlusDirectory, platform.oxlintPackage, {
       version: "1.0.1",
@@ -115,6 +121,12 @@ describe("experimental Oxlint discovery", () => {
         packageName: platform.oxlintPackage,
         packageVersion: "1.0.1",
         binaryPath: join(bindingDirectory, "oxlint.node")
+      },
+      {
+        component: "oxlint-dts",
+        packageName: "oxlint",
+        packageVersion: "1.0.0",
+        binaryPath: join(oxlintDirectory, "dist", "index.d.ts")
       },
       {
         component: "oxlint-tsgolint",

--- a/_packages/tsgo/test/patcher.test.ts
+++ b/_packages/tsgo/test/patcher.test.ts
@@ -2,6 +2,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
+import * as Scope from "effect/Scope"
 import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -12,7 +13,9 @@ import {
   PatcherError,
   preparePatch,
   prepareUnpatch,
-  ReplacementUnavailableError
+  renderOxlintDeclarations,
+  ReplacementUnavailableError,
+  resolveReplacement
 } from "../src/patcher/index.js"
 
 const temporaryDirectories: Array<string> = []
@@ -23,8 +26,8 @@ const makeTemporaryDirectory = async () => {
   return directory
 }
 
-const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
-  Effect.runPromise(effect.pipe(Effect.provide(NodeServices.layer)))
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path | Scope.Scope>) =>
+  Effect.runPromise(Effect.scoped(effect).pipe(Effect.provide(NodeServices.layer)))
 
 afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
@@ -33,7 +36,7 @@ afterEach(async () => {
 describe("patcher", () => {
   it("prepares ordered rename and copy operations for every target", async () => {
     const directory = await makeTemporaryDirectory()
-    const first = join(directory, "first.node")
+    const first = join(directory, "first.d.ts")
     const second = join(directory, "second")
     const firstReplacement = join(directory, "first-effect")
     const secondReplacement = join(directory, "second-effect")
@@ -44,14 +47,14 @@ describe("patcher", () => {
       writeFile(secondReplacement, "second-effect")
     ])
     const targets: ReadonlyArray<DiscoveredBinary> = [
-      { component: "oxlint", packageName: "oxlint", packageVersion: "1", binaryPath: first },
+      { component: "oxlint-dts", packageName: "oxlint", packageVersion: "1", binaryPath: first },
       { component: "oxlint-tsgolint", packageName: "oxlint-tsgolint", packageVersion: "2", binaryPath: second }
     ]
 
     const plan = await run(preparePatch(targets, {
       skipMissing: false,
       resolveReplacement: (target) => Effect.succeed({
-        path: target.component === "oxlint" ? firstReplacement : secondReplacement
+        path: target.component === "oxlint-dts" ? firstReplacement : secondReplacement
       })
     }))
     expect(plan.operations).toEqual([
@@ -61,6 +64,44 @@ describe("patcher", () => {
       { _tag: "Copy", sourcePath: secondReplacement, destinationPath: second },
       { _tag: "Chmod", path: second, mode: 0o755 }
     ])
+  })
+
+  it("generates an Oxlint declaration replacement in the temporary directory", async () => {
+    const directory = await makeTemporaryDirectory()
+    const declarationPath = join(directory, "index.d.ts")
+    await writeFile(declarationPath, [
+      'type LintPluginOptionsSchema = "eslint" | "typescript";',
+      "type RuleNoConfig = unknown;",
+      "interface DummyRuleMap {",
+      '  "eslint/no-unused-vars"?: RuleNoConfig;',
+      "}",
+      ""
+    ].join("\n"))
+    const target: DiscoveredBinary = {
+      component: "oxlint-dts",
+      packageName: "oxlint",
+      packageVersion: "1.0.0",
+      binaryPath: declarationPath
+    }
+
+    const replacement = await run(Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const resolved = yield* resolveReplacement(target)
+      return { path: resolved.path, source: yield* fs.readFileString(resolved.path) }
+    }))
+    expect(replacement.path).not.toBe(declarationPath)
+    expect(replacement.source).toContain(
+      'type LintPluginOptionsSchema = "effecttsgo" | "eslint" | "typescript";'
+    )
+    expect(replacement.source).toContain('"effecttsgo/floating-effect"?: RuleNoConfig;')
+    expect(replacement.source).toContain('"eslint/no-unused-vars"?: RuleNoConfig;')
+    await expect(access(replacement.path)).rejects.toThrow()
+  })
+
+  it("rejects declarations whose expected anchors changed", () => {
+    expect(() => renderOxlintDeclarations("interface OtherRuleMap {}\n")).toThrow(
+      "Unable to locate the Oxlint plugin declaration."
+    )
   })
 
   it("preflights the whole plan without mutation", async () => {


### PR DESCRIPTION
## Summary

- discover `oxlint/dist/index.d.ts` as an internal `oxlint-dts` patch target
- generate a scoped temporary replacement that adds the `effecttsgo` plugin and all Effect rule names
- patch and restore the declaration through the existing transactional backup flow
- grant the reusable release-matrix workflow the caller-level `contents: read` permission it requires

## Example

```ts
import { defineConfig } from "oxlint"

export default defineConfig({
  plugins: ["effecttsgo"],
  rules: {
    "effecttsgo/floating-effect": "warn"
  }
})
```

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `git diff --check`
- GitHub accepted the updated workflows and queued Validate and Validate Oxlint

Tests were not run as requested.