### PR TITLE
Fix Vite+ Oxlint setup handling

### DIFF
--- a/.changeset/calm-tools-skip.md
+++ b/.changeset/calm-tools-skip.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Avoid installing redundant Oxlint dependencies when Vite+ is present and identify already-patched components in skip messages.

--- a/_packages/tsgo/src/cli/setup/assessment.ts
+++ b/_packages/tsgo/src/cli/setup/assessment.ts
@@ -12,7 +12,8 @@ import {
   LSP_PLUGIN_NAME,
   isNativeTypescriptVersion,
   OXLINT_PACKAGE_NAME,
-  OXLINT_TSGOLINT_PACKAGE_NAME
+  OXLINT_TSGOLINT_PACKAGE_NAME,
+  VITE_PLUS_PACKAGE_NAME
 } from "./consts.js"
 import { getPatchIntegrations, hasPatchCommand } from "./patch-command.js"
 import type { RuleSeverity } from "./rule-info.js"
@@ -121,6 +122,7 @@ const assessPackageJson = (
   const lspVersion = assessDependency(LSP_PACKAGE_NAME)
   const oxlintVersion = assessDependency(OXLINT_PACKAGE_NAME)
   const oxlintTsgolintVersion = assessDependency(OXLINT_TSGOLINT_PACKAGE_NAME)
+  const vitePlusVersion = assessDependency(VITE_PLUS_PACKAGE_NAME)
   let typescriptVersion = Option.none<PackageDependency>()
   for (const packageName of defaultTypescriptPackageNames) {
     const typescriptDep = assessDependency(packageName)
@@ -148,6 +150,7 @@ const assessPackageJson = (
     typescriptVersion,
     oxlintVersion,
     oxlintTsgolintVersion,
+    vitePlusVersion,
     prepareScript
   }
 }

--- a/_packages/tsgo/src/cli/setup/changes.ts
+++ b/_packages/tsgo/src/cli/setup/changes.ts
@@ -271,6 +271,7 @@ const computePackageJsonChanges = (
         ] as const) {
           if (
             target.integrations.includes("oxlint") &&
+            Option.isNone(current.vitePlusVersion) &&
             Option.isNone(currentDependency) &&
             Option.isSome(targetDependency) &&
             targetDependency.value.dependencyType === dependencyType
@@ -315,6 +316,7 @@ const computePackageJsonChanges = (
         targetDependency: Option.Option<PackageDependency>
       ) => {
         if (Option.isNone(targetDependency)) return
+        if (Option.isNone(currentDependency) && Option.isSome(current.vitePlusVersion)) return
         if (
           Option.isSome(currentDependency) &&
           currentDependency.value.version === targetDependency.value.version &&

--- a/_packages/tsgo/src/cli/setup/consts.ts
+++ b/_packages/tsgo/src/cli/setup/consts.ts
@@ -6,6 +6,7 @@ export const defaultTypescriptPackageNames = ["typescript", "@typescript/native"
 export const PATCH_COMMAND = "effect-tsgo patch"
 export const OXLINT_PACKAGE_NAME = "oxlint"
 export const OXLINT_TSGOLINT_PACKAGE_NAME = "oxlint-tsgolint"
+export const VITE_PLUS_PACKAGE_NAME = "vite-plus"
 
 /**
  * `typescript` package versions >= 7 ship the native Go-ported binary that this

--- a/_packages/tsgo/src/cli/setup/target-prompt.ts
+++ b/_packages/tsgo/src/cli/setup/target-prompt.ts
@@ -43,7 +43,8 @@ export const gatherTargetState = (
           title: "Oxlint type-aware rules",
           value: "oxlint" as Integration,
           selected: Option.isSome(assessment.packageJson.oxlintVersion) ||
-            Option.isSome(assessment.packageJson.oxlintTsgolintVersion)
+            Option.isSome(assessment.packageJson.oxlintTsgolintVersion) ||
+            Option.isSome(assessment.packageJson.vitePlusVersion)
         }
       ]
     })
@@ -194,7 +195,10 @@ export const gatherTargetState = (
             packageName: defaultTypescriptPackageName
           }))
           : assessment.packageJson.typescriptVersion,
-        oxlintVersion: useOxlint
+        oxlintVersion: useOxlint && (
+            Option.isSome(assessment.packageJson.oxlintVersion) ||
+            Option.isNone(assessment.packageJson.vitePlusVersion)
+          )
           ? Option.some({
             dependencyType: Option.match(assessment.packageJson.oxlintVersion, {
               onNone: () => lspDependencyType,
@@ -203,7 +207,10 @@ export const gatherTargetState = (
             version: context.defaultOxlintVersion
           })
           : assessment.packageJson.oxlintVersion,
-        oxlintTsgolintVersion: useOxlint
+        oxlintTsgolintVersion: useOxlint && (
+            Option.isSome(assessment.packageJson.oxlintTsgolintVersion) ||
+            Option.isNone(assessment.packageJson.vitePlusVersion)
+          )
           ? Option.some({
             dependencyType: Option.match(assessment.packageJson.oxlintTsgolintVersion, {
               onNone: () => lspDependencyType,

--- a/_packages/tsgo/src/cli/setup/types.ts
+++ b/_packages/tsgo/src/cli/setup/types.ts
@@ -45,6 +45,7 @@ export namespace Assessment {
     readonly typescriptVersion: Option.Option<PackageDependency>
     readonly oxlintVersion: Option.Option<PackageDependency>
     readonly oxlintTsgolintVersion: Option.Option<PackageDependency>
+    readonly vitePlusVersion: Option.Option<PackageDependency>
     readonly prepareScript: Option.Option<{
       readonly script: string
       readonly hasPatch: boolean

--- a/_packages/tsgo/src/patcher/index.ts
+++ b/_packages/tsgo/src/patcher/index.ts
@@ -183,7 +183,7 @@ export const preparePatch = (
       skipped.push({
         target,
         reason: "already-patched",
-        message: `Backup already exists at ${backupPath}; ${target.component} is already patched.`
+        message: `${target.component} skipped because backup already exists at ${backupPath}.`
       })
       continue
     }

--- a/_packages/tsgo/test/patcher.test.ts
+++ b/_packages/tsgo/test/patcher.test.ts
@@ -128,8 +128,8 @@ describe("patcher", () => {
     await writeFile(`${targetPath}.original`, "original")
     await writeFile(replacementPath, "replacement")
     const target: DiscoveredBinary = {
-      component: "oxlint",
-      packageName: "oxlint",
+      component: "oxlint-tsgolint",
+      packageName: "oxlint-tsgolint",
       packageVersion: "1",
       binaryPath: targetPath
     }
@@ -139,6 +139,9 @@ describe("patcher", () => {
     }))
     expect(plan.operations).toEqual([])
     expect(plan.skipped[0]?.reason).toBe("already-patched")
+    expect(plan.skipped[0]?.message).toBe(
+      `oxlint-tsgolint skipped because backup already exists at ${targetPath}.original.`
+    )
     await expect(access(`${targetPath}.original.1`)).rejects.toThrow()
   })
 

--- a/_packages/tsgo/test/setup/changes.test.ts
+++ b/_packages/tsgo/test/setup/changes.test.ts
@@ -257,6 +257,26 @@ describe("computeChanges", () => {
     }))
   })
 
+  it.each(["dependencies", "devDependencies"] as const)(
+    "should assess vite-plus from %s",
+    (dependencyType) => {
+      const assessment = assess({
+        packageJson: {
+          fileName: "/test/package.json",
+          text: JSON.stringify({ [dependencyType]: { "vite-plus": "^0.2.8" } })
+        },
+        tsconfig: { fileName: "/test/tsconfig.json", text: "{}" },
+        oxlintConfig: Option.none(),
+        vscodeSettings: Option.none()
+      })
+
+      expect(assessment.packageJson.vitePlusVersion).toEqual(Option.some({
+        dependencyType,
+        version: "^0.2.8"
+      }))
+    }
+  )
+
   it("should pin both Oxlint dependencies when enabling the integration", () => {
     const result = runComputeChanges({
       integrations: ["oxlint"],
@@ -272,6 +292,62 @@ describe("computeChanges", () => {
     expect(insertedText).toContain('"oxlint": "1.77.0"')
     expect(insertedText).toContain('"oxlint-tsgolint": "7.0.2001"')
     expect(insertedText).toContain("effect-tsgo patch --no-typescript --oxlint")
+  })
+
+  it.each(["dependencies", "devDependencies"] as const)(
+    "should not add Oxlint dependencies when vite-plus is in %s",
+    (dependencyType) => {
+      const packageJsonText = JSON.stringify({
+        name: "test-project",
+        [dependencyType]: {
+          "vite-plus": "^0.2.8"
+        }
+      }, null, 2)
+      const result = runComputeChanges({
+        packageJsonText,
+        integrations: ["oxlint"],
+        typescriptVersion: null,
+        oxlintVersion: { dependencyType, version: "1.77.0" },
+        oxlintTsgolintVersion: { dependencyType, version: "7.0.2001" }
+      })
+      const packageJsonChange = result.codeActions
+        .flatMap((action) => action.changes)
+        .find((change) => change.fileName === "/test/package.json")
+      const updated = applyTextChanges(packageJsonText, packageJsonChange?.textChanges ?? [])
+
+      const parsed = JSON.parse(updated)
+      expect(parsed[dependencyType]["vite-plus"]).toBe("^0.2.8")
+      expect(parsed.dependencies?.oxlint).toBeUndefined()
+      expect(parsed.dependencies?.["oxlint-tsgolint"]).toBeUndefined()
+      expect(parsed.devDependencies?.oxlint).toBeUndefined()
+      expect(parsed.devDependencies?.["oxlint-tsgolint"]).toBeUndefined()
+      expect(updated).toContain("effect-tsgo patch --no-typescript --oxlint")
+    }
+  )
+
+  it("should continue to pin explicit Oxlint dependencies alongside vite-plus", () => {
+    const packageJsonText = JSON.stringify({
+      name: "test-project",
+      devDependencies: {
+        "vite-plus": "^0.2.8",
+        "oxlint": "1.76.0",
+        "oxlint-tsgolint": "7.0.2000"
+      }
+    }, null, 2)
+    const result = runComputeChanges({
+      packageJsonText,
+      integrations: ["oxlint"],
+      typescriptVersion: null,
+      oxlintVersion: { dependencyType: "devDependencies", version: "1.77.0" },
+      oxlintTsgolintVersion: { dependencyType: "devDependencies", version: "7.0.2001" }
+    })
+    const packageJsonChange = result.codeActions
+      .flatMap((action) => action.changes)
+      .find((change) => change.fileName === "/test/package.json")
+    const updated = JSON.parse(applyTextChanges(packageJsonText, packageJsonChange?.textChanges ?? []))
+
+    expect(updated.devDependencies.oxlint).toBe("1.77.0")
+    expect(updated.devDependencies["oxlint-tsgolint"]).toBe("7.0.2001")
   })
 
   it("should prepend the Effect Oxlint schema to an existing .oxlintrc.json", () => {

--- a/_packages/tsgo/test/setup/diff-renderer.test.ts
+++ b/_packages/tsgo/test/setup/diff-renderer.test.ts
@@ -84,6 +84,7 @@ function makeAssessmentState(opts?: {
       typescriptVersion: Option.none(),
       oxlintVersion: Option.none(),
       oxlintTsgolintVersion: Option.none(),
+      vitePlusVersion: Option.none(),
       prepareScript: Option.none()
     },
     tsconfig: {


### PR DESCRIPTION
## Summary

- detect `vite-plus` in dependencies and devDependencies during setup
- avoid adding redundant direct `oxlint` and `oxlint-tsgolint` dependencies when Vite+ provides them
- preserve pinning for explicit direct Oxlint dependencies
- prefix already-patched skip messages with the component name

## Behavior

Given a project with `vite-plus` installed, selecting the Oxlint integration now configures `effect-tsgo patch --oxlint` without adding direct Oxlint packages. Existing direct Oxlint package declarations continue to be managed.

Already-patched output now reads, for example:

```text
oxlint-tsgolint skipped because backup already exists at <path>.
```

## Testing

Not rerun as part of the PR workflow, per request.