### PR TITLE
Update Effect beta to 4.0.0-beta.103

### DIFF
--- a/.changeset/update-effect-beta-103.md
+++ b/.changeset/update-effect-beta-103.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Update Effect v4 dependencies and embedded test fixtures to `4.0.0-beta.103`, and suppress auto-imports from blocked Effect internal modules.

--- a/_packages/tsgo/package.json
+++ b/_packages/tsgo/package.json
@@ -50,12 +50,12 @@
     "@effect/tsgo-darwin-arm64": "workspace:*"
   },
   "devDependencies": {
-    "@effect/platform-node": "^4.0.0-beta.101",
-    "@effect/platform-node-shared": "^4.0.0-beta.101",
+    "@effect/platform-node": "^4.0.0-beta.103",
+    "@effect/platform-node-shared": "^4.0.0-beta.103",
     "@types/node": "^24.3.0",
     "tsdown": "^0.20.1",
     "typescript": "^5.9.2",
-    "effect": "^4.0.0-beta.101",
+    "effect": "^4.0.0-beta.103",
     "vitest": "^3.2.1"
   }
 }

--- a/_tools/repoctl/package.json
+++ b/_tools/repoctl/package.json
@@ -11,8 +11,8 @@
     "test": "node --test test/*.test.ts"
   },
   "dependencies": {
-    "@effect/platform-node": "^4.0.0-beta.101",
-    "effect": "^4.0.0-beta.101",
+    "@effect/platform-node": "^4.0.0-beta.103",
+    "effect": "^4.0.0-beta.103",
     "semver": "^7.7.2"
   },
   "devDependencies": {

--- a/internal/autoimportstyle/stylepolicy.go
+++ b/internal/autoimportstyle/stylepolicy.go
@@ -112,6 +112,11 @@ func (sp *stylePolicy) Apply(export *autoimport.Export, fix *autoimport.Fix) *au
 	if pkgName == "" {
 		return fix
 	}
+	if pkgName == "effect" &&
+		(sp.namespacePackages[pkgName] || sp.barrelPackages[pkgName]) &&
+		strings.HasPrefix(fix.ModuleSpecifier, "effect/internal/") {
+		return nil
+	}
 
 	// Check namespace-import packages
 	if sp.namespacePackages[pkgName] {

--- a/internal/autoimportstyle/stylepolicy_test.go
+++ b/internal/autoimportstyle/stylepolicy_test.go
@@ -106,6 +106,20 @@ func TestApplyNamespaceRewrite(t *testing.T) {
 	}
 }
 
+func TestApplySuppressesEffectInternalImport(t *testing.T) {
+	t.Parallel()
+	sp := newStylePolicy(&etscore.ResolvedEffectPluginOptions{
+		NamespaceImportPackages: []string{"effect"},
+	})
+
+	export := makeExport("effect", "effect/internal/schema/parser", "")
+	fix := makeAddNewFix(lsproto.ImportKindNamed, "effect/internal/schema/parser", "succeed")
+
+	if result := sp.Apply(export, fix); result != nil {
+		t.Errorf("expected blocked Effect internal import to be suppressed, got %#v", result)
+	}
+}
+
 func TestApplyNamespaceRewriteFromAddToExisting(t *testing.T) {
 	t.Parallel()
 	sp := newStylePolicy(&etscore.ResolvedEffectPluginOptions{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,17 +18,17 @@ importers:
   _packages/tsgo:
     devDependencies:
       '@effect/platform-node':
-        specifier: ^4.0.0-beta.101
-        version: 4.0.0-beta.101(effect@4.0.0-beta.101)(ioredis@5.9.2)
+        specifier: ^4.0.0-beta.103
+        version: 4.0.0-beta.103(effect@4.0.0-beta.103)(ioredis@5.9.2)
       '@effect/platform-node-shared':
-        specifier: ^4.0.0-beta.101
-        version: 4.0.0-beta.101(effect@4.0.0-beta.101)
+        specifier: ^4.0.0-beta.103
+        version: 4.0.0-beta.103(effect@4.0.0-beta.103)
       '@types/node':
         specifier: ^24.3.0
         version: 24.10.13
       effect:
-        specifier: ^4.0.0-beta.101
-        version: 4.0.0-beta.101
+        specifier: ^4.0.0-beta.103
+        version: 4.0.0-beta.103
       tsdown:
         specifier: ^0.20.1
         version: 0.20.3(typescript@5.9.3)
@@ -78,11 +78,11 @@ importers:
   _tools/repoctl:
     dependencies:
       '@effect/platform-node':
-        specifier: ^4.0.0-beta.101
-        version: 4.0.0-beta.101(effect@4.0.0-beta.101)(ioredis@5.9.2)
+        specifier: ^4.0.0-beta.103
+        version: 4.0.0-beta.103(effect@4.0.0-beta.103)(ioredis@5.9.2)
       effect:
-        specifier: ^4.0.0-beta.101
-        version: 4.0.0-beta.101
+        specifier: ^4.0.0-beta.103
+        version: 4.0.0-beta.103
       semver:
         specifier: ^7.7.2
         version: 7.8.5
@@ -145,8 +145,8 @@ importers:
   testdata/tests/effect-v4:
     dependencies:
       '@effect/vitest':
-        specifier: 4.0.0-beta.101
-        version: 4.0.0-beta.101(effect@4.0.0-beta.101)(vitest@4.1.10(@types/node@22.19.15)(vite@7.3.1(@types/node@22.19.15)(yaml@2.9.0)))
+        specifier: 4.0.0-beta.103
+        version: 4.0.0-beta.103(effect@4.0.0-beta.103)(vitest@4.1.10(@types/node@22.19.15)(vite@7.3.1(@types/node@22.19.15)(yaml@2.9.0)))
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
@@ -157,8 +157,8 @@ importers:
         specifier: 4.1.10
         version: 4.1.10
       effect:
-        specifier: 4.0.0-beta.101
-        version: 4.0.0-beta.101
+        specifier: 4.0.0-beta.103
+        version: 4.0.0-beta.103
       fast-check:
         specifier: ^4.4.0
         version: 4.5.3
@@ -178,8 +178,8 @@ importers:
         specifier: ^22.0.0
         version: 22.19.15
       effect:
-        specifier: 4.0.0-beta.101
-        version: 4.0.0-beta.101
+        specifier: 4.0.0-beta.103
+        version: 4.0.0-beta.103
       fast-check:
         specifier: ^4.4.0
         version: 4.5.3
@@ -196,8 +196,8 @@ importers:
         specifier: ^22.0.0
         version: 22.19.15
       effect:
-        specifier: 4.0.0-beta.101
-        version: 4.0.0-beta.101
+        specifier: 4.0.0-beta.103
+        version: 4.0.0-beta.103
       fast-check:
         specifier: ^4.4.0
         version: 4.5.3
@@ -208,8 +208,8 @@ importers:
   testdata/tests/oxlint:
     dependencies:
       effect:
-        specifier: 4.0.0-beta.101
-        version: 4.0.0-beta.101
+        specifier: 4.0.0-beta.103
+        version: 4.0.0-beta.103
 
 packages:
 
@@ -303,17 +303,17 @@ packages:
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
-  '@effect/platform-node-shared@4.0.0-beta.101':
-    resolution: {integrity: sha512-g4L7XiyJSNJLJVhlslyg2zBCQsoKQf1y1gd+Yfd+3wD9ymC+m7ymbd/5FGqnT1aXV6E2AwRr4D/R1eyRUikvWQ==}
+  '@effect/platform-node-shared@4.0.0-beta.103':
+    resolution: {integrity: sha512-0aCZMBid5ifqmY55TkfCDLaGTIM8qu3bNFUW7qL9vh/7jFOkaIAMX2MA8muG4deqW17XWxawddWu4v0fK+UW3g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.101
+      effect: ^4.0.0-beta.103
 
-  '@effect/platform-node@4.0.0-beta.101':
-    resolution: {integrity: sha512-pClk7dmMtHgM6Byu7CzGfrPvZ1/4BwmrRlCg2Op+iJozMkwVUxq8v4beK8b9SvxsliJjHZFznjvkVLX7LQjBqw==}
+  '@effect/platform-node@4.0.0-beta.103':
+    resolution: {integrity: sha512-VD8fbpendwFokMwzC7/MxazjhEVDihPC5NZtomYEyZwGaA1LXMvwP1y8pfXwfshUkG56TN4EMQqzu72c0B9FhA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.101
+      effect: ^4.0.0-beta.103
       ioredis: ^5.7.0
 
   '@effect/vitest@0.27.0':
@@ -322,11 +322,11 @@ packages:
       effect: ^3.19.0
       vitest: ^3.2.0
 
-  '@effect/vitest@4.0.0-beta.101':
-    resolution: {integrity: sha512-F5Ur8pZYti0xkZFyb4hPZt8RrKQ1XBoC28ZkKxc7N1iPbhE9fWOvlWA1NC2XlN2wWG08yb5g5jR53LdOxjlhpQ==}
+  '@effect/vitest@4.0.0-beta.103':
+    resolution: {integrity: sha512-Kz3gemVuJNAZ3e4V6A7BwAP87x2Av8LyHOlCjy9jbZzlncwJXO7Olk1Sje3hdKaet3wEl51A/0/89xJ2IYSgNg==}
     peerDependencies:
-      effect: ^4.0.0-beta.101
-      vitest: ^3.0.0 || ^4.0.0
+      effect: ^4.0.0-beta.103
+      vitest: ^4.1.0
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -952,8 +952,8 @@ packages:
   effect@3.19.19:
     resolution: {integrity: sha512-Yc8U/SVXo2dHnaP7zNBlAo83h/nzSJpi7vph6Hzyl4ulgMBIgPmz3UzOjb9sBgpFE00gC0iETR244sfXDNLHRg==}
 
-  effect@4.0.0-beta.101:
-    resolution: {integrity: sha512-HjowumlIo+orthn4jMlEJPuzIYPBV+uq/XiciHWhiedLsXQpWHdNJHO5d59BVDP5s1LPuvERcktwFqRXnJqnhA==}
+  effect@4.0.0-beta.103:
+    resolution: {integrity: sha512-pE8TxF4m2tQzVI+77dIlm3s+81TACV1AiX1JEkvY+zVuxgQQ8aGSkqXNJF6b/ST+coCSk5cUdbULpQ7sm4oHyw==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -1596,19 +1596,19 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@effect/platform-node-shared@4.0.0-beta.101(effect@4.0.0-beta.101)':
+  '@effect/platform-node-shared@4.0.0-beta.103(effect@4.0.0-beta.103)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.101
+      effect: 4.0.0-beta.103
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.101(effect@4.0.0-beta.101)(ioredis@5.9.2)':
+  '@effect/platform-node@4.0.0-beta.103(effect@4.0.0-beta.103)(ioredis@5.9.2)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.101(effect@4.0.0-beta.101)
-      effect: 4.0.0-beta.101
+      '@effect/platform-node-shared': 4.0.0-beta.103(effect@4.0.0-beta.103)
+      effect: 4.0.0-beta.103
       ioredis: 5.9.2
       mime: 4.1.0
       undici: 8.9.0
@@ -1621,9 +1621,9 @@ snapshots:
       effect: 3.19.19
       vitest: 3.2.4(@types/node@22.19.15)(yaml@2.9.0)
 
-  '@effect/vitest@4.0.0-beta.101(effect@4.0.0-beta.101)(vitest@4.1.10(@types/node@22.19.15)(vite@7.3.1(@types/node@22.19.15)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.103(effect@4.0.0-beta.103)(vitest@4.1.10(@types/node@22.19.15)(vite@7.3.1(@types/node@22.19.15)(yaml@2.9.0)))':
     dependencies:
-      effect: 4.0.0-beta.101
+      effect: 4.0.0-beta.103
       vitest: 4.1.10(@types/node@22.19.15)(vite@7.3.1(@types/node@22.19.15)(yaml@2.9.0))
 
   '@emnapi/core@1.8.1':
@@ -2077,7 +2077,7 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  effect@4.0.0-beta.101:
+  effect@4.0.0-beta.103:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.9.0

--- a/testdata/baselines/reference/effect-v4/classImplementsIssue.errors.txt
+++ b/testdata/baselines/reference/effect-v4/classImplementsIssue.errors.txt
@@ -10,6 +10,8 @@ Effect version: 4.0.0
         index: number = 1
         remaining: number = 1
     
+        close() {
+        }
         fastForward() {
         }
         take(): A | undefined {

--- a/testdata/baselines/reference/effect-v4/classImplementsIssue.flows.classImplementsIssue.mermaid
+++ b/testdata/baselines/reference/effect-v4/classImplementsIssue.flows.classImplementsIssue.mermaid
@@ -2,16 +2,17 @@ flowchart TB
   0[/"type: <br/>node: PubSub.PubSub.ReplayWindow"/]
   1[/"type: 1<br/>node: 1"/]
   2[/"type: 1<br/>node: 1"/]
-  3[["type: #40;#41; =#gt; void<br/>node: fastForward#40;#41; #123;#92;n    #125;"]]
-  4[["type: #40;#41; =#gt; A #124; undefined<br/>node: take#40;#41;: A #124; undefined #123;#92;n      return 1 as A#92;n    #125;"]]
-  5[/"type: A<br/>node: 1 as A"/]
-  6[["type: #40;n: number#41; =#gt; A#91;#93;<br/>node: takeN#40;n: number#41;: Array#lt;A#gt; #123;#92;n      return 1 as any#92;n    #125;"]]
-  7[/"type: any<br/>node: 1 as any"/]
-  8[["type: #40;#41; =#gt; A#91;#93;<br/>node: takeAll#40;#41;: Array#lt;A#gt; #123;#92;n      return 1 as any#92;n    #125;"]]
-  9[/"type: any<br/>node: 1 as any"/]
-  5 -->|"kind: potentialReturn"| 4
-  5 -->|"kind: usedBy"| 4
-  7 -->|"kind: potentialReturn"| 6
-  7 -->|"kind: usedBy"| 6
-  9 -->|"kind: potentialReturn"| 8
-  9 -->|"kind: usedBy"| 8
+  3[["type: #40;#41; =#gt; void<br/>node: close#40;#41; #123;#92;n    #125;"]]
+  4[["type: #40;#41; =#gt; void<br/>node: fastForward#40;#41; #123;#92;n    #125;"]]
+  5[["type: #40;#41; =#gt; A #124; undefined<br/>node: take#40;#41;: A #124; undefined #123;#92;n      return 1 as A#92;n    #125;"]]
+  6[/"type: A<br/>node: 1 as A"/]
+  7[["type: #40;n: number#41; =#gt; A#91;#93;<br/>node: takeN#40;n: number#41;: Array#lt;A#gt; #123;#92;n      return 1 as any#92;n    #125;"]]
+  8[/"type: any<br/>node: 1 as any"/]
+  9[["type: #40;#41; =#gt; A#91;#93;<br/>node: takeAll#40;#41;: Array#lt;A#gt; #123;#92;n      return 1 as any#92;n    #125;"]]
+  10[/"type: any<br/>node: 1 as any"/]
+  6 -->|"kind: potentialReturn"| 5
+  6 -->|"kind: usedBy"| 5
+  8 -->|"kind: potentialReturn"| 7
+  8 -->|"kind: usedBy"| 7
+  10 -->|"kind: potentialReturn"| 9
+  10 -->|"kind: usedBy"| 9

--- a/testdata/baselines/reference/effect-v4/classImplementsIssue.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/classImplementsIssue.quickfixes.txt
@@ -1,6 +1,6 @@
 === Quick Fix Inventory ===
 
-[D1] (12:11-12:12) TS6133: 'n' is declared but its value is never read.
+[D1] (14:11-14:12) TS6133: 'n' is declared but its value is never read.
   (no quick fixes)
 
 === Quick Fix Application Results ===

--- a/testdata/baselines/reference/effect-v4/missingReturnYieldStarFnUntraced.errors.txt
+++ b/testdata/baselines/reference/effect-v4/missingReturnYieldStarFnUntraced.errors.txt
@@ -24,7 +24,7 @@ Effect version: 4.0.0
     export const shouldNotComplainRegularFnUntraced = Effect.fnUntraced((a: string) => {
                                                                         ~~~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
-!!! related TS2771 /node_modules/effect/dist/Effect.d.ts(16984,9): The last overload is declared here.
+!!! related TS2771 /node_modules/effect/dist/Effect.d.ts(16514,9): The last overload is declared here.
         return Effect.fail(a)
     })
     

--- a/testdata/baselines/reference/effect-v4/outdatedApi.errors.txt
+++ b/testdata/baselines/reference/effect-v4/outdatedApi.errors.txt
@@ -132,7 +132,7 @@ Effect version: 4.0.0
     export const p_catchAllCause = Effect.catchAllCause(Effect.fail("err"), (_cause) => Effect.succeed(0))
                                           ~~~~~~~~~~~~~
 !!! error TS2551: Property 'catchAllCause' does not exist on type 'typeof import("/node_modules/effect/dist/Effect")'. Did you mean 'catchCause'?
-!!! related TS2728 /node_modules/effect/dist/Effect.d.ts(4878,22): 'catchCause' is declared here.
+!!! related TS2728 /node_modules/effect/dist/Effect.d.ts(4774,22): 'catchCause' is declared here.
                                           ~~~~~~~~~~~~~
 !!! warning TS377052: This project targets Effect v4, but this code uses the Effect v3 API `catchAllCause`. The referenced API belongs to the v3 surface rather than the configured v4 surface. Renamed to catchCause. effect(outdatedApi)
                                                                              ~~~~~~
@@ -142,7 +142,7 @@ Effect version: 4.0.0
     export const p_catchAllDefect = Effect.catchAllDefect(Effect.die("defect"), (_defect) => Effect.succeed(0))
                                            ~~~~~~~~~~~~~~
 !!! error TS2551: Property 'catchAllDefect' does not exist on type 'typeof import("/node_modules/effect/dist/Effect")'. Did you mean 'catchDefect'?
-!!! related TS2728 /node_modules/effect/dist/Effect.d.ts(5001,22): 'catchDefect' is declared here.
+!!! related TS2728 /node_modules/effect/dist/Effect.d.ts(4909,22): 'catchDefect' is declared here.
                                            ~~~~~~~~~~~~~~
 !!! warning TS377052: This project targets Effect v4, but this code uses the Effect v3 API `catchAllDefect`. The referenced API belongs to the v3 surface rather than the configured v4 surface. Renamed to catchDefect. effect(outdatedApi)
                                                                                  ~~~~~~~
@@ -168,7 +168,7 @@ Effect version: 4.0.0
     export const p_async = Effect.async<number>((resume) => {
                                   ~~~~~
 !!! error TS2551: Property 'async' does not exist on type 'typeof import("/node_modules/effect/dist/Effect")'. Did you mean 'sync'?
-!!! related TS2728 /node_modules/effect/dist/Effect.d.ts(1536,22): 'sync' is declared here.
+!!! related TS2728 /node_modules/effect/dist/Effect.d.ts(1408,22): 'sync' is declared here.
                                   ~~~~~
 !!! warning TS377052: This project targets Effect v4, but this code uses the Effect v3 API `async`. The referenced API belongs to the v3 surface rather than the configured v4 surface. Renamed to callback. Note: in v4 the callback receives a Scheduler as 'this' context. effect(outdatedApi)
                                                  ~~~~~~

--- a/testdata/tests/effect-v4-document-symbols/package.json
+++ b/testdata/tests/effect-v4-document-symbols/package.json
@@ -2,7 +2,7 @@
     "name": "effect-v4-document-symbols-tests",
     "private": true,
     "dependencies": {
-        "effect": "4.0.0-beta.101",
+        "effect": "4.0.0-beta.103",
         "@standard-schema/spec": "^1.1.0",
         "fast-check": "^4.4.0",
         "pure-rand": "^7.0.0",

--- a/testdata/tests/effect-v4-refactors/package.json
+++ b/testdata/tests/effect-v4-refactors/package.json
@@ -2,7 +2,7 @@
     "name": "effect-v4-refactors-tests",
     "private": true,
     "dependencies": {
-        "effect": "4.0.0-beta.101",
+        "effect": "4.0.0-beta.103",
         "@standard-schema/spec": "^1.1.0",
         "fast-check": "^4.4.0",
         "pure-rand": "^7.0.0",

--- a/testdata/tests/effect-v4/classImplementsIssue.ts
+++ b/testdata/tests/effect-v4/classImplementsIssue.ts
@@ -4,6 +4,8 @@ export class ReplayWindowImpl<A> implements PubSub.PubSub.ReplayWindow<A> {
     index: number = 1
     remaining: number = 1
 
+    close() {
+    }
     fastForward() {
     }
     take(): A | undefined {

--- a/testdata/tests/effect-v4/package.json
+++ b/testdata/tests/effect-v4/package.json
@@ -2,11 +2,11 @@
     "name": "effect-v4-tests",
     "private": true,
     "dependencies": {
-        "@effect/vitest": "4.0.0-beta.101",
+        "@effect/vitest": "4.0.0-beta.103",
         "@standard-schema/spec": "^1.1.0",
         "@types/node": "^22.0.0",
         "@vitest/runner": "4.1.10",
-        "effect": "4.0.0-beta.101",
+        "effect": "4.0.0-beta.103",
         "fast-check": "^4.4.0",
         "pure-rand": "^7.0.0",
         "vitest": "4.1.10"

--- a/testdata/tests/oxlint/package.json
+++ b/testdata/tests/oxlint/package.json
@@ -2,6 +2,6 @@
   "name": "oxlint-profile-tests",
   "private": true,
   "dependencies": {
-    "effect": "4.0.0-beta.101"
+    "effect": "4.0.0-beta.103"
   }
 }


### PR DESCRIPTION
## Summary

- update Effect v4, platform, and Vitest dependencies to `4.0.0-beta.103`
- align fixtures and baselines with beta.103, including `PubSub.ReplayWindow.close`
- suppress invalid style-rewritten imports from package-blocked `effect/internal/*` modules
- add a patch changeset

## Example

Beta.103 exposes `succeed` through an internal Schema parser declaration. Import-style rewriting no longer turns that candidate into invalid imports such as:

```ts
import * as parser from "effect/internal/schema/parser"
```

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`