### PR TITLE
feat: add non-interactive setup

### DIFF
--- a/.changeset/non-interactive-setup.md
+++ b/.changeset/non-interactive-setup.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": minor
+---
+
+Add a non-interactive `setup` workflow with explicit project, integration, diagnostic, editor, preview, and apply options. Setup now also recommends running the package manager install command whenever it changes `package.json`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ This project targets **Effect V4** (codename: "smol") primarily and also Effect 
 The setup of the TSGO version of the LSP can be performed via the command line interface:
 
 ```bash
+# Interactive and guided setup for human friends
 npx @effect/tsgo setup
+# Non-interactive, for LLM friends
+npx @effect/tsgo setup --help
 ```
 
 This will guide you through the installation process, which includes:

--- a/_packages/tsgo/src/cli/setup/changes.ts
+++ b/_packages/tsgo/src/cli/setup/changes.ts
@@ -980,6 +980,13 @@ export const computeChanges = (
   const packageJsonResult = computePackageJsonChanges(assessment.packageJson, target.packageJson)
   codeActions = [...codeActions, ...packageJsonResult.codeActions]
   messages = [...messages, ...packageJsonResult.messages]
+  if (packageJsonResult.codeActions.length > 0) {
+    messages = [
+      ...messages,
+      "`package.json` changed. Run your package manager's install command " +
+        "(for example, `pnpm install`, `npm install`, `yarn install`, or `bun install`)."
+    ]
+  }
 
   // Compute tsconfig changes
   const tsconfigResult = computeTsConfigChanges(
@@ -1090,6 +1097,24 @@ export const reviewAndApplyChanges = (
 
     if (!shouldProceed) {
       yield* Console.log(options?.cancelMessage ?? "No changes were made.")
+      return
+    }
+
+    yield* applyChanges(result, options)
+  })
+
+export const previewChanges = (result: ComputeChangesResult, assessmentState: Assessment.State) =>
+  renderCodeActions(result, assessmentState)
+
+export const applyChanges = (
+  result: ComputeChangesResult,
+  options?: {
+    readonly applyMessage?: string
+    readonly successMessage?: string
+  }
+) =>
+  Effect.gen(function*() {
+    if (result.codeActions.length === 0) {
       return
     }
 

--- a/_packages/tsgo/src/cli/setup/index.ts
+++ b/_packages/tsgo/src/cli/setup/index.ts
@@ -1,37 +1,68 @@
 import * as Effect from "effect/Effect"
+import * as Option from "effect/Option"
 import * as Path from "effect/Path"
 import * as Command from "effect/unstable/cli/Command"
 import * as Assessment from "./assessment.js"
 import * as Changes from "./changes.js"
-import { gatherTargetState } from "./target-prompt.js"
-import { selectTsConfigFile } from "./tsconfig-prompt.js"
+import {
+  hasNonInteractiveTargetFlags,
+  NonInteractiveSetupError,
+  resolveTargetOptions,
+  setupFlags
+} from "./options.js"
+import * as Target from "./target.js"
+import { gatherTargetOptions } from "./target-prompt.js"
+import { readTsConfigFile, selectTsConfigFile } from "./tsconfig-prompt.js"
 import * as upstreamJson from "../../../upstream.json" with { type: "json" }
 import * as pkgJson from "../../../package.json" with { type: "json" }
 
-export const setupCommand = Command.make("setup").pipe(
-  Command.withDescription("Setup @effect/tsgo for the given project using an interactive CLI."),
-  Command.withHandler(() =>
+export const setupCommand = Command.make("setup", setupFlags).pipe(
+  Command.withDescription("Setup @effect/tsgo for the given project."),
+  Command.withHandler((flags) =>
     Effect.gen(function*() {
       const path = yield* Path.Path
 
       const currentDir = path.resolve(process.cwd())
-      const tsconfigInput = yield* selectTsConfigFile(currentDir)
+      if (!flags.nonInteractive && hasNonInteractiveTargetFlags(flags)) {
+        return yield* Effect.fail(new NonInteractiveSetupError({
+          reason: "Setup choice flags require --non-interactive."
+        }))
+      }
+      if (flags.nonInteractive && Option.isNone(flags.project)) {
+        return yield* Effect.fail(new NonInteractiveSetupError({
+          reason: "Non-interactive setup requires --project."
+        }))
+      }
+      const tsconfigInput = Option.isSome(flags.project)
+        ? yield* readTsConfigFile(path.resolve(currentDir, flags.project.value))
+        : yield* selectTsConfigFile(currentDir)
 
       const assessmentInput = yield* Assessment.createAssessmentInput(currentDir, tsconfigInput)
       const assessmentState = Assessment.assess(assessmentInput)
-      const targetState = yield* gatherTargetState(assessmentState, {
+      const targetContext = {
         defaultLspVersion: pkgJson.version,
         defaultTypescriptVersion: upstreamJson.tags.typescript.latest,
         defaultOxlintVersion: upstreamJson.tags.oxlint.latest,
         defaultOxlintTsgolintVersion: upstreamJson.tags["oxlint-tsgolint"].latest,
         defaultSchemaPath: path.resolve(currentDir, "node_modules", pkgJson.name, "schema.json"),
         defaultOxlintrcSchemaPath: path.resolve(currentDir, "node_modules", pkgJson.name, "oxlint-schema.json")
-      })
+      }
+      const targetOptions = flags.nonInteractive
+        ? yield* resolveTargetOptions(assessmentState, flags)
+        : yield* gatherTargetOptions(assessmentState)
+      const targetState = yield* Target.create(assessmentState, targetContext, targetOptions)
       const result = Changes.computeChanges(assessmentState, targetState)
 
-      yield* Changes.reviewAndApplyChanges(result, assessmentState, {
-        cancelMessage: "Setup cancelled. No changes were made."
-      })
+      if (flags.apply) {
+        yield* Changes.previewChanges(result, assessmentState)
+        yield* Changes.applyChanges(result)
+      } else if (flags.nonInteractive) {
+        yield* Changes.previewChanges(result, assessmentState)
+      } else {
+        yield* Changes.reviewAndApplyChanges(result, assessmentState, {
+          cancelMessage: "Setup cancelled. No changes were made."
+        })
+      }
     })
   )
 )

--- a/_packages/tsgo/src/cli/setup/options.ts
+++ b/_packages/tsgo/src/cli/setup/options.ts
@@ -1,0 +1,210 @@
+import * as Data from "effect/Data"
+import * as Effect from "effect/Effect"
+import * as Option from "effect/Option"
+import * as Flag from "effect/unstable/cli/Flag"
+import {
+  applyPresetDiagnosticSeverities,
+  isPresetEnabled,
+  type DiagnosticPresetName
+} from "../presets.js"
+import { getAllPresets, getAllRules, type RuleSeverity } from "./rule-info.js"
+import type * as Target from "./target.js"
+import type { Assessment, Editor, Integration } from "./types.js"
+
+const dependencyTypes = ["devDependencies", "dependencies"] as const
+const severityNames = ["off", "suggestion", "message", "warning", "error"] as const
+
+export const setupFlags = {
+  project: Flag.file("project").pipe(
+    Flag.optional,
+    Flag.withDescription("The project tsconfig file to configure")
+  ),
+  nonInteractive: Flag.boolean("non-interactive").pipe(
+    Flag.withDefault(false),
+    Flag.withDescription("Never open an interactive prompt")
+  ),
+  acceptDefaults: Flag.boolean("accept-defaults").pipe(
+    Flag.withDefault(false),
+    Flag.withDescription("Use recommended defaults for unspecified setup choices")
+  ),
+  apply: Flag.boolean("apply").pipe(
+    Flag.withDefault(false),
+    Flag.withDescription("Apply changes without asking for confirmation")
+  ),
+  typescript: Flag.boolean("typescript").pipe(
+    Flag.optional,
+    Flag.withDescription("Configure the TypeScript language service integration")
+  ),
+  oxlint: Flag.boolean("oxlint").pipe(
+    Flag.optional,
+    Flag.withDescription("Configure the Oxlint type-aware rules integration")
+  ),
+  dependencyType: Flag.choice("dependency-type", dependencyTypes).pipe(
+    Flag.optional,
+    Flag.withDescription("Install @effect/tsgo in this dependency section")
+  ),
+  preset: Flag.string("preset").pipe(
+    Flag.atLeast(0),
+    Flag.withDescription("Enable a diagnostic preset; may be specified more than once")
+  ),
+  noPresets: Flag.boolean("no-presets").pipe(
+    Flag.withDefault(false),
+    Flag.withDescription("Do not select any diagnostic presets")
+  ),
+  diagnostic: Flag.string("diagnostic").pipe(
+    Flag.atLeast(0),
+    Flag.withDescription("Set a diagnostic severity as <rule>=<severity>; may be specified more than once")
+  ),
+  vscode: Flag.boolean("vscode").pipe(
+    Flag.optional,
+    Flag.withDescription("Configure VS Code-based editors")
+  ),
+  nvim: Flag.boolean("nvim").pipe(
+    Flag.optional,
+    Flag.withDescription("Show Neovim setup instructions")
+  ),
+  emacs: Flag.boolean("emacs").pipe(
+    Flag.optional,
+    Flag.withDescription("Show Emacs setup instructions")
+  )
+}
+
+export type SetupFlags = {
+  readonly [K in keyof typeof setupFlags]: typeof setupFlags[K] extends Flag.Flag<infer A> ? A : never
+}
+
+export class NonInteractiveSetupError extends Data.TaggedError("NonInteractiveSetupError")<{
+  readonly reason: string
+}> {
+  get message(): string {
+    return this.reason
+  }
+}
+
+const fail = (reason: string) => Effect.fail(new NonInteractiveSetupError({ reason }))
+
+export const hasNonInteractiveTargetFlags = (flags: SetupFlags): boolean =>
+  flags.acceptDefaults ||
+  Option.isSome(flags.typescript) ||
+  Option.isSome(flags.oxlint) ||
+  Option.isSome(flags.dependencyType) ||
+  flags.preset.length > 0 ||
+  flags.noPresets ||
+  flags.diagnostic.length > 0 ||
+  Option.isSome(flags.vscode) ||
+  Option.isSome(flags.nvim) ||
+  Option.isSome(flags.emacs)
+
+const currentDiagnosticSeverities = (assessment: Assessment.State) =>
+  Option.getOrElse(assessment.tsconfig.currentDiagnosticSeverities, () => ({}))
+
+const resolvePresets = (
+  assessment: Assessment.State,
+  flags: SetupFlags
+): Effect.Effect<ReadonlyArray<DiagnosticPresetName>, NonInteractiveSetupError> => {
+  if (flags.noPresets && flags.preset.length > 0) {
+    return fail("--no-presets cannot be combined with --preset.")
+  }
+
+  const presets = getAllPresets()
+  const presetNames = new Set(presets.map((preset) => preset.name))
+  const selected = flags.noPresets
+    ? []
+    : flags.preset.length > 0
+    ? flags.preset
+    : flags.acceptDefaults
+    ? presets
+      .filter((preset) => isPresetEnabled(preset.name, currentDiagnosticSeverities(assessment)))
+      .map((preset) => preset.name)
+    : []
+  const invalid = selected.find((name) => !presetNames.has(name))
+  return invalid === undefined
+    ? Effect.succeed(selected)
+    : fail(`Unknown diagnostic preset '${invalid}'. Available presets: ${[...presetNames].join(", ")}.`)
+}
+
+const applyDiagnosticOverrides = (
+  severities: Record<string, RuleSeverity>,
+  overrides: ReadonlyArray<string>
+): Effect.Effect<Record<string, RuleSeverity>, NonInteractiveSetupError> => {
+  const rulesByLowerCase = new Map(getAllRules().map((rule) => [rule.name.toLowerCase(), rule.name]))
+  const result = { ...severities }
+
+  for (const override of overrides) {
+    const separator = override.lastIndexOf("=")
+    const inputName = separator === -1 ? "" : override.slice(0, separator)
+    const severity = separator === -1 ? "" : override.slice(separator + 1)
+    const ruleName = rulesByLowerCase.get(inputName.toLowerCase())
+    if (ruleName === undefined || !severityNames.includes(severity as RuleSeverity)) {
+      return fail(
+        `Invalid diagnostic '${override}'. Expected <rule>=<severity>, where severity is one of ${severityNames.join(", ")}.`
+      )
+    }
+    result[ruleName] = severity as RuleSeverity
+  }
+
+  return Effect.succeed(result)
+}
+
+export const resolveTargetOptions = (
+  assessment: Assessment.State,
+  flags: SetupFlags
+): Effect.Effect<Target.Options, NonInteractiveSetupError> =>
+  Effect.gen(function*() {
+    if (!flags.acceptDefaults && (Option.isNone(flags.typescript) || Option.isNone(flags.oxlint))) {
+      return yield* fail(
+        "Non-interactive setup requires both integration flags or --accept-defaults. " +
+          "Pass --typescript/--no-typescript and --oxlint/--no-oxlint."
+      )
+    }
+
+    const defaultOxlint = Option.isSome(assessment.packageJson.oxlintVersion) ||
+      Option.isSome(assessment.packageJson.oxlintTsgolintVersion) ||
+      Option.isSome(assessment.packageJson.vitePlusVersion)
+    const integrations: Array<Integration> = []
+    if (Option.getOrElse(flags.typescript, () => flags.acceptDefaults)) {
+      integrations.push("typescript")
+    }
+    if (Option.getOrElse(flags.oxlint, () => flags.acceptDefaults && defaultOxlint)) {
+      integrations.push("oxlint")
+    }
+    const useTypescript = integrations.includes("typescript")
+    const hasTypescriptOnlyOverrides = flags.preset.length > 0 ||
+      flags.diagnostic.length > 0 ||
+      Option.getOrElse(flags.vscode, () => false) ||
+      Option.getOrElse(flags.nvim, () => false) ||
+      Option.getOrElse(flags.emacs, () => false)
+    if (!useTypescript && hasTypescriptOnlyOverrides) {
+      return yield* fail("Diagnostic presets, diagnostic overrides, and editor choices require --typescript.")
+    }
+
+    const dependencyType = Option.match(flags.dependencyType, {
+      onNone: () => Option.match(assessment.packageJson.lspVersion, {
+        onNone: () => "devDependencies" as const,
+        onSome: (dependency) => dependency.dependencyType
+      }),
+      onSome: (value) => value
+    })
+    if (integrations.length > 0 && Option.isNone(flags.dependencyType) && !flags.acceptDefaults) {
+      return yield* fail("Non-interactive setup requires --dependency-type unless --accept-defaults is used.")
+    }
+
+    const selectedPresets = useTypescript ? yield* resolvePresets(assessment, flags) : []
+    const presetSeverities = applyPresetDiagnosticSeverities(
+      currentDiagnosticSeverities(assessment),
+      selectedPresets
+    )
+    const diagnosticSeverities = yield* applyDiagnosticOverrides(presetSeverities, flags.diagnostic)
+    const editorSelections: ReadonlyArray<readonly [Option.Option<boolean>, Editor, boolean]> = [
+      [flags.vscode, "vscode", Option.isSome(assessment.vscodeSettings)],
+      [flags.nvim, "nvim", false],
+      [flags.emacs, "emacs", false]
+    ]
+    const editors = useTypescript
+      ? editorSelections.flatMap(([selection, editor, recommended]) =>
+        Option.getOrElse(selection, () => flags.acceptDefaults && recommended) ? [editor] : []
+      )
+      : []
+
+    return { integrations, dependencyType, diagnosticSeverities, editors }
+  })

--- a/_packages/tsgo/src/cli/setup/target-prompt.ts
+++ b/_packages/tsgo/src/cli/setup/target-prompt.ts
@@ -1,36 +1,25 @@
 import * as Effect from "effect/Effect"
 import * as Option from "effect/Option"
-import * as Path from "effect/Path"
 import type * as Terminal from "effect/Terminal"
 import * as Prompt from "effect/unstable/cli/Prompt"
 import { applyPresetDiagnosticSeverities, type DiagnosticPresetName, isPresetEnabled } from "../presets.js"
-import { defaultTypescriptPackageNames } from "./consts.js"
-import type { Assessment, Editor, Integration, Target } from "./types.js"
+import * as Target from "./target.js"
+import type { Assessment, Editor, Integration } from "./types.js"
 import { getAllPresets, getAllRules } from "./rule-info.js"
 import { createRulePrompt } from "./rule-prompt.js"
 
 /**
  * Context input for gathering target state
  */
-export interface GatherTargetContext {
-  readonly defaultLspVersion: string
-  readonly defaultTypescriptVersion: string
-  readonly defaultOxlintVersion: string
-  readonly defaultOxlintTsgolintVersion: string
-  readonly defaultSchemaPath: string
-  readonly defaultOxlintrcSchemaPath: string
-}
+export type GatherTargetContext = Target.Context
 
 /**
  * Gather target state from user based on current assessment
  */
-export const gatherTargetState = (
-  assessment: Assessment.State,
-  context: GatherTargetContext
-): Effect.Effect<Target.State, Terminal.QuitError, Prompt.Environment | Path.Path> =>
+export const gatherTargetOptions = (
+  assessment: Assessment.State
+): Effect.Effect<Target.Options, Terminal.QuitError, Prompt.Environment> =>
   Effect.gen(function*() {
-    const path = yield* Path.Path
-
     const integrations = yield* Prompt.multiSelect({
       message: "Which integrations would you like to configure?",
       choices: [
@@ -54,24 +43,11 @@ export const gatherTargetState = (
 
     if (integrations.length === 0) {
       return {
-        packageJson: {
-          lspVersion: Option.none(),
-          typescriptVersion: assessment.packageJson.typescriptVersion,
-          oxlintVersion: assessment.packageJson.oxlintVersion,
-          oxlintTsgolintVersion: assessment.packageJson.oxlintTsgolintVersion,
-          prepareScript: false,
-          managePrepareScript: true,
-          integrations
-        },
-        tsconfig: {
-          schemaPath: Option.none(),
-          diagnosticSeverities: Option.none(),
-          manageIntegration: true
-        },
-        oxlintrcSchemaPath: Option.none(),
-        vscodeSettings: Option.none(),
+        integrations,
+        dependencyType: "devDependencies",
+        diagnosticSeverities: {},
         editors: []
-      } satisfies Target.State
+      }
     }
 
     // Determine current LSP installation state
@@ -134,10 +110,6 @@ export const gatherTargetState = (
       )
       : initialSeverities
 
-    const diagnosticSeverities = Object.keys(diagnosticSeveritiesRecord).length > 0
-      ? Option.some(diagnosticSeveritiesRecord)
-      : Option.none()
-
     // Editor Selection - Using multi-select
     // Pre-select VSCode if .vscode/settings.json exists
     const hasVscodeSettings = Option.isSome(assessment.vscodeSettings)
@@ -161,77 +133,15 @@ export const gatherTargetState = (
       ]
     }) : []
 
-    // Build target state
-    const defaultTypescriptPackageName = defaultTypescriptPackageNames[0]
-    const relativeSchemaPath = path
-      .relative(path.dirname(assessment.tsconfig.path), context.defaultSchemaPath)
-      .replaceAll("\\", "/")
-    const oxlintrcSchemaPath = useOxlint
-      ? Option.map(assessment.oxlintConfig, (config) => {
-        const relativePath = path
-          .relative(path.dirname(config.path), context.defaultOxlintrcSchemaPath)
-          .replaceAll("\\", "/")
-        return relativePath.startsWith(".") ? relativePath : `./${relativePath}`
-      })
-      : Option.none()
-    const vscodeSettings: Option.Option<Target.VSCodeSettings> = editors.includes("vscode")
-      ? Option.some({
-        settings: {
-          "js/ts.experimental.useTsgo": true,
-          "js/ts.tsdk.path": "./node_modules/typescript/bin",
-          "js/ts.tsdk.promptToUseWorkspaceVersion": true,
-          "js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"]
-        }
-      })
-      : Option.none()
-
     return {
-      packageJson: {
-        lspVersion: Option.some({ dependencyType: lspDependencyType, version: context.defaultLspVersion }),
-        typescriptVersion: useTypescript
-          ? Option.orElse(assessment.packageJson.typescriptVersion, () => Option.some({
-            dependencyType: lspDependencyType,
-            version: context.defaultTypescriptVersion,
-            packageName: defaultTypescriptPackageName
-          }))
-          : assessment.packageJson.typescriptVersion,
-        oxlintVersion: useOxlint && (
-            Option.isSome(assessment.packageJson.oxlintVersion) ||
-            Option.isNone(assessment.packageJson.vitePlusVersion)
-          )
-          ? Option.some({
-            dependencyType: Option.match(assessment.packageJson.oxlintVersion, {
-              onNone: () => lspDependencyType,
-              onSome: (dependency) => dependency.dependencyType
-            }),
-            version: context.defaultOxlintVersion
-          })
-          : assessment.packageJson.oxlintVersion,
-        oxlintTsgolintVersion: useOxlint && (
-            Option.isSome(assessment.packageJson.oxlintTsgolintVersion) ||
-            Option.isNone(assessment.packageJson.vitePlusVersion)
-          )
-          ? Option.some({
-            dependencyType: Option.match(assessment.packageJson.oxlintTsgolintVersion, {
-              onNone: () => lspDependencyType,
-              onSome: (dependency) => dependency.dependencyType
-            }),
-            version: context.defaultOxlintTsgolintVersion
-          })
-          : assessment.packageJson.oxlintTsgolintVersion,
-        prepareScript: true,
-        managePrepareScript: true,
-        integrations
-      },
-      tsconfig: {
-        schemaPath: useTypescript
-          ? Option.some(relativeSchemaPath.startsWith(".") ? relativeSchemaPath : `./${relativeSchemaPath}`)
-          : Option.none(),
-        diagnosticSeverities,
-        manageIntegration: true
-      },
-      oxlintrcSchemaPath,
-      vscodeSettings,
+      integrations,
+      dependencyType: lspDependencyType,
+      diagnosticSeverities: diagnosticSeveritiesRecord,
       editors
-    } satisfies Target.State
+    } satisfies Target.Options
   })
+
+export const gatherTargetState = (
+  assessment: Assessment.State,
+  context: GatherTargetContext
+) => gatherTargetOptions(assessment).pipe(Effect.flatMap((options) => Target.create(assessment, context, options)))

--- a/_packages/tsgo/src/cli/setup/target.ts
+++ b/_packages/tsgo/src/cli/setup/target.ts
@@ -1,9 +1,138 @@
 import * as Option from "effect/Option"
-import type { Assessment } from "./types.js"
-import type { Editor, Target } from "./types.js"
+import * as Effect from "effect/Effect"
+import * as Path from "effect/Path"
+import { defaultTypescriptPackageNames } from "./consts.js"
 import type { RuleSeverity } from "./rule-info.js"
+import type { Assessment } from "./types.js"
+import type { Editor, Integration, Target } from "./types.js"
 
 export type { Editor, Target }
+
+export interface Options {
+  readonly integrations: ReadonlyArray<Integration>
+  readonly dependencyType: "dependencies" | "devDependencies"
+  readonly diagnosticSeverities: Readonly<Record<string, RuleSeverity>>
+  readonly editors: ReadonlyArray<Editor>
+}
+
+export interface Context {
+  readonly defaultLspVersion: string
+  readonly defaultTypescriptVersion: string
+  readonly defaultOxlintVersion: string
+  readonly defaultOxlintTsgolintVersion: string
+  readonly defaultSchemaPath: string
+  readonly defaultOxlintrcSchemaPath: string
+}
+
+export const create = (
+  assessment: Assessment.State,
+  context: Context,
+  options: Options
+): Effect.Effect<Target.State, never, Path.Path> =>
+  Effect.gen(function*() {
+    const path = yield* Path.Path
+    const { dependencyType, diagnosticSeverities: diagnosticSeveritiesRecord, editors, integrations } = options
+    const useTypescript = integrations.includes("typescript")
+    const useOxlint = integrations.includes("oxlint")
+
+    if (integrations.length === 0) {
+      return {
+        packageJson: {
+          lspVersion: Option.none(),
+          typescriptVersion: assessment.packageJson.typescriptVersion,
+          oxlintVersion: assessment.packageJson.oxlintVersion,
+          oxlintTsgolintVersion: assessment.packageJson.oxlintTsgolintVersion,
+          prepareScript: false,
+          managePrepareScript: true,
+          integrations
+        },
+        tsconfig: {
+          schemaPath: Option.none(),
+          diagnosticSeverities: Option.none(),
+          manageIntegration: true
+        },
+        oxlintrcSchemaPath: Option.none(),
+        vscodeSettings: Option.none(),
+        editors: []
+      } satisfies Target.State
+    }
+
+    const diagnosticSeverities = Object.keys(diagnosticSeveritiesRecord).length > 0
+      ? Option.some({ ...diagnosticSeveritiesRecord })
+      : Option.none()
+    const defaultTypescriptPackageName = defaultTypescriptPackageNames[0]
+    const relativeSchemaPath = path
+      .relative(path.dirname(assessment.tsconfig.path), context.defaultSchemaPath)
+      .replaceAll("\\", "/")
+    const oxlintrcSchemaPath = useOxlint
+      ? Option.map(assessment.oxlintConfig, (config) => {
+        const relativePath = path
+          .relative(path.dirname(config.path), context.defaultOxlintrcSchemaPath)
+          .replaceAll("\\", "/")
+        return relativePath.startsWith(".") ? relativePath : `./${relativePath}`
+      })
+      : Option.none()
+    const vscodeSettings: Option.Option<Target.VSCodeSettings> = editors.includes("vscode")
+      ? Option.some({
+        settings: {
+          "js/ts.experimental.useTsgo": true,
+          "js/ts.tsdk.path": "./node_modules/typescript/bin",
+          "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+          "js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"]
+        }
+      })
+      : Option.none()
+
+    return {
+      packageJson: {
+        lspVersion: Option.some({ dependencyType, version: context.defaultLspVersion }),
+        typescriptVersion: useTypescript
+          ? Option.orElse(assessment.packageJson.typescriptVersion, () => Option.some({
+            dependencyType,
+            version: context.defaultTypescriptVersion,
+            packageName: defaultTypescriptPackageName
+          }))
+          : assessment.packageJson.typescriptVersion,
+        oxlintVersion: useOxlint && (
+            Option.isSome(assessment.packageJson.oxlintVersion) ||
+            Option.isNone(assessment.packageJson.vitePlusVersion)
+          )
+          ? Option.some({
+            dependencyType: Option.match(assessment.packageJson.oxlintVersion, {
+              onNone: () => dependencyType,
+              onSome: (dependency) => dependency.dependencyType
+            }),
+            version: context.defaultOxlintVersion
+          })
+          : assessment.packageJson.oxlintVersion,
+        oxlintTsgolintVersion: useOxlint && (
+            Option.isSome(assessment.packageJson.oxlintTsgolintVersion) ||
+            Option.isNone(assessment.packageJson.vitePlusVersion)
+          )
+          ? Option.some({
+            dependencyType: Option.match(assessment.packageJson.oxlintTsgolintVersion, {
+              onNone: () => dependencyType,
+              onSome: (dependency) => dependency.dependencyType
+            }),
+            version: context.defaultOxlintTsgolintVersion
+          })
+          : assessment.packageJson.oxlintTsgolintVersion,
+        prepareScript: true,
+        managePrepareScript: true,
+        integrations
+      },
+      tsconfig: {
+        schemaPath: useTypescript
+          ? Option.some(relativeSchemaPath.startsWith(".") ? relativeSchemaPath : `./${relativeSchemaPath}`)
+          : Option.none(),
+        diagnosticSeverities,
+        manageIntegration: true
+      },
+      oxlintrcSchemaPath,
+      vscodeSettings,
+      editors
+    } satisfies Target.State
+  })
 
 export const fromAssessment = (inputState: Assessment.State): Target.State => ({
   packageJson: {

--- a/_packages/tsgo/src/cli/setup/tsconfig-prompt.ts
+++ b/_packages/tsgo/src/cli/setup/tsconfig-prompt.ts
@@ -75,19 +75,27 @@ export const selectTsConfigFile = (
       }
     }
 
-    selectedTsconfigPath = path.resolve(selectedTsconfigPath)
+    return yield* readTsConfigFile(selectedTsconfigPath)
+  })
 
-    const tsconfigExists = yield* fs.exists(selectedTsconfigPath)
-    if (!tsconfigExists) {
-      return yield* new TsConfigNotFoundError({ path: selectedTsconfigPath })
+export const readTsConfigFile = (
+  tsconfigPath: string
+): Effect.Effect<
+  FileInput,
+  PlatformError.PlatformError | TsConfigNotFoundError | FileReadError,
+  FileSystem.FileSystem | Path.Path
+> =>
+  Effect.gen(function*() {
+    const fs = yield* FileSystem.FileSystem
+    const path = yield* Path.Path
+    const resolvedPath = path.resolve(tsconfigPath)
+
+    if (!(yield* fs.exists(resolvedPath))) {
+      return yield* new TsConfigNotFoundError({ path: resolvedPath })
     }
 
-    const tsconfigText = yield* fs.readFileString(selectedTsconfigPath).pipe(
-      Effect.mapError((cause) => new FileReadError({ path: selectedTsconfigPath, cause }))
+    const text = yield* fs.readFileString(resolvedPath).pipe(
+      Effect.mapError((cause) => new FileReadError({ path: resolvedPath, cause }))
     )
-
-    return {
-      fileName: selectedTsconfigPath,
-      text: tsconfigText
-    }
+    return { fileName: resolvedPath, text }
   })

--- a/_packages/tsgo/test/setup/__snapshots__/setup-cli.test.ts.snap
+++ b/_packages/tsgo/test/setup/__snapshots__/setup-cli.test.ts.snap
@@ -15,6 +15,7 @@ exports[`Setup CLI > should add LSP plugin alongside existing plugins > change s
 
 exports[`Setup CLI > should add LSP plugin alongside existing plugins > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
@@ -77,6 +78,7 @@ exports[`Setup CLI > should add LSP with VS Code editor selected and create new 
 
 exports[`Setup CLI > should add LSP with VS Code editor selected and create new settings file > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
   "",
   "VS Code / Cursor / VS Code-based editors:",
@@ -126,6 +128,7 @@ exports[`Setup CLI > should add LSP with custom diagnostic severities when no pl
 
 exports[`Setup CLI > should add LSP with custom diagnostic severities when no plugin exists > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
@@ -173,6 +176,7 @@ exports[`Setup CLI > should add custom diagnostic severities when plugin exists 
 
 exports[`Setup CLI > should add custom diagnostic severities when plugin exists without custom values > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
@@ -223,6 +227,7 @@ exports[`Setup CLI > should generate changes for Astro-style configs using the l
 
 exports[`Setup CLI > should generate changes for Astro-style configs using the legacy prepare command > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
@@ -290,6 +295,7 @@ exports[`Setup CLI > should generate changes for adding LSP with defaults > chan
 
 exports[`Setup CLI > should generate changes for adding LSP with defaults > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
@@ -333,6 +339,7 @@ exports[`Setup CLI > should generate changes for adding LSP with prepare script 
 
 exports[`Setup CLI > should generate changes for adding LSP with prepare script > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
@@ -377,6 +384,7 @@ exports[`Setup CLI > should generate changes for removing LSP and prepare script
 
 exports[`Setup CLI > should generate changes for removing LSP and prepare script > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo unpatch --typescript --no-oxlint\` to restore the original integrations.",
 ]
 `;
@@ -419,6 +427,7 @@ exports[`Setup CLI > should generate changes for removing LSP when already insta
 
 exports[`Setup CLI > should generate changes for removing LSP when already installed > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo unpatch --typescript --no-oxlint\` to restore the original integrations.",
 ]
 `;
@@ -460,6 +469,7 @@ exports[`Setup CLI > should not override existing plugins when adding LSP plugin
 
 exports[`Setup CLI > should not override existing plugins when adding LSP plugin > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
@@ -540,6 +550,7 @@ exports[`Setup CLI > should preserve all existing VS Code settings from a real r
 
 exports[`Setup CLI > should preserve all existing VS Code settings from a real repository config > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
   "",
   "VS Code / Cursor / VS Code-based editors:",
@@ -605,6 +616,7 @@ exports[`Setup CLI > should preserve existing VS Code settings when adding LSP-s
 
 exports[`Setup CLI > should preserve existing VS Code settings when adding LSP-specific settings > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
   "",
   "VS Code / Cursor / VS Code-based editors:",
@@ -654,6 +666,7 @@ exports[`Setup CLI > should remove only LSP patch command from prepare script wi
 
 exports[`Setup CLI > should remove only LSP patch command from prepare script with multiple commands > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo unpatch --typescript --no-oxlint\` to restore the original integrations.",
 ]
 `;
@@ -698,6 +711,7 @@ exports[`Setup CLI > should remove only LSP plugin while preserving other plugin
 
 exports[`Setup CLI > should remove only LSP plugin while preserving other plugins > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo unpatch --typescript --no-oxlint\` to restore the original integrations.",
 ]
 `;
@@ -742,6 +756,7 @@ exports[`Setup CLI > should replace existing tsconfig schema when adding LSP > c
 
 exports[`Setup CLI > should replace existing tsconfig schema when adding LSP > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
@@ -785,6 +800,7 @@ exports[`Setup CLI > should update LSP version when already installed with older
 
 exports[`Setup CLI > should update LSP version when already installed with older version > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;
@@ -831,6 +847,7 @@ exports[`Setup CLI > should update custom diagnostic severities when plugin alre
 
 exports[`Setup CLI > should update custom diagnostic severities when plugin already has custom values > messages 1`] = `
 [
+  "\`package.json\` changed. Run your package manager's install command (for example, \`pnpm install\`, \`npm install\`, \`yarn install\`, or \`bun install\`).",
   "Run \`effect-tsgo patch --typescript --no-oxlint\` to complete the installation.",
 ]
 `;

--- a/_packages/tsgo/test/setup/changes.test.ts
+++ b/_packages/tsgo/test/setup/changes.test.ts
@@ -769,6 +769,35 @@ describe("computeChanges", () => {
   })
 
   describe("post-apply messages", () => {
+    const installMessage = "`package.json` changed. Run your package manager's install command " +
+      "(for example, `pnpm install`, `npm install`, `yarn install`, or `bun install`)."
+
+    it("should recommend installing when package.json changes", () => {
+      const result = runComputeChanges({})
+
+      expect(result.messages).toContain(installMessage)
+    })
+
+    it("should not recommend installing when package.json is unchanged", () => {
+      const packageJsonText = JSON.stringify({
+        name: "test-project",
+        version: "1.0.0",
+        devDependencies: {
+          "@effect/tsgo": "0.0.4",
+          "typescript": TEST_TYPESCRIPT_VERSION
+        },
+        scripts: {
+          prepare: "effect-tsgo patch --typescript --no-oxlint"
+        }
+      }, null, 2)
+      const result = runComputeChanges({ packageJsonText })
+
+      expect(result.codeActions.some((action) =>
+        action.changes.some((change) => change.fileName === "/test/package.json")
+      )).toBe(false)
+      expect(result.messages).not.toContain(installMessage)
+    })
+
     it("should include patch message when installing", () => {
       const result = runComputeChanges({})
 

--- a/_packages/tsgo/test/setup/options.test.ts
+++ b/_packages/tsgo/test/setup/options.test.ts
@@ -1,0 +1,187 @@
+import * as NodeServices from "@effect/platform-node/NodeServices"
+import * as Effect from "effect/Effect"
+import * as Option from "effect/Option"
+import * as Command from "effect/unstable/cli/Command"
+import { describe, expect, it } from "vitest"
+import { assess } from "../../src/cli/setup/assessment.js"
+import {
+  resolveTargetOptions,
+  setupFlags,
+  type SetupFlags
+} from "../../src/cli/setup/options.js"
+import type { Assessment } from "../../src/cli/setup/types.js"
+
+const createAssessment = (): Assessment.State =>
+  assess({
+    packageJson: {
+      fileName: "/project/package.json",
+      text: JSON.stringify({
+        devDependencies: {
+          "@effect/tsgo": "1.0.0",
+          "oxlint": "1.0.0"
+        }
+      })
+    },
+    tsconfig: {
+      fileName: "/project/tsconfig.json",
+      text: JSON.stringify({
+        compilerOptions: {
+          plugins: [{
+            name: "@effect/language-service",
+            diagnosticSeverity: { floatingEffect: "warning" }
+          }]
+        }
+      })
+    },
+    oxlintConfig: Option.none(),
+    vscodeSettings: Option.some({
+      fileName: "/project/.vscode/settings.json",
+      text: "{}"
+    })
+  })
+
+const parseSetupFlags = async (args: ReadonlyArray<string>) => {
+  let result: SetupFlags | undefined
+  const command = Command.make("setup", setupFlags).pipe(
+    Command.withHandler((flags) => Effect.sync(() => result = flags))
+  )
+  await Effect.runPromise(
+    Command.runWith(command, { version: "test" })(args).pipe(Effect.provide(NodeServices.layer))
+  )
+  return result
+}
+
+describe("non-interactive setup options", () => {
+  it("parses automation and target choice flags", async () => {
+    const flags = await parseSetupFlags([
+      "--non-interactive",
+      "--project",
+      "tsconfig.json",
+      "--accept-defaults",
+      "--apply",
+      "--no-typescript",
+      "--oxlint",
+      "--dependency-type",
+      "dependencies",
+      "--preset",
+      "effect-native",
+      "--diagnostic",
+      "floatingEffect=error",
+      "--vscode",
+      "--nvim",
+      "--no-emacs"
+    ])
+
+    expect(flags).toMatchObject({
+      nonInteractive: true,
+      acceptDefaults: true,
+      apply: true,
+      typescript: Option.some(false),
+      oxlint: Option.some(true),
+      dependencyType: Option.some("dependencies"),
+      preset: ["effect-native"],
+      diagnostic: ["floatingEffect=error"],
+      vscode: Option.some(true),
+      nvim: Option.some(true),
+      emacs: Option.some(false)
+    })
+  })
+
+  it("reproduces assessment-sensitive recommendations", async () => {
+    const flags = await parseSetupFlags(["--non-interactive", "--accept-defaults"])
+    const options = await Effect.runPromise(resolveTargetOptions(createAssessment(), flags!))
+
+    expect(options.integrations).toEqual(["typescript", "oxlint"])
+    expect(options.dependencyType).toBe("devDependencies")
+    expect(options.editors).toEqual(["vscode"])
+    expect(options.diagnosticSeverities.floatingEffect).toBe("warning")
+  })
+
+  it("requires unresolved choices when defaults are not accepted", async () => {
+    const flags = await parseSetupFlags(["--non-interactive"])
+
+    await expect(Effect.runPromise(resolveTargetOptions(createAssessment(), flags!)))
+      .rejects.toThrow("requires both integration flags or --accept-defaults")
+  })
+
+  it("requires both integration decisions without defaults", async () => {
+    const flags = await parseSetupFlags([
+      "--non-interactive",
+      "--typescript",
+      "--dependency-type",
+      "devDependencies"
+    ])
+
+    await expect(Effect.runPromise(resolveTargetOptions(createAssessment(), flags!)))
+      .rejects.toThrow("requires both integration flags")
+  })
+
+  it("uses explicit choices instead of recommendations", async () => {
+    const flags = await parseSetupFlags([
+      "--non-interactive",
+      "--typescript",
+      "--no-oxlint",
+      "--dependency-type",
+      "dependencies",
+      "--no-presets",
+      "--diagnostic",
+      "floatingEffect=error",
+      "--no-vscode",
+      "--nvim"
+    ])
+    const options = await Effect.runPromise(resolveTargetOptions(createAssessment(), flags!))
+
+    expect(options).toMatchObject({
+      integrations: ["typescript"],
+      dependencyType: "dependencies",
+      editors: ["nvim"],
+      diagnosticSeverities: { floatingEffect: "error" }
+    })
+  })
+
+  it("rejects invalid presets and diagnostic overrides", async () => {
+    const invalidPreset = await parseSetupFlags([
+      "--non-interactive",
+      "--accept-defaults",
+      "--preset",
+      "unknown"
+    ])
+    await expect(Effect.runPromise(resolveTargetOptions(createAssessment(), invalidPreset!)))
+      .rejects.toThrow("Unknown diagnostic preset 'unknown'")
+
+    const invalidDiagnostic = await parseSetupFlags([
+      "--non-interactive",
+      "--accept-defaults",
+      "--diagnostic",
+      "floatingEffect=loud"
+    ])
+    await expect(Effect.runPromise(resolveTargetOptions(createAssessment(), invalidDiagnostic!)))
+      .rejects.toThrow("Invalid diagnostic 'floatingEffect=loud'")
+  })
+
+  it("does not select TypeScript-only defaults when TypeScript is disabled", async () => {
+    const flags = await parseSetupFlags([
+      "--non-interactive",
+      "--accept-defaults",
+      "--no-typescript",
+      "--oxlint"
+    ])
+    const options = await Effect.runPromise(resolveTargetOptions(createAssessment(), flags!))
+
+    expect(options.editors).toEqual([])
+  })
+
+  it("rejects TypeScript-only overrides when TypeScript is disabled", async () => {
+    const flags = await parseSetupFlags([
+      "--non-interactive",
+      "--no-typescript",
+      "--oxlint",
+      "--dependency-type",
+      "devDependencies",
+      "--vscode"
+    ])
+
+    await expect(Effect.runPromise(resolveTargetOptions(createAssessment(), flags!)))
+      .rejects.toThrow("editor choices require --typescript")
+  })
+})

--- a/_packages/tsgo/test/setup/setup-command.test.ts
+++ b/_packages/tsgo/test/setup/setup-command.test.ts
@@ -1,0 +1,48 @@
+import * as NodeServices from "@effect/platform-node/NodeServices"
+import * as Effect from "effect/Effect"
+import * as Command from "effect/unstable/cli/Command"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { setupCommand } from "../../src/cli/setup/index.js"
+
+const originalCwd = process.cwd()
+
+afterEach(() => {
+  process.chdir(originalCwd)
+})
+
+const runSetup = (args: ReadonlyArray<string>) =>
+  Effect.runPromise(
+    Command.runWith(setupCommand, { version: "test" })(args).pipe(Effect.provide(NodeServices.layer))
+  )
+
+describe("setup command", () => {
+  it("previews or applies recommended defaults without prompting", async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), "effect-tsgo-setup-"))
+    const packageJsonPath = join(projectDir, "package.json")
+    const tsconfigPath = join(projectDir, "tsconfig.json")
+    await writeFile(packageJsonPath, JSON.stringify({ name: "test-project", devDependencies: {} }, null, 2))
+    await writeFile(tsconfigPath, JSON.stringify({ compilerOptions: {} }, null, 2))
+    process.chdir(projectDir)
+
+    try {
+      const args = ["--non-interactive", "--project", "tsconfig.json", "--accept-defaults"]
+      await runSetup(args)
+      expect(await readFile(packageJsonPath, "utf8")).not.toContain("@effect/tsgo")
+
+      await runSetup([...args, "--apply"])
+      expect(await readFile(packageJsonPath, "utf8")).toContain("@effect/tsgo")
+      expect(await readFile(tsconfigPath, "utf8")).toContain("@effect/language-service")
+    } finally {
+      process.chdir(originalCwd)
+      await rm(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it("fails instead of prompting when the project is missing", async () => {
+    await expect(runSetup(["--non-interactive", "--accept-defaults"]))
+      .rejects.toThrow("Non-interactive setup requires --project")
+  })
+})


### PR DESCRIPTION
## Summary

- add a non-interactive `setup` mode with explicit project, integration, dependency, diagnostic, and editor options
- separate interactive option gathering from shared target construction
- support safe preview-by-default behavior and explicit `--apply` writes
- recommend running the package manager install command whenever setup changes `package.json`

## Example

```bash
npx @effect/tsgo setup \
  --non-interactive \
  --project tsconfig.json \
  --accept-defaults \
  --apply
```

Without `--apply`, the command prints the proposed changes without writing them. Strict non-interactive usage reports missing required choices rather than opening a prompt.

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`

Closes #544