### PR TITLE
feat: describe upstream updates

### DIFF
--- a/.changeset/upstream-update-descriptions.md
+++ b/.changeset/upstream-update-descriptions.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": minor
+---
+
+Generate detailed upstream update pull request descriptions with explicit version changes and the TypeScript-Go commits introduced by the update.

--- a/.github/workflows/update-upstreams.yml
+++ b/.github/workflows/update-upstreams.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Update upstream metadata
         id: upstream
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm exec repoctl upstream update
 
       - name: Open metadata update pull request
@@ -40,12 +42,13 @@ jobs:
         if: steps.upstream.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ steps.upstream.outputs.description }}
         run: |
           pnpm exec repoctl github open-pr-if-changed \
             --base main \
             --head update-upstreams \
             --title 'chore: update upstreams' \
-            --body 'Automated update of TypeScript-Go upstream component tags.' \
+            --body "$PR_BODY" \
             --commit-message 'chore: update upstream metadata' \
             --check generation_check_id='Generate TypeScript next tag'
 
@@ -85,12 +88,13 @@ jobs:
         if: steps.upstream.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ steps.upstream.outputs.description }}
         run: |
           pnpm exec repoctl github open-pr-if-changed \
             --base main \
             --head update-upstreams \
             --title 'chore: update upstreams' \
-            --body 'Automated update of upstream metadata, generated TypeScript next-tag sources, and Nix inputs.' \
+            --body "$PR_BODY" \
             --commit-message 'chore: generate TypeScript next tag' \
             --check validation_check_id='Validate TypeScript next tag'
 

--- a/_tools/repoctl/src/upstream.ts
+++ b/_tools/repoctl/src/upstream.ts
@@ -174,6 +174,11 @@ interface TypeScriptMetadata {
   readonly gitHead: string
 }
 
+interface TypeScriptGoCommit {
+  readonly sha: string
+  readonly message: string
+}
+
 interface OxlintSelection {
   readonly oxlintVersion: string
   readonly tsgolintVersion: string
@@ -309,9 +314,15 @@ export const formatOxlintConfigurationSchema = (value: unknown): string | undefi
   return `${JSON.stringify(value, null, 2)}\n`
 }
 
-const fetchJson = Effect.fnUntraced(function*(url: string) {
+const fetchJson = Effect.fnUntraced(function*(url: string, authenticate = false) {
+  const token = authenticate ? process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN : undefined
   const response = yield* Effect.tryPromise({
-    try: () => fetch(url, { headers: { "User-Agent": "effect-tsgo-repoctl" } }),
+    try: () => fetch(url, {
+      headers: {
+        "User-Agent": "effect-tsgo-repoctl",
+        ...(token === undefined ? {} : { Authorization: `Bearer ${token}` })
+      }
+    }),
     catch: (error) => new UpstreamManifestError({ reason: `Unable to fetch ${url}: ${String(error)}` })
   })
   if (!response.ok) {
@@ -322,6 +333,169 @@ const fetchJson = Effect.fnUntraced(function*(url: string) {
     catch: (error) => new UpstreamManifestError({ reason: `Unable to parse ${url}: ${String(error)}` })
   })
 })
+
+const GitHubComparison = Schema.Struct({
+  total_commits: Schema.Number,
+  commits: Schema.Array(Schema.Struct({
+    sha: GitRevision,
+    commit: Schema.Struct({ message: NonEmptyString })
+  }))
+})
+
+const fetchTypeScriptGoCommits = Effect.fnUntraced(function*(before: string, after: string) {
+  if (before === after) {
+    return []
+  }
+  const commits: Array<TypeScriptGoCommit> = []
+  let page = 1
+  let totalCommits = 0
+  do {
+    const url = [
+      `https://api.github.com/repos/microsoft/typescript-go/compare/${before}...${after}`,
+      `?per_page=100&page=${page}`
+    ].join("")
+    const comparison = yield* fetchJson(url, true)
+    const decoded = yield* Schema.decodeUnknownEffect(GitHubComparison)(comparison).pipe(
+      Effect.mapError((error) => new UpstreamManifestError({
+        reason: `Unable to read TypeScript-Go comparison: ${error.message}`
+      }))
+    )
+    totalCommits = decoded.total_commits
+    if (decoded.commits.length === 0 && commits.length < totalCommits) {
+      return yield* new UpstreamManifestError({ reason: "TypeScript-Go comparison ended before all commits were read" })
+    }
+    commits.push(...decoded.commits.map(({ commit, sha }) => ({
+      sha,
+      message: commit.message.split(/[\r\n]/, 1)[0]!
+    })))
+    page++
+  } while (commits.length < totalCommits)
+  return commits
+})
+
+export interface UpstreamUpdateDescriptionOptions {
+  readonly before: typeof Upstream.Type
+  readonly after: typeof Upstream.Type
+  readonly nextCommits: ReadonlyArray<TypeScriptGoCommit>
+  readonly schemaChanged: boolean
+  readonly oxlintSchemaChanged: boolean
+}
+
+export const formatUpstreamUpdateDescription = ({
+  after,
+  before,
+  nextCommits,
+  oxlintSchemaChanged,
+  schemaChanged
+}: UpstreamUpdateDescriptionOptions): string => {
+  const beforeVitePlus = before.profiles.find(({ name }) => name === "vite-plus")!
+  const afterVitePlus = after.profiles.find(({ name }) => name === "vite-plus")!
+  const beforeVitePlusVersion = /^Vite\+ (.+) compatibility runtime$/.exec(beforeVitePlus.description)?.[1]
+  const afterVitePlusVersion = /^Vite\+ (.+) compatibility runtime$/.exec(afterVitePlus.description)?.[1]
+  const versionUpdates = [
+    {
+      label: "TypeScript next",
+      packageName: "typescript",
+      spec: "typescript@next",
+      previous: before.tags.typescript.next,
+      updated: after.tags.typescript.next
+    },
+    {
+      label: "TypeScript latest",
+      packageName: "typescript",
+      spec: "typescript@latest",
+      previous: before.tags.typescript.latest,
+      updated: after.tags.typescript.latest
+    },
+    {
+      label: "Oxlint",
+      packageName: "oxlint",
+      spec: "oxlint@latest",
+      previous: before.tags.oxlint.latest,
+      updated: after.tags.oxlint.latest
+    },
+    {
+      label: "Oxlint TypeScript-Go lint plugin",
+      packageName: "oxlint-tsgolint",
+      spec: "oxlint-tsgolint@latest",
+      previous: before.tags["oxlint-tsgolint"].latest,
+      updated: after.tags["oxlint-tsgolint"].latest
+    },
+    {
+      label: "Vite+",
+      packageName: "vite-plus",
+      spec: "vite-plus@latest",
+      previous: beforeVitePlusVersion,
+      updated: afterVitePlusVersion
+    },
+    {
+      label: "Vite+ Oxlint runtime",
+      packageName: "oxlint",
+      spec: "oxlint",
+      previous: beforeVitePlus.dependencies.oxlint,
+      updated: afterVitePlus.dependencies.oxlint
+    },
+    {
+      label: "Vite+ TypeScript-Go lint runtime",
+      packageName: "oxlint-tsgolint",
+      spec: "oxlint-tsgolint",
+      previous: beforeVitePlus.dependencies["oxlint-tsgolint"],
+      updated: afterVitePlus.dependencies["oxlint-tsgolint"]
+    }
+  ].filter((update): update is typeof update & { readonly previous: string; readonly updated: string } =>
+    update.previous !== undefined && update.updated !== undefined && update.previous !== update.updated)
+  const previousNext = before.components.typescript[before.tags.typescript.next]!.gitHead
+  const updatedNext = after.components.typescript[after.tags.typescript.next]!.gitHead
+  const sections = ["Automated update of upstream metadata, generated TypeScript next-tag sources, and Nix inputs."]
+
+  if (versionUpdates.length > 0) {
+    sections.push([
+      "## Version updates",
+      "",
+      ...versionUpdates.map(({ label, packageName, previous, spec, updated }) =>
+        `- ${label}: [\`${spec}\`](https://www.npmjs.com/package/${packageName}/v/${updated}) \`${previous}\` -> \`${updated}\``)
+    ].join("\n"))
+  }
+  if (previousNext !== updatedNext) {
+    sections.push([
+      "## TypeScript-Go",
+      "",
+      `- Previous commit: [\`${previousNext}\`](https://github.com/microsoft/typescript-go/commit/${previousNext})`,
+      `- Updated commit: [\`${updatedNext}\`](https://github.com/microsoft/typescript-go/commit/${updatedNext})`,
+      `- Compare: https://github.com/microsoft/typescript-go/compare/${previousNext}...${updatedNext}`
+    ].join("\n"))
+  }
+  if (nextCommits.length > 0) {
+    sections.push([
+      "## Upstream commits",
+      "",
+      ...nextCommits.map(({ message, sha }) =>
+        `- [${sha.slice(0, 7)}](https://github.com/microsoft/typescript-go/commit/${sha}) ${message}`)
+    ].join("\n"))
+  }
+  const otherUpdates = [
+    ...(schemaChanged ? ["- Refreshed the tsconfig schema from JSON Schema Store."] : []),
+    ...(oxlintSchemaChanged ? ["- Refreshed the Oxlint configuration schema from the selected package."] : [])
+  ]
+  if (otherUpdates.length > 0) {
+    sections.push(["## Other updates", "", ...otherUpdates].join("\n"))
+  }
+  return sections.join("\n\n")
+}
+
+export const formatGitHubOutputs = (outputs: Readonly<Record<string, string>>) =>
+  Object.entries(outputs).map(([name, value]) => {
+    const normalizedValue = value.replace(/\r\n?/g, "\n")
+    if (!normalizedValue.includes("\n")) {
+      return `${name}=${normalizedValue}\n`
+    }
+    let delimiter = `repoctl_${name}`
+    const lines = new Set(normalizedValue.split("\n"))
+    while (lines.has(delimiter)) {
+      delimiter += "_"
+    }
+    return `${name}<<${delimiter}\n${normalizedValue}\n${delimiter}\n`
+  }).join("")
 
 const resolveRemoteTag = Effect.fnUntraced(function*(repositoryRoot: string, repository: string, tag: string) {
   const output = yield* runCommandString("git", repositoryRoot, [
@@ -538,6 +712,15 @@ export const updateUpstream = Effect.fnUntraced(function*(repositoryRoot: string
   const oxlintSchemaChanged = oxlintSchema !== currentOxlintSchema
   const hasChanges = metadataChanged || schemaChanged || oxlintSchemaChanged
 
+  const nextCommits = yield* fetchTypeScriptGoCommits(nextBefore.gitHead, next.gitHead)
+  const description = formatUpstreamUpdateDescription({
+    before: upstream,
+    after: updated,
+    nextCommits,
+    schemaChanged,
+    oxlintSchemaChanged
+  })
+
   if (metadataChanged) {
     yield* fs.writeFileString(
       path.join(repositoryRoot, "_packages", "tsgo", "upstream.json"),
@@ -568,12 +751,13 @@ export const updateUpstream = Effect.fnUntraced(function*(repositoryRoot: string
     latest_previous_version: latestBefore.npmVersion,
     latest_previous_git_head: latestBefore.gitHead,
     latest_version: latest.npmVersion,
-    latest_git_head: latest.gitHead
+    latest_git_head: latest.gitHead,
+    description
   }
   if (process.env.GITHUB_OUTPUT !== undefined) {
     yield* Effect.tryPromise(() => appendFile(
       process.env.GITHUB_OUTPUT!,
-      Object.entries(outputs).map(([name, value]) => `${name}=${value}\n`).join("")
+      formatGitHubOutputs(outputs)
     ))
   }
   yield* Effect.log(hasChanges ? "Updated upstream metadata" : "Upstream metadata is current")

--- a/_tools/repoctl/test/upstream.test.ts
+++ b/_tools/repoctl/test/upstream.test.ts
@@ -6,8 +6,10 @@ import {
   decodeLatestNpmVersion,
   decodeUpstream,
   findTypeScriptVersion,
+  formatGitHubOutputs,
   formatOxlintConfigurationSchema,
   formatTSConfigSchema,
+  formatUpstreamUpdateDescription,
   getComponent
 } from "../src/upstream.ts"
 import { resolveUpstreamInfo } from "../src/upstreamResolve.ts"
@@ -17,7 +19,7 @@ const secondRevision = "1123456789abcdef0123456789abcdef01234567"
 const thirdRevision = "2123456789abcdef0123456789abcdef01234567"
 
 const manifest = () => ({
-  schemaVersion: 4,
+  schemaVersion: 4 as const,
   tags: {
     typescript: {
       latest: "7.0.0",
@@ -206,6 +208,75 @@ test("finds a TypeScript npm version by its git head", () => {
     "7.0.1": { gitHead: revision },
     "7.0.2": { gitHead: secondRevision }
   }, secondRevision), "7.0.2")
+})
+
+test("describes upstream version and TypeScript-Go commit updates", () => {
+  const before = manifest()
+  const after = manifest()
+  const afterTypeScript = after.components.typescript as Record<string, { gitHead: string }>
+  const afterOxlint = after.components.oxlint as Record<string, { gitHead: string }>
+  after.tags.typescript.next = "7.2.0"
+  afterTypeScript["7.2.0"] = { gitHead: thirdRevision }
+  after.tags.oxlint.latest = "1.2.0"
+  afterOxlint["1.2.0"] = { gitHead: thirdRevision }
+  after.profiles[0]!.description = "Vite+ 1.1.0 compatibility runtime"
+  after.profiles[0]!.dependencies.oxlint = "1.2.0"
+
+  assert.equal(formatUpstreamUpdateDescription({
+    before,
+    after,
+    nextCommits: [{ sha: thirdRevision, message: "Add a useful feature" }],
+    schemaChanged: true,
+    oxlintSchemaChanged: false
+  }), [
+    "Automated update of upstream metadata, generated TypeScript next-tag sources, and Nix inputs.",
+    "",
+    "## Version updates",
+    "",
+    "- TypeScript next: [`typescript@next`](https://www.npmjs.com/package/typescript/v/7.2.0) `7.1.0` -> `7.2.0`",
+    "- Oxlint: [`oxlint@latest`](https://www.npmjs.com/package/oxlint/v/1.2.0) `1.1.0` -> `1.2.0`",
+    "- Vite+: [`vite-plus@latest`](https://www.npmjs.com/package/vite-plus/v/1.1.0) `1.0.0` -> `1.1.0`",
+    "- Vite+ Oxlint runtime: [`oxlint`](https://www.npmjs.com/package/oxlint/v/1.2.0) `1.0.0` -> `1.2.0`",
+    "",
+    "## TypeScript-Go",
+    "",
+    `- Previous commit: [\`${secondRevision}\`](https://github.com/microsoft/typescript-go/commit/${secondRevision})`,
+    `- Updated commit: [\`${thirdRevision}\`](https://github.com/microsoft/typescript-go/commit/${thirdRevision})`,
+    `- Compare: https://github.com/microsoft/typescript-go/compare/${secondRevision}...${thirdRevision}`,
+    "",
+    "## Upstream commits",
+    "",
+    `- [${thirdRevision.slice(0, 7)}](https://github.com/microsoft/typescript-go/commit/${thirdRevision}) Add a useful feature`,
+    "",
+    "## Other updates",
+    "",
+    "- Refreshed the tsconfig schema from JSON Schema Store."
+  ].join("\n"))
+})
+
+test("writes multiline descriptions as GitHub step outputs", () => {
+  assert.equal(formatGitHubOutputs({ has_changes: "true", description: "first\nsecond" }), [
+    "has_changes=true",
+    "description<<repoctl_description",
+    "first",
+    "second",
+    "repoctl_description",
+    ""
+  ].join("\n"))
+  assert.equal(formatGitHubOutputs({ description: "repoctl_description\nbody" }), [
+    "description<<repoctl_description_",
+    "repoctl_description",
+    "body",
+    "repoctl_description_",
+    ""
+  ].join("\n"))
+  assert.equal(formatGitHubOutputs({ description: "first\rsecond" }), [
+    "description<<repoctl_description",
+    "first",
+    "second",
+    "repoctl_description",
+    ""
+  ].join("\n"))
 })
 
 test("formats a JSON Schema Store tsconfig schema", () => {


### PR DESCRIPTION
## Summary

- return a Markdown description from `repoctl upstream update` with explicit upstream version transitions
- include paginated TypeScript-Go compare links and introduced commit subjects when the next revision changes
- use the generated description for both update-upstreams PR creation steps
- serialize multiline GitHub Actions outputs safely and scope API authentication to GitHub

## Example

```markdown
## Version updates

- TypeScript next: `7.1.0` -> `7.2.0`
- Oxlint: `1.1.0` -> `1.2.0`

## TypeScript-Go

- Previous commit: `<old revision>`
- Updated commit: `<new revision>`
- Compare: https://github.com/microsoft/typescript-go/compare/<old>...<new>

## Upstream commits

- [abcdef0](https://github.com/microsoft/typescript-go/commit/abcdef0) Add a useful feature
```

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`