### PR TITLE
Fix TS2731 false positive in tagged templates

### DIFF
--- a/.changeset/fix-tagged-template-ts2731.md
+++ b/.changeset/fix-tagged-template-ts2731.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Avoid false positive TS2731 diagnostics for symbol-valued interpolations in tagged template literals when Effect diagnostic rules traverse the template expression.

--- a/internal/effecttest/effect_in_failure_ts2589_test.go
+++ b/internal/effecttest/effect_in_failure_ts2589_test.go
@@ -40,6 +40,43 @@ func TestEffectInFailureCanTriggerPluginOnlyTS2589(t *testing.T) {
 	}
 }
 
+func TestTaggedTemplateSymbolInterpolationDoesNotReportTS2731(t *testing.T) {
+	t.Parallel()
+
+	for _, rule := range []string{"anyUnknownInErrorContext", "effectInFailure"} {
+		t.Run(rule, func(t *testing.T) {
+			diagnostics := collectDiagnosticStringsFromContent(t, buildTaggedTemplateSymbolCase(rule))
+			if hasDiagnosticCode(diagnostics, "TS2731:") {
+				t.Fatalf("did not expect TS2731 with %s enabled, got %v", rule, diagnostics)
+			}
+		})
+	}
+}
+
+func buildTaggedTemplateSymbolCase(rule string) string {
+	return `// @filename: tsconfig.json
+{
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnosticSeverity": {
+          "` + rule + `": "error"
+        }
+      }
+    ]
+  }
+}
+
+// @filename: test.ts
+const self: unique symbol = Symbol("self")
+function sql(strings: TemplateStringsArray, ...args: Array<unknown>): string {
+  return strings.join("?") + args.length
+}
+export const q = sql` + "`(${self}) < 1`" + `
+`
+}
+
 func TestIssue362RemedaChunkDoesNotReportExcessiveTypeDepth(t *testing.T) {
 	t.Parallel()
 

--- a/internal/typeparser/get_type_at_location.go
+++ b/internal/typeparser/get_type_at_location.go
@@ -49,6 +49,14 @@ func (tp TypeParser) getTypeAtLocationUncached(node *ast.Node) (result *checker.
 		return nil
 	}
 
+	// Tagged templates pass interpolation values directly to the tag function;
+	// they do not stringify them. Asking the checker for the type of the inner
+	// TemplateExpression forces a normally unreachable checking path that can
+	// emit TS2731 for symbol-typed interpolations as a side effect.
+	if node.Kind == ast.KindTemplateExpression && node.Parent != nil && ast.IsTaggedTemplateExpression(node.Parent) {
+		return nil
+	}
+
 	// A meta property used as a call callee (import.defer(...)) has no type of
 	// its own and the checker debug-asserts when asked (checkMetaProperty); the
 	// enclosing call expression carries the meaningful type.


### PR DESCRIPTION
## Summary

- skip type queries for template expressions nested directly in tagged templates
- prevent incidental checker TS2731 diagnostics for symbol-valued interpolations
- add regression coverage with both affected Effect rules enabled individually

## Why

Tagged templates pass interpolation values to the tag function without string conversion. Rule traversal was forcing a normally unreachable checker path by requesting the inner template expression's type.

Closes #568.

## Validation

- `nix build .#effect-tsgo`
- runtime reproduction with `anyUnknownInErrorContext` and `effectInFailure` enabled
