### PR TITLE
Invalidate build info when Effect plugin options change

### DIFF
--- a/.changeset/invalidate-effect-buildinfo-options.md
+++ b/.changeset/invalidate-effect-buildinfo-options.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Persist Effect plugin options in TypeScript build information so incremental builds recheck semantic diagnostics when extended tsconfig plugin settings change.

--- a/_patches/typescript-go/028-incremental-effect-options.patch
+++ b/_patches/typescript-go/028-incremental-effect-options.patch
@@ -18,25 +18,19 @@ index 61ae063d4..47da02331 100644
  	ReferencedMap              []*BuildInfoReferenceMapEntry        `json:"referencedMap,omitzero"`
  	SemanticDiagnosticsPerFile []*BuildInfoSemanticDiagnostic       `json:"semanticDiagnosticsPerFile,omitzero"`
  	EmitDiagnosticsPerFile     []*BuildInfoDiagnosticsOfFile        `json:"emitDiagnosticsPerFile,omitzero"`
-@@ -526,6 +528,7 @@ func (b *BuildInfo) GetCompilerOptions(buildInfoDirectory string) *core.Compiler
- 		}
- 
- 	}
+@@ -529,1 +531,2 @@
 +	options.Effect = b.Effect
  	return options
- }
- 
+
 diff --git a/internal/execute/incremental/snapshottobuildinfo.go b/internal/execute/incremental/snapshottobuildinfo.go
 index 909fab087..6595cd86c 100644
 --- a/internal/execute/incremental/snapshottobuildinfo.go
 +++ b/internal/execute/incremental/snapshottobuildinfo.go
-@@ -17,5 +17,6 @@ func snapshotToBuildInfo(snapshot *snapshot, program *compiler.Program, buildInfo
+@@ -19,3 +19,4 @@ func snapshotToBuildInfo(snapshot *snapshot, program *compiler.Program, buildInfo
  	buildInfo := &BuildInfo{
  		Version: core.Version(),
 +		Effect:  snapshot.options.Effect,
  	}
- 	to := &toBuildInfo{
- 		snapshot:          snapshot,
 diff --git a/internal/tsoptions/declscompiler.go b/internal/tsoptions/declscompiler.go
 index c6a70ff9e..fd1672ea7 100644
 --- a/internal/tsoptions/declscompiler.go

--- a/_patches/typescript-go/028-incremental-effect-options.patch
+++ b/_patches/typescript-go/028-incremental-effect-options.patch
@@ -1,0 +1,53 @@
+diff --git a/internal/execute/incremental/buildInfo.go b/internal/execute/incremental/buildInfo.go
+index 61ae063d4..47da02331 100644
+--- a/internal/execute/incremental/buildInfo.go
++++ b/internal/execute/incremental/buildInfo.go
+@@ -4,6 +4,7 @@ import (
+ 	"fmt"
+ 	"iter"
+ 
++	"github.com/effect-ts/tsgo/etscore"
+ 	"github.com/microsoft/typescript-go/internal/ast"
+ 	"github.com/microsoft/typescript-go/internal/collections"
+ 	"github.com/microsoft/typescript-go/internal/core"
+@@ -476,6 +477,7 @@ type BuildInfo struct {
+ 	FileInfos                  []*BuildInfoFileInfo                 `json:"fileInfos,omitzero"`
+ 	FileIdsList                [][]BuildInfoFileId                  `json:"fileIdsList,omitzero"`
+ 	Options                    *collections.OrderedMap[string, any] `json:"options,omitzero"`
++	Effect                     *etscore.EffectPluginOptions         `json:"effect,omitzero"`
+ 	ReferencedMap              []*BuildInfoReferenceMapEntry        `json:"referencedMap,omitzero"`
+ 	SemanticDiagnosticsPerFile []*BuildInfoSemanticDiagnostic       `json:"semanticDiagnosticsPerFile,omitzero"`
+ 	EmitDiagnosticsPerFile     []*BuildInfoDiagnosticsOfFile        `json:"emitDiagnosticsPerFile,omitzero"`
+@@ -526,6 +528,7 @@ func (b *BuildInfo) GetCompilerOptions(buildInfoDirectory string) *core.Compiler
+ 		}
+ 
+ 	}
++	options.Effect = b.Effect
+ 	return options
+ }
+ 
+diff --git a/internal/execute/incremental/snapshottobuildinfo.go b/internal/execute/incremental/snapshottobuildinfo.go
+index 909fab087..6595cd86c 100644
+--- a/internal/execute/incremental/snapshottobuildinfo.go
++++ b/internal/execute/incremental/snapshottobuildinfo.go
+@@ -17,5 +17,6 @@ func snapshotToBuildInfo(snapshot *snapshot, program *compiler.Program, buildInfo
+ 	buildInfo := &BuildInfo{
+ 		Version: core.Version(),
++		Effect:  snapshot.options.Effect,
+ 	}
+ 	to := &toBuildInfo{
+ 		snapshot:          snapshot,
+diff --git a/internal/tsoptions/declscompiler.go b/internal/tsoptions/declscompiler.go
+index c6a70ff9e..fd1672ea7 100644
+--- a/internal/tsoptions/declscompiler.go
++++ b/internal/tsoptions/declscompiler.go
+@@ -1243,6 +1243,9 @@ func CompilerOptionsAffectSemanticDiagnostics(
+ 	oldOptions *core.CompilerOptions,
+ 	newOptions *core.CompilerOptions,
+ ) bool {
++	if !reflect.DeepEqual(oldOptions.Effect, newOptions.Effect) {
++		return true
++	}
+ 	return optionsHaveChanges(oldOptions, newOptions, func(option *CommandLineOption) bool {
+ 		return option.AffectsSemanticDiagnostics
+ 	})


### PR DESCRIPTION
## Summary

- persist effective Effect plugin options in `.tsbuildinfo`
- restore those options when loading an incremental program
- treat Effect option changes as affecting semantic diagnostics

## Why

Changes to plugin configuration in an extended tsconfig made the build run, but the incremental snapshot could not observe those changes. It therefore reused stale semantic diagnostics from the previous build.

Closes #569.

## Validation

- `nix build .#effect-tsgo`
- built a composite project with Effect options in an extended tsconfig
- changed rule severity from `error` to `off` without touching source files
- confirmed the incremental build updates the persisted effective options and completes cleanly
