### PR TITLE
fix: avoid preferTypedSchemaDecoder panic on transformed inputs

### DIFF
--- a/.changeset/fix-typed-schema-decoder-call-input.md
+++ b/.changeset/fix-typed-schema-decoder-call-input.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Prevent `preferTypedSchemaDecoder` from panicking when a decoder input is produced by a preceding call or pipe transformation.

--- a/internal/effecttest/effect_in_failure_ts2589_test.go
+++ b/internal/effecttest/effect_in_failure_ts2589_test.go
@@ -45,6 +45,8 @@ func TestTaggedTemplateSymbolInterpolationDoesNotReportTS2731(t *testing.T) {
 
 	for _, rule := range []string{"anyUnknownInErrorContext", "effectInFailure"} {
 		t.Run(rule, func(t *testing.T) {
+			t.Parallel()
+
 			diagnostics := collectDiagnosticStringsFromContent(t, buildTaggedTemplateSymbolCase(rule))
 			if hasDiagnosticCode(diagnostics, "TS2731:") {
 				t.Fatalf("did not expect TS2731 with %s enabled, got %v", rule, diagnostics)

--- a/internal/rules/prefer_typed_schema_decoder.go
+++ b/internal/rules/prefer_typed_schema_decoder.go
@@ -146,8 +146,10 @@ func analyzeTypedSchemaDecoderApplication(tp *typeparser.TypeParser, c *checker.
 	}
 
 	assignableType := inputType
-	if literal := ast.SkipParentheses(inputNode); literal != nil && (literal.Kind == ast.KindObjectLiteralExpression || literal.Kind == ast.KindArrayLiteralExpression) {
-		assignableType = checker.Checker_checkExpressionWithContextualType(c, literal, schemaType.E, nil, checker.CheckModeTypeOnly)
+	if inputNode != nil {
+		if literal := ast.SkipParentheses(inputNode); literal != nil && (literal.Kind == ast.KindObjectLiteralExpression || literal.Kind == ast.KindArrayLiteralExpression) {
+			assignableType = checker.Checker_checkExpressionWithContextualType(c, literal, schemaType.E, nil, checker.CheckModeTypeOnly)
+		}
 	}
 	if assignableType == nil || !checker.Checker_isTypeAssignableTo(c, assignableType, schemaType.E) {
 		return nil

--- a/testdata/baselines/reference/effect-v4/preferTypedSchemaDecoder.errors.txt
+++ b/testdata/baselines/reference/effect-v4/preferTypedSchemaDecoder.errors.txt
@@ -12,9 +12,11 @@ Effect version: 4.0.0
 /.src/preferTypedSchemaDecoder.ts(29,42): warning TS377112: This input is already assignable to the schema's Encoded type. Use `decodeSync` to preserve compile-time type checking instead of discarding the input type through `decodeUnknownSync`. effect(preferTypedSchemaDecoder)
 /.src/preferTypedSchemaDecoder.ts(30,22): warning TS377112: This input is already assignable to the schema's Encoded type. Use `decodeSync` to preserve compile-time type checking instead of discarding the input type through `decodeUnknownSync`. effect(preferTypedSchemaDecoder)
 /.src/preferTypedSchemaDecoder.ts(33,35): warning TS377112: This input is already assignable to the schema's Encoded type. Use `decodeSync` to preserve compile-time type checking instead of discarding the input type through `decodeUnknownSync`. effect(preferTypedSchemaDecoder)
+/.src/preferTypedSchemaDecoder.ts(65,31): warning TS377112: This input is already assignable to the schema's Encoded type. Use `decodeEffect` to preserve compile-time type checking instead of discarding the input type through `decodeUnknownEffect`. effect(preferTypedSchemaDecoder)
+/.src/preferTypedSchemaDecoder.ts(67,67): warning TS377112: This input is already assignable to the schema's Encoded type. Use `decodeEffect` to preserve compile-time type checking instead of discarding the input type through `decodeUnknownEffect`. effect(preferTypedSchemaDecoder)
 
 
-==== /.src/preferTypedSchemaDecoder.ts (11 errors) ====
+==== /.src/preferTypedSchemaDecoder.ts (13 errors) ====
     // @effect-diagnostics *:off
     // @effect-diagnostics preferTypedSchemaDecoder:warning
     
@@ -93,4 +95,19 @@ Effect version: 4.0.0
     
     decodeGeneric(person)
     decodeNestedGeneric(person)
+    
+    // Regression test for https://github.com/Effect-TS/tsgo/issues/572.
+    const NamedPerson = Schema.Struct({ name: Schema.String })
+    
+    function makeFields(name: string): { readonly name: string } {
+      return { name }
+    }
+    
+    export const decoded = Schema.decodeUnknownEffect(NamedPerson)(makeFields("Ada"))
+                                  ~~~~~~~~~~~~~~~~~~~
+!!! warning TS377112: This input is already assignable to the schema's Encoded type. Use `decodeEffect` to preserve compile-time type checking instead of discarding the input type through `decodeUnknownEffect`. effect(preferTypedSchemaDecoder)
+    
+    export const pipedCallExpression = pipe("Ada", makeFields, Schema.decodeUnknownEffect(NamedPerson))
+                                                                      ~~~~~~~~~~~~~~~~~~~
+!!! warning TS377112: This input is already assignable to the schema's Encoded type. Use `decodeEffect` to preserve compile-time type checking instead of discarding the input type through `decodeUnknownEffect`. effect(preferTypedSchemaDecoder)
     

--- a/testdata/baselines/reference/effect-v4/preferTypedSchemaDecoder.flows.preferTypedSchemaDecoder.mermaid
+++ b/testdata/baselines/reference/effect-v4/preferTypedSchemaDecoder.flows.preferTypedSchemaDecoder.mermaid
@@ -36,6 +36,20 @@ flowchart TB
   34[/"type: #123; name: string; coordinates: #91;number, number#93;; #125;<br/>node: person"/]
   35["type: #123; readonly name: string; readonly coordinates: readonly #91;number, number#93;; #125;<br/>callee: decodeNestedGeneric<br/>args: #91;#93;"]
   36[/"type: #lt;T extends string#gt;#40;input: #123; readonly name: T; readonly coordinates: #91;number, number#93;; #125;#41; =#gt; #123; readonly name: string; readonly coordinates: readonly #91;number, number#93;; #125;<br/>node: decodeNestedGeneric"/]
+  37[/"type: #123; name: String; #125;<br/>node: #123; name: Schema.String #125;"/]
+  38["type: Struct#lt;#123; readonly name: String; #125;#gt;<br/>callee: Schema.Struct<br/>args: #91;#93;"]
+  39[/"type: #lt;const Fields extends Struct.Fields#gt;#40;fields: Fields#41; =#gt; Struct#lt;Fields#gt;<br/>node: Schema.Struct"/]
+  40[["type: #40;name: string#41; =#gt; #123; readonly name: string; #125;<br/>node: function makeFields#40;name: string#41;: #123; readonly name: string #125; #123;#92;n  return #123; name #125;#92;n#125;"]]
+  41[/"type: #123; name: string; #125;<br/>node: #123; name #125;"/]
+  42[/"type: Effect#lt;#123; readonly name: string; #125;, SchemaError, never#gt;<br/>node: Schema.decodeUnknownEffect#40;NamedPerson#41;#40;makeFields#40;#quot;Ada#quot;#41;#41;"/]
+  43[/"type: #quot;Ada#quot;<br/>node: #quot;Ada#quot;"/]
+  44["type: #123; readonly name: string; #125;<br/>callee: makeFields<br/>args: #91;#93;"]
+  45[/"type: #40;name: string#41; =#gt; #123; readonly name: string; #125;<br/>node: makeFields"/]
+  46[/"type: #quot;Ada#quot;<br/>node: #quot;Ada#quot;"/]
+  47["type: #123; readonly name: string; #125;<br/>callee: makeFields<br/>args: #91;#93;"]
+  48["type: Effect#lt;#123; readonly name: string; #125;, SchemaError, never#gt;<br/>callee: Schema.decodeUnknownEffect<br/>args: #91;NamedPerson#93;"]
+  49[/"type: #lt;S extends Constraint#gt;#40;schema: S, options?: ParseOptions #124; undefined#41; =#gt; #40;input: unknown, options?: ParseOptions #124; undefined#41; =#gt; Effect#lt;S#91;#quot;Type#quot;#93;, SchemaError, S#91;#quot;DecodingServices#quot;#93;#gt;<br/>node: Schema.decodeUnknownEffect"/]
+  50[/"type: Struct#lt;#123; readonly name: String; #125;#gt;<br/>node: NamedPerson"/]
   1 -->|"kind: pipe"| 2
   3 -->|"kind: transformCallee"| 2
   2 -->|"kind: usedBy"| 0
@@ -52,3 +66,14 @@ flowchart TB
   33 -->|"kind: transformCallee"| 32
   34 -->|"kind: pipe"| 35
   36 -->|"kind: transformCallee"| 35
+  37 -->|"kind: pipe"| 38
+  39 -->|"kind: transformCallee"| 38
+  41 -->|"kind: potentialReturn"| 40
+  41 -->|"kind: usedBy"| 40
+  43 -->|"kind: pipe"| 44
+  45 -->|"kind: transformCallee"| 44
+  44 -->|"kind: usedBy"| 42
+  46 -->|"kind: pipe"| 47
+  49 -->|"kind: transformCallee"| 48
+  50 -->|"kind: transformArg"| 48
+  47 -->|"kind: pipe"| 48

--- a/testdata/baselines/reference/effect-v4/preferTypedSchemaDecoder.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/preferTypedSchemaDecoder.pipings.txt
@@ -1,4 +1,4 @@
-==== /.src/preferTypedSchemaDecoder.ts (23 flows) ====
+==== /.src/preferTypedSchemaDecoder.ts (26 flows) ====
 
 === Piping Flow ===
 Location: 8:15 - 11:3
@@ -321,3 +321,53 @@ Transformations (1):
       callee: decodeNestedGeneric
       args: (constant)
       outType: { readonly name: string; readonly coordinates: readonly [number, number]; }
+
+=== Piping Flow ===
+Location: 59:20 - 59:59
+Node: Schema.Struct({ name: Schema.String })
+Node Kind: KindCallExpression
+
+Subject: { name: Schema.String }
+Subject Type: { name: String; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.Struct
+      args: (constant)
+      outType: Struct<{ readonly name: String; }>
+
+=== Piping Flow ===
+Location: 65:23 - 65:82
+Node: Schema.decodeUnknownEffect(NamedPerson)(makeFields("Ada"))
+Node Kind: KindCallExpression
+
+Subject: "Ada"
+Subject Type: "Ada"
+
+Transformations (2):
+  [0] kind: call
+      callee: makeFields
+      args: (constant)
+      outType: { readonly name: string; }
+  [1] kind: call
+      callee: Schema.decodeUnknownEffect(NamedPerson)
+      args: (constant)
+      outType: Effect<{ readonly name: string; }, SchemaError, never>
+
+=== Piping Flow ===
+Location: 67:35 - 67:100
+Node: pipe("Ada", makeFields, Schema.decodeUnknownEffect(NamedPerson))
+Node Kind: KindCallExpression
+
+Subject: "Ada"
+Subject Type: "Ada"
+
+Transformations (2):
+  [0] kind: pipe
+      callee: makeFields
+      args: (constant)
+      outType: { readonly name: string; }
+  [1] kind: pipe
+      callee: Schema.decodeUnknownEffect
+      args: [NamedPerson]
+      outType: Effect<{ readonly name: string; }, SchemaError, never>

--- a/testdata/baselines/reference/effect-v4/preferTypedSchemaDecoder.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/preferTypedSchemaDecoder.quickfixes.txt
@@ -54,6 +54,16 @@
   Fix 1: "Disable preferTypedSchemaDecoder for entire file"
   Fix 2: "Replace with decodeSync"
 
+[D12] (65:31-65:50) TS377112: This input is already assignable to the schema's Encoded type. Use `decodeEffect` to preserve compile-time type checking instead of discarding the input type through `decodeUnknownEffect`. effect(preferTypedSchemaDecoder)
+  Fix 0: "Disable preferTypedSchemaDecoder for this line"
+  Fix 1: "Disable preferTypedSchemaDecoder for entire file"
+  Fix 2: "Replace with decodeEffect"
+
+[D13] (67:67-67:86) TS377112: This input is already assignable to the schema's Encoded type. Use `decodeEffect` to preserve compile-time type checking instead of discarding the input type through `decodeUnknownEffect`. effect(preferTypedSchemaDecoder)
+  Fix 0: "Disable preferTypedSchemaDecoder for this line"
+  Fix 1: "Disable preferTypedSchemaDecoder for entire file"
+  Fix 2: "Replace with decodeEffect"
+
 === Quick Fix Application Results ===
 
 === [D1] Fix 0: "Disable preferTypedSchemaDecoder for this line" ===
@@ -122,6 +132,17 @@ function decodeNestedGeneric<T extends string>(input: { readonly name: T; readon
 decodeGeneric(person)
 decodeNestedGeneric(person)
 
+// Regression test for https://github.com/Effect-TS/tsgo/issues/572.
+const NamedPerson = Schema.Struct({ name: Schema.String })
+
+function makeFields(name: string): { readonly name: string } {
+  return { name }
+}
+
+export const decoded = Schema.decodeUnknownEffect(NamedPerson)(makeFields("Ada"))
+
+export const pipedCallExpression = pipe("Ada", makeFields, Schema.decodeUnknownEffect(NamedPerson))
+
 
 === [D2] Fix 0: "Disable preferTypedSchemaDecoder for this line" ===
 skipped by default
@@ -188,6 +209,17 @@ function decodeNestedGeneric<T extends string>(input: { readonly name: T; readon
 
 decodeGeneric(person)
 decodeNestedGeneric(person)
+
+// Regression test for https://github.com/Effect-TS/tsgo/issues/572.
+const NamedPerson = Schema.Struct({ name: Schema.String })
+
+function makeFields(name: string): { readonly name: string } {
+  return { name }
+}
+
+export const decoded = Schema.decodeUnknownEffect(NamedPerson)(makeFields("Ada"))
+
+export const pipedCallExpression = pipe("Ada", makeFields, Schema.decodeUnknownEffect(NamedPerson))
 
 
 === [D3] Fix 0: "Disable preferTypedSchemaDecoder for this line" ===
@@ -256,6 +288,17 @@ function decodeNestedGeneric<T extends string>(input: { readonly name: T; readon
 decodeGeneric(person)
 decodeNestedGeneric(person)
 
+// Regression test for https://github.com/Effect-TS/tsgo/issues/572.
+const NamedPerson = Schema.Struct({ name: Schema.String })
+
+function makeFields(name: string): { readonly name: string } {
+  return { name }
+}
+
+export const decoded = Schema.decodeUnknownEffect(NamedPerson)(makeFields("Ada"))
+
+export const pipedCallExpression = pipe("Ada", makeFields, Schema.decodeUnknownEffect(NamedPerson))
+
 
 === [D4] Fix 0: "Disable preferTypedSchemaDecoder for this line" ===
 skipped by default
@@ -322,6 +365,17 @@ function decodeNestedGeneric<T extends string>(input: { readonly name: T; readon
 
 decodeGeneric(person)
 decodeNestedGeneric(person)
+
+// Regression test for https://github.com/Effect-TS/tsgo/issues/572.
+const NamedPerson = Schema.Struct({ name: Schema.String })
+
+function makeFields(name: string): { readonly name: string } {
+  return { name }
+}
+
+export const decoded = Schema.decodeUnknownEffect(NamedPerson)(makeFields("Ada"))
+
+export const pipedCallExpression = pipe("Ada", makeFields, Schema.decodeUnknownEffect(NamedPerson))
 
 
 === [D5] Fix 0: "Disable preferTypedSchemaDecoder for this line" ===
@@ -390,6 +444,17 @@ function decodeNestedGeneric<T extends string>(input: { readonly name: T; readon
 decodeGeneric(person)
 decodeNestedGeneric(person)
 
+// Regression test for https://github.com/Effect-TS/tsgo/issues/572.
+const NamedPerson = Schema.Struct({ name: Schema.String })
+
+function makeFields(name: string): { readonly name: string } {
+  return { name }
+}
+
+export const decoded = Schema.decodeUnknownEffect(NamedPerson)(makeFields("Ada"))
+
+export const pipedCallExpression = pipe("Ada", makeFields, Schema.decodeUnknownEffect(NamedPerson))
+
 
 === [D6] Fix 0: "Disable preferTypedSchemaDecoder for this line" ===
 skipped by default
@@ -456,6 +521,17 @@ function decodeNestedGeneric<T extends string>(input: { readonly name: T; readon
 
 decodeGeneric(person)
 decodeNestedGeneric(person)
+
+// Regression test for https://github.com/Effect-TS/tsgo/issues/572.
+const NamedPerson = Schema.Struct({ name: Schema.String })
+
+function makeFields(name: string): { readonly name: string } {
+  return { name }
+}
+
+export const decoded = Schema.decodeUnknownEffect(NamedPerson)(makeFields("Ada"))
+
+export const pipedCallExpression = pipe("Ada", makeFields, Schema.decodeUnknownEffect(NamedPerson))
 
 
 === [D7] Fix 0: "Disable preferTypedSchemaDecoder for this line" ===
@@ -524,6 +600,17 @@ function decodeNestedGeneric<T extends string>(input: { readonly name: T; readon
 decodeGeneric(person)
 decodeNestedGeneric(person)
 
+// Regression test for https://github.com/Effect-TS/tsgo/issues/572.
+const NamedPerson = Schema.Struct({ name: Schema.String })
+
+function makeFields(name: string): { readonly name: string } {
+  return { name }
+}
+
+export const decoded = Schema.decodeUnknownEffect(NamedPerson)(makeFields("Ada"))
+
+export const pipedCallExpression = pipe("Ada", makeFields, Schema.decodeUnknownEffect(NamedPerson))
+
 
 === [D8] Fix 0: "Disable preferTypedSchemaDecoder for this line" ===
 skipped by default
@@ -591,6 +678,17 @@ function decodeNestedGeneric<T extends string>(input: { readonly name: T; readon
 decodeGeneric(person)
 decodeNestedGeneric(person)
 
+// Regression test for https://github.com/Effect-TS/tsgo/issues/572.
+const NamedPerson = Schema.Struct({ name: Schema.String })
+
+function makeFields(name: string): { readonly name: string } {
+  return { name }
+}
+
+export const decoded = Schema.decodeUnknownEffect(NamedPerson)(makeFields("Ada"))
+
+export const pipedCallExpression = pipe("Ada", makeFields, Schema.decodeUnknownEffect(NamedPerson))
+
 
 === [D9] Fix 0: "Disable preferTypedSchemaDecoder for this line" ===
 skipped by default
@@ -657,6 +755,17 @@ function decodeNestedGeneric<T extends string>(input: { readonly name: T; readon
 
 decodeGeneric(person)
 decodeNestedGeneric(person)
+
+// Regression test for https://github.com/Effect-TS/tsgo/issues/572.
+const NamedPerson = Schema.Struct({ name: Schema.String })
+
+function makeFields(name: string): { readonly name: string } {
+  return { name }
+}
+
+export const decoded = Schema.decodeUnknownEffect(NamedPerson)(makeFields("Ada"))
+
+export const pipedCallExpression = pipe("Ada", makeFields, Schema.decodeUnknownEffect(NamedPerson))
 
 
 === [D10] Fix 0: "Disable preferTypedSchemaDecoder for this line" ===
@@ -730,4 +839,171 @@ function decodeNestedGeneric<T extends string>(input: { readonly name: T; readon
 
 decodeGeneric(person)
 decodeNestedGeneric(person)
+
+// Regression test for https://github.com/Effect-TS/tsgo/issues/572.
+const NamedPerson = Schema.Struct({ name: Schema.String })
+
+function makeFields(name: string): { readonly name: string } {
+  return { name }
+}
+
+export const decoded = Schema.decodeUnknownEffect(NamedPerson)(makeFields("Ada"))
+
+export const pipedCallExpression = pipe("Ada", makeFields, Schema.decodeUnknownEffect(NamedPerson))
+
+
+=== [D12] Fix 0: "Disable preferTypedSchemaDecoder for this line" ===
+skipped by default
+
+=== [D12] Fix 1: "Disable preferTypedSchemaDecoder for entire file" ===
+skipped by default
+
+=== [D12] Fix 2: "Replace with decodeEffect" ===
+
+--- file:///.src/preferTypedSchemaDecoder.ts ---
+// @effect-diagnostics *:off
+// @effect-diagnostics preferTypedSchemaDecoder:warning
+
+import { pipe, Schema } from "effect"
+import { decodeUnknownSync } from "effect/Schema"
+import * as SchemaParser from "effect/SchemaParser"
+
+const Person = Schema.Struct({
+  name: Schema.String,
+  coordinates: Schema.Tuple([Schema.Number, Schema.Number])
+})
+
+const person = {
+  name: "Ada",
+  coordinates: [1, 2] as [number, number]
+}
+
+// Typed variables and contextually typed literals are reported.
+export const sync = Schema.decodeUnknownSync(Person)(person)
+export const literal = Schema.decodeUnknownSync(Person)({ name: "Ada", coordinates: [1, 2] })
+export const effect = Schema.decodeUnknownEffect(Person)(person)
+export const exit = Schema.decodeUnknownExit(Person)(person)
+export const option = Schema.decodeUnknownOption(Person)(person)
+export const result = Schema.decodeUnknownResult(Person)(person)
+export const promise = Schema.decodeUnknownPromise(Person)(person)
+
+// SchemaParser APIs and piping forms are normalized through piping flows.
+export const parser = SchemaParser.decodeUnknownSync(Person)(person)
+export const piped = pipe(person, Schema.decodeUnknownSync(Person))
+export const named = decodeUnknownSync(Person)(person)
+
+// Application options do not prevent recognizing the decoder application.
+export const withOptions = Schema.decodeUnknownSync(Person)({ name: "Ada", coordinates: [1, 2] }, { errors: "all" })
+
+declare const unknownInput: unknown
+declare const anyInput: any
+declare const wrongInput: { readonly name: number }
+
+// Unknown, any, incompatible, and unresolved generic inputs are valid uses.
+Schema.decodeUnknownSync(Person)(unknownInput)
+Schema.decodeUnknownSync(Person)(anyInput)
+Schema.decodeUnknownSync(Person)(wrongInput)
+Schema.decodeUnknownSync(Person)({ name: 1, coordinates: [1, 2] })
+Schema.decodeUnknownSync(Person)({ name: "Ada" })
+Schema.decodeUnknownSync(Person)({ name: "Ada", coordinates: [1] })
+
+function decodeGeneric<T>(input: T) {
+  return Schema.decodeUnknownSync(Person)(input)
+}
+
+function decodeNestedGeneric<T extends string>(input: { readonly name: T; readonly coordinates: [number, number] }) {
+  return Schema.decodeUnknownSync(Person)(input)
+}
+
+decodeGeneric(person)
+decodeNestedGeneric(person)
+
+// Regression test for https://github.com/Effect-TS/tsgo/issues/572.
+const NamedPerson = Schema.Struct({ name: Schema.String })
+
+function makeFields(name: string): { readonly name: string } {
+  return { name }
+}
+
+export const decoded = Schema.decodeEffect(NamedPerson)(makeFields("Ada"))
+
+export const pipedCallExpression = pipe("Ada", makeFields, Schema.decodeUnknownEffect(NamedPerson))
+
+
+=== [D13] Fix 0: "Disable preferTypedSchemaDecoder for this line" ===
+skipped by default
+
+=== [D13] Fix 1: "Disable preferTypedSchemaDecoder for entire file" ===
+skipped by default
+
+=== [D13] Fix 2: "Replace with decodeEffect" ===
+
+--- file:///.src/preferTypedSchemaDecoder.ts ---
+// @effect-diagnostics *:off
+// @effect-diagnostics preferTypedSchemaDecoder:warning
+
+import { pipe, Schema } from "effect"
+import { decodeUnknownSync } from "effect/Schema"
+import * as SchemaParser from "effect/SchemaParser"
+
+const Person = Schema.Struct({
+  name: Schema.String,
+  coordinates: Schema.Tuple([Schema.Number, Schema.Number])
+})
+
+const person = {
+  name: "Ada",
+  coordinates: [1, 2] as [number, number]
+}
+
+// Typed variables and contextually typed literals are reported.
+export const sync = Schema.decodeUnknownSync(Person)(person)
+export const literal = Schema.decodeUnknownSync(Person)({ name: "Ada", coordinates: [1, 2] })
+export const effect = Schema.decodeUnknownEffect(Person)(person)
+export const exit = Schema.decodeUnknownExit(Person)(person)
+export const option = Schema.decodeUnknownOption(Person)(person)
+export const result = Schema.decodeUnknownResult(Person)(person)
+export const promise = Schema.decodeUnknownPromise(Person)(person)
+
+// SchemaParser APIs and piping forms are normalized through piping flows.
+export const parser = SchemaParser.decodeUnknownSync(Person)(person)
+export const piped = pipe(person, Schema.decodeUnknownSync(Person))
+export const named = decodeUnknownSync(Person)(person)
+
+// Application options do not prevent recognizing the decoder application.
+export const withOptions = Schema.decodeUnknownSync(Person)({ name: "Ada", coordinates: [1, 2] }, { errors: "all" })
+
+declare const unknownInput: unknown
+declare const anyInput: any
+declare const wrongInput: { readonly name: number }
+
+// Unknown, any, incompatible, and unresolved generic inputs are valid uses.
+Schema.decodeUnknownSync(Person)(unknownInput)
+Schema.decodeUnknownSync(Person)(anyInput)
+Schema.decodeUnknownSync(Person)(wrongInput)
+Schema.decodeUnknownSync(Person)({ name: 1, coordinates: [1, 2] })
+Schema.decodeUnknownSync(Person)({ name: "Ada" })
+Schema.decodeUnknownSync(Person)({ name: "Ada", coordinates: [1] })
+
+function decodeGeneric<T>(input: T) {
+  return Schema.decodeUnknownSync(Person)(input)
+}
+
+function decodeNestedGeneric<T extends string>(input: { readonly name: T; readonly coordinates: [number, number] }) {
+  return Schema.decodeUnknownSync(Person)(input)
+}
+
+decodeGeneric(person)
+decodeNestedGeneric(person)
+
+// Regression test for https://github.com/Effect-TS/tsgo/issues/572.
+const NamedPerson = Schema.Struct({ name: Schema.String })
+
+function makeFields(name: string): { readonly name: string } {
+  return { name }
+}
+
+export const decoded = Schema.decodeUnknownEffect(NamedPerson)(makeFields("Ada"))
+
+export const pipedCallExpression = pipe("Ada", makeFields, Schema.decodeEffect(NamedPerson))
 

--- a/testdata/tests/effect-v4/preferTypedSchemaDecoder.ts
+++ b/testdata/tests/effect-v4/preferTypedSchemaDecoder.ts
@@ -54,3 +54,14 @@ function decodeNestedGeneric<T extends string>(input: { readonly name: T; readon
 
 decodeGeneric(person)
 decodeNestedGeneric(person)
+
+// Regression test for https://github.com/Effect-TS/tsgo/issues/572.
+const NamedPerson = Schema.Struct({ name: Schema.String })
+
+function makeFields(name: string): { readonly name: string } {
+  return { name }
+}
+
+export const decoded = Schema.decodeUnknownEffect(NamedPerson)(makeFields("Ada"))
+
+export const pipedCallExpression = pipe("Ada", makeFields, Schema.decodeUnknownEffect(NamedPerson))


### PR DESCRIPTION
## Summary

- guard contextual literal analysis when a piping-flow intermediate has a type but no corresponding AST node
- preserve assignability analysis using the intermediate transformation output type
- cover both nested call-expression inputs and multi-stage `pipe` inputs

## Example

```ts
Schema.decodeUnknownEffect(Person)(makeFields("Ada"))
pipe("Ada", makeFields, Schema.decodeUnknownEffect(Person))
```

Both forms now report `preferTypedSchemaDecoder` normally instead of panicking.

## Validation

- `pnpm lint`
- `pnpm check`
- `pnpm test`

Closes #572