### PR TITLE
fix: preserve JSON formatting during setup

### DIFF
--- a/.changeset/preserve-setup-json-formatting.md
+++ b/.changeset/preserve-setup-json-formatting.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Preserve existing indentation and newline styles when setup updates JSON configuration files.

--- a/_packages/tsgo/src/cli/setup/changes.ts
+++ b/_packages/tsgo/src/cli/setup/changes.ts
@@ -90,6 +90,8 @@ function deleteNodeFromList<T extends ts.Node>(
   }
 }
 
+const emptyListInsertions = new WeakMap<object, WeakSet<object>>()
+
 /**
  * Insert a node at the end of a list (array or object properties), handling commas properly
  */
@@ -99,12 +101,57 @@ function insertNodeAtEndOfList<T extends ts.Node>(
   nodeArray: ts.NodeArray<T>,
   newNode: T
 ) {
+  const formatOptions = getFormatOptions(sourceFile)
   if (nodeArray.length === 0) {
-    tracker.insertNodeAt(sourceFile, nodeArray.pos + 1, newNode, { suffix: "\n" })
+    const insertedLists = emptyListInsertions.get(tracker) ?? new WeakSet<object>()
+    const hasPreviousInsertion = insertedLists.has(nodeArray)
+    insertedLists.add(nodeArray)
+    emptyListInsertions.set(tracker, insertedLists)
+    const closingIndentation = getIndentationAtPosition(sourceFile, nodeArray.pos, formatOptions.tabSize)
+    const hasFollowingLineBreak = /^[ \t]*\r?\n/.test(sourceFile.text.slice(nodeArray.pos))
+    tracker.insertNodeAt(sourceFile, nodeArray.pos, newNode, {
+      indentation: closingIndentation.column + formatOptions.indentSize,
+      prefix: formatOptions.newLineCharacter,
+      suffix: hasPreviousInsertion
+        ? ","
+        : hasFollowingLineBreak ? "" : `${formatOptions.newLineCharacter}${closingIndentation.text}`
+    })
   } else {
     const lastElement = nodeArray[nodeArray.length - 1]
-    tracker.insertNodeAt(sourceFile, lastElement.end, newNode, { prefix: ",\n" })
+    const indentation = getIndentationAtPosition(
+      sourceFile,
+      lastElement.getStart(sourceFile),
+      formatOptions.tabSize
+    )
+    tracker.insertNodeAt(sourceFile, lastElement.end, newNode, {
+      indentation: indentation.column,
+      prefix: `,${formatOptions.newLineCharacter}`
+    })
   }
+}
+
+function getFormatOptions(sourceFile: ts.SourceFile) {
+  const indentation = sourceFile.text.match(/^([ \t]+)\S/m)?.[1]
+  const indentSize = indentation?.includes("\t") ? 2 : indentation?.length ?? 2
+  const newLineCharacter = sourceFile.text.includes("\r\n") ? "\r\n" : "\n"
+  return {
+    ...ts.getDefaultFormatCodeSettings(newLineCharacter),
+    indentSize,
+    tabSize: indentSize,
+    convertTabsToSpaces: !indentation?.includes("\t"),
+    newLineCharacter
+  }
+}
+
+function getIndentationAtPosition(sourceFile: ts.SourceFile, position: number, tabSize: number) {
+  const { line } = sourceFile.getLineAndCharacterOfPosition(position)
+  const lineStart = sourceFile.getPositionOfLineAndCharacter(line, 0)
+  const text = sourceFile.text.slice(lineStart, position).match(/^[ \t]*/)?.[0] ?? ""
+  const column = [...text].reduce(
+    (column, character) => character === "\t" ? column + tabSize - (column % tabSize) : column + 1,
+    0
+  )
+  return { column, text }
 }
 
 function findDependencyCollectionProperty(
@@ -211,9 +258,9 @@ const tsInternal = ts as any
 /**
  * Create a ChangeTracker context
  */
-function createTrackerContext() {
+function createTrackerContext(sourceFile: ts.SourceFile) {
   const host = createMinimalHost()
-  const formatOptions = { indentSize: 2, tabSize: 2 } as ts.EditorSettings
+  const formatOptions = getFormatOptions(sourceFile)
   const formatContext = tsInternal.formatting.getFormatContext(formatOptions, host)
   const preferences = {} as ts.UserPreferences
   return { host, formatContext, preferences }
@@ -234,7 +281,7 @@ const computePackageJsonChanges = (
     return emptyFileChangesResult()
   }
 
-  const ctx = createTrackerContext()
+  const ctx = createTrackerContext(current.sourceFile)
 
   const fileChanges = tsInternal.textChanges.ChangeTracker.with(
     ctx,
@@ -606,7 +653,7 @@ const computeTsConfigChanges = (
       const schemaProperty = findPropertyInObject(rootObj, "$schema")
       if (!isEffectSchemaProperty(schemaProperty)) return emptyFileChangesResult()
 
-      const ctx = createTrackerContext()
+      const ctx = createTrackerContext(current.sourceFile)
       const fileChanges = tsInternal.textChanges.ChangeTracker.with(ctx, (tracker: any) => {
         descriptions.push("Remove $schema from tsconfig")
         deleteNodeFromList(tracker, current.sourceFile, rootObj.properties, schemaProperty!)
@@ -628,7 +675,7 @@ const computeTsConfigChanges = (
     }
 
     // Create compilerOptions with the plugin entry
-    const ctx = createTrackerContext()
+    const ctx = createTrackerContext(current.sourceFile)
 
     const fileChanges = tsInternal.textChanges.ChangeTracker.with(
       ctx,
@@ -706,7 +753,7 @@ const computeTsConfigChanges = (
 
   const compilerOptions = compilerOptionsProperty.initializer
 
-  const ctx = createTrackerContext()
+  const ctx = createTrackerContext(current.sourceFile)
 
   const fileChanges = tsInternal.textChanges.ChangeTracker.with(
     ctx,
@@ -858,7 +905,7 @@ const computeOxlintConfigChanges = (
     ts.factory.createStringLiteral("$schema"),
     ts.factory.createStringLiteral(schemaPath.value)
   )
-  const ctx = createTrackerContext()
+  const ctx = createTrackerContext(current.sourceFile)
   const fileChanges = tsInternal.textChanges.ChangeTracker.with(ctx, (tracker: any) => {
     if (schemaProperty) {
       tracker.replaceNode(current.sourceFile, schemaProperty.initializer, schemaPropertyAssignment.initializer)
@@ -897,7 +944,7 @@ const computeVSCodeSettingsChanges = (
     return emptyFileChangesResult()
   }
 
-  const ctx = createTrackerContext()
+  const ctx = createTrackerContext(current.sourceFile)
 
   const createSettingValue = (value: unknown): ts.Expression =>
     typeof value === "string"

--- a/_packages/tsgo/test/setup/__snapshots__/setup-cli.test.ts.snap
+++ b/_packages/tsgo/test/setup/__snapshots__/setup-cli.test.ts.snap
@@ -25,13 +25,13 @@ exports[`Setup CLI > should add LSP plugin alongside existing plugins > package.
   "name": "test-project",
   "version": "1.0.0",
   "dependencies": {},
-"devDependencies": { "@effect/tsgo": "^0.0.5","typescript": "7.1.0-dev.test" }
+  "devDependencies": { "@effect/tsgo": "^0.0.5", "typescript": "7.1.0-dev.test" }
 }"
 `;
 
 exports[`Setup CLI > should add LSP plugin alongside existing plugins > tsconfig.json 1`] = `
 "{
-	"$schema": "./node_modules/@effect/tsgo/schema.json",
+  "$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -39,9 +39,9 @@ exports[`Setup CLI > should add LSP plugin alongside existing plugins > tsconfig
       {
         "name": "typescript-plugin-css-modules"
       },
-{
-	"name": "@effect/language-service"
-}
+      {
+        "name": "@effect/language-service"
+      }
     ]
   }
 }"
@@ -94,21 +94,21 @@ exports[`Setup CLI > should add LSP with VS Code editor selected and create new 
   "name": "test-project",
   "version": "1.0.0",
   "dependencies": {},
-"devDependencies": { "@effect/tsgo": "^0.0.5","typescript": "7.1.0-dev.test" }
+  "devDependencies": { "@effect/tsgo": "^0.0.5", "typescript": "7.1.0-dev.test" }
 }"
 `;
 
 exports[`Setup CLI > should add LSP with VS Code editor selected and create new settings file > tsconfig.json 1`] = `
 "{
-	"$schema": "./node_modules/@effect/tsgo/schema.json",
+  "$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
-"plugins": [
-	{
-		"name": "@effect/language-service"
-	}
-]
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
   }
 }"
 `;
@@ -138,25 +138,25 @@ exports[`Setup CLI > should add LSP with custom diagnostic severities when no pl
   "name": "test-project",
   "version": "1.0.0",
   "dependencies": {},
-"devDependencies": { "@effect/tsgo": "^0.0.5","typescript": "7.1.0-dev.test" }
+  "devDependencies": { "@effect/tsgo": "^0.0.5", "typescript": "7.1.0-dev.test" }
 }"
 `;
 
 exports[`Setup CLI > should add LSP with custom diagnostic severities when no plugin exists > tsconfig.json 1`] = `
 "{
-	"$schema": "./node_modules/@effect/tsgo/schema.json",
+  "$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
-"plugins": [
-	{
-		"name": "@effect/language-service",
-		"diagnosticSeverity": {
-			"floatingEffect": "warning",
-			"missingEffectError": "off"
-		}
-	}
-]
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnosticSeverity": {
+          "floatingEffect": "warning",
+          "missingEffectError": "off"
+        }
+      }
+    ]
   }
 }"
 `;
@@ -188,24 +188,24 @@ exports[`Setup CLI > should add custom diagnostic severities when plugin exists 
   "dependencies": {},
   "devDependencies": {
     "@effect/tsgo": "^0.0.5",
-"typescript": "7.1.0-dev.test"
+    "typescript": "7.1.0-dev.test"
   }
 }"
 `;
 
 exports[`Setup CLI > should add custom diagnostic severities when plugin exists without custom values > tsconfig.json 1`] = `
 "{
-	"$schema": "./node_modules/@effect/tsgo/schema.json",
+  "$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
     "plugins": [
       {
         "name": "@effect/language-service",
-"diagnosticSeverity": {
-	"floatingEffect": "warning",
-	"missingEffectContext": "message"
-}
+        "diagnosticSeverity": {
+          "floatingEffect": "warning",
+          "missingEffectContext": "message"
+        }
       }
     ]
   }
@@ -242,14 +242,14 @@ exports[`Setup CLI > should generate changes for Astro-style configs using the l
   "devDependencies": {
     "@effect/language-service": "^0.80.0",
     "typescript": "7.1.0-dev.test",
-"@effect/tsgo": "^0.0.5"
+    "@effect/tsgo": "^0.0.5"
   }
 }"
 `;
 
 exports[`Setup CLI > should generate changes for Astro-style configs using the legacy prepare command > tsconfig.json 1`] = `
 "{
-	"$schema": "./node_modules/@effect/tsgo/schema.json",
+  "$schema": "./node_modules/@effect/tsgo/schema.json",
   "extends": "astro/tsconfigs/strictest",
   "include": [
     ".astro/types.d.ts",
@@ -305,21 +305,21 @@ exports[`Setup CLI > should generate changes for adding LSP with defaults > pack
   "name": "test-project",
   "version": "1.0.0",
   "dependencies": {},
-"devDependencies": { "@effect/tsgo": "^0.0.5","typescript": "7.1.0-dev.test" }
+  "devDependencies": { "@effect/tsgo": "^0.0.5", "typescript": "7.1.0-dev.test" }
 }"
 `;
 
 exports[`Setup CLI > should generate changes for adding LSP with defaults > tsconfig.json 1`] = `
 "{
-	"$schema": "./node_modules/@effect/tsgo/schema.json",
+  "$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
-"plugins": [
-	{
-		"name": "@effect/language-service"
-	}
-]
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
   }
 }"
 `;
@@ -349,22 +349,22 @@ exports[`Setup CLI > should generate changes for adding LSP with prepare script 
   "name": "test-project",
   "version": "1.0.0",
   "dependencies": {},
-"scripts": { "prepare": "effect-tsgo patch --typescript --no-oxlint" },
-"devDependencies": { "@effect/tsgo": "^0.0.5","typescript": "7.1.0-dev.test" }
+  "scripts": { "prepare": "effect-tsgo patch --typescript --no-oxlint" },
+  "devDependencies": { "@effect/tsgo": "^0.0.5", "typescript": "7.1.0-dev.test" }
 }"
 `;
 
 exports[`Setup CLI > should generate changes for adding LSP with prepare script > tsconfig.json 1`] = `
 "{
-	"$schema": "./node_modules/@effect/tsgo/schema.json",
+  "$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
-"plugins": [
-	{
-		"name": "@effect/language-service"
-	}
-]
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
   }
 }"
 `;
@@ -479,13 +479,13 @@ exports[`Setup CLI > should not override existing plugins when adding LSP plugin
   "name": "test-project",
   "version": "1.0.0",
   "dependencies": {},
-"devDependencies": { "@effect/tsgo": "^0.0.5","typescript": "7.1.0-dev.test" }
+  "devDependencies": { "@effect/tsgo": "^0.0.5", "typescript": "7.1.0-dev.test" }
 }"
 `;
 
 exports[`Setup CLI > should not override existing plugins when adding LSP plugin > tsconfig.json 1`] = `
 "{
-	"$schema": "./node_modules/@effect/tsgo/schema.json",
+  "$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -499,9 +499,9 @@ exports[`Setup CLI > should not override existing plugins when adding LSP plugin
       {
         "name": "another-typescript-plugin"
       },
-{
-	"name": "@effect/language-service"
-}
+      {
+        "name": "@effect/language-service"
+      }
     ]
   }
 }"
@@ -524,10 +524,10 @@ exports[`Setup CLI > should preserve all existing VS Code settings from a real r
   "editor.wordBasedSuggestions": "matchingDocuments",
   "editor.parameterHints.enabled": true,
   "files.insertFinalNewline": true,
-"js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"],
-"js/ts.tsdk.promptToUseWorkspaceVersion": true,
-"js/ts.tsdk.path": "./node_modules/typescript/bin",
-"js/ts.experimental.useTsgo": true
+  "js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"],
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+  "js/ts.tsdk.path": "./node_modules/typescript/bin",
+  "js/ts.experimental.useTsgo": true
 }"
 `;
 
@@ -566,21 +566,21 @@ exports[`Setup CLI > should preserve all existing VS Code settings from a real r
   "name": "test-project",
   "version": "1.0.0",
   "dependencies": {},
-"devDependencies": { "@effect/tsgo": "^0.0.5","typescript": "7.1.0-dev.test" }
+  "devDependencies": { "@effect/tsgo": "^0.0.5", "typescript": "7.1.0-dev.test" }
 }"
 `;
 
 exports[`Setup CLI > should preserve all existing VS Code settings from a real repository config > tsconfig.json 1`] = `
 "{
-	"$schema": "./node_modules/@effect/tsgo/schema.json",
+  "$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
-"plugins": [
-	{
-		"name": "@effect/language-service"
-	}
-]
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
   }
 }"
 `;
@@ -590,10 +590,10 @@ exports[`Setup CLI > should preserve existing VS Code settings when adding LSP-s
   "editor.formatOnSave": true,
   "editor.tabSize": 2,
   "files.autoSave": "onFocusChange",
-"js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"],
-"js/ts.tsdk.promptToUseWorkspaceVersion": true,
-"js/ts.tsdk.path": "./node_modules/typescript/bin",
-"js/ts.experimental.useTsgo": true
+  "js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"],
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+  "js/ts.tsdk.path": "./node_modules/typescript/bin",
+  "js/ts.experimental.useTsgo": true
 }"
 `;
 
@@ -632,21 +632,21 @@ exports[`Setup CLI > should preserve existing VS Code settings when adding LSP-s
   "name": "test-project",
   "version": "1.0.0",
   "dependencies": {},
-"devDependencies": { "@effect/tsgo": "^0.0.5","typescript": "7.1.0-dev.test" }
+  "devDependencies": { "@effect/tsgo": "^0.0.5", "typescript": "7.1.0-dev.test" }
 }"
 `;
 
 exports[`Setup CLI > should preserve existing VS Code settings when adding LSP-specific settings > tsconfig.json 1`] = `
 "{
-	"$schema": "./node_modules/@effect/tsgo/schema.json",
+  "$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
-"plugins": [
-	{
-		"name": "@effect/language-service"
-	}
-]
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
   }
 }"
 `;
@@ -766,7 +766,7 @@ exports[`Setup CLI > should replace existing tsconfig schema when adding LSP > p
   "name": "test-project",
   "version": "1.0.0",
   "dependencies": {},
-"devDependencies": { "@effect/tsgo": "^0.0.5","typescript": "7.1.0-dev.test" }
+  "devDependencies": { "@effect/tsgo": "^0.0.5", "typescript": "7.1.0-dev.test" }
 }"
 `;
 
@@ -776,11 +776,11 @@ exports[`Setup CLI > should replace existing tsconfig schema when adding LSP > t
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
-"plugins": [
-	{
-		"name": "@effect/language-service"
-	}
-]
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
   }
 }"
 `;
@@ -819,7 +819,7 @@ exports[`Setup CLI > should update LSP version when already installed with older
 
 exports[`Setup CLI > should update LSP version when already installed with older version > tsconfig.json 1`] = `
 "{
-	"$schema": "./node_modules/@effect/tsgo/schema.json",
+  "$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -859,14 +859,14 @@ exports[`Setup CLI > should update custom diagnostic severities when plugin alre
   "dependencies": {},
   "devDependencies": {
     "@effect/tsgo": "^0.0.5",
-"typescript": "7.1.0-dev.test"
+    "typescript": "7.1.0-dev.test"
   }
 }"
 `;
 
 exports[`Setup CLI > should update custom diagnostic severities when plugin already has custom values > tsconfig.json 1`] = `
 "{
-	"$schema": "./node_modules/@effect/tsgo/schema.json",
+  "$schema": "./node_modules/@effect/tsgo/schema.json",
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
@@ -874,10 +874,10 @@ exports[`Setup CLI > should update custom diagnostic severities when plugin alre
       {
         "name": "@effect/language-service",
         "diagnosticSeverity": {
-					"floatingEffect": "warning",
-					"missingEffectError": "off",
-					"missingLayerContext": "error"
-				}
+          "floatingEffect": "warning",
+          "missingEffectError": "off",
+          "missingLayerContext": "error"
+        }
       }
     ]
   }

--- a/_packages/tsgo/test/setup/changes.test.ts
+++ b/_packages/tsgo/test/setup/changes.test.ts
@@ -985,4 +985,98 @@ describe("computeChanges", () => {
       expect(rendered).not.toContain("diagnosticSeverity")
     })
   })
+
+  describe("JSON indentation", () => {
+    it.each([
+      ["two spaces", "  ", "\n"],
+      ["four spaces", "    ", "\n"],
+      ["tabs", "\t", "\n"],
+      ["CRLF newlines", "  ", "\r\n"]
+    ])("should preserve %s in package.json", (_, indentation, newLine) => {
+      const packageJsonText = [
+        "{",
+        `${indentation}"name": "test-project",`,
+        `${indentation}"devDependencies": {`,
+        `${indentation.repeat(2)}"typescript": "${TEST_TYPESCRIPT_VERSION}"`,
+        `${indentation}}`,
+        "}"
+      ].join(newLine)
+      const result = runComputeChanges({
+        packageJsonText,
+        typescriptVersion: null,
+        prepareScript: false,
+        editors: [],
+        vscodeTargetSettings: null
+      })
+      const change = result.codeActions
+        .flatMap((action) => action.changes)
+        .find((change) => change.fileName === "/test/package.json")
+      const updated = applyTextChanges(packageJsonText, change?.textChanges ?? [])
+
+      expect(updated).toContain(`${newLine}${indentation.repeat(2)}"@effect/tsgo": "0.0.4"`)
+      expect(() => JSON.parse(updated)).not.toThrow()
+    })
+
+    it.each([
+      ["two spaces", "  "],
+      ["four spaces", "    "],
+      ["tabs", "\t"]
+    ])("should preserve %s in tsconfig.json", (_, indentation) => {
+      const tsconfigText = [
+        "{",
+        `${indentation}"compilerOptions": {`,
+        `${indentation.repeat(2)}"strict": true`,
+        `${indentation}}`,
+        "}"
+      ].join("\n")
+      const result = runComputeChanges({
+        tsconfigText,
+        prepareScript: false,
+        editors: [],
+        vscodeTargetSettings: null
+      })
+      const change = result.codeActions
+        .flatMap((action) => action.changes)
+        .find((change) => change.fileName === "/test/tsconfig.json")
+      const updated = applyTextChanges(tsconfigText, change?.textChanges ?? [])
+
+      expect(updated).toContain(`\n${indentation}"$schema"`)
+      expect(updated).toContain(`\n${indentation.repeat(2)}"plugins"`)
+      expect(updated).toContain(`\n${indentation.repeat(4)}"name": "@effect/language-service"`)
+      expect(() => JSON.parse(updated)).not.toThrow()
+    })
+
+    it.each([
+      { layout: "inline", lines: ["  \"devDependencies\": {}"] },
+      { layout: "multiline", lines: ["  \"devDependencies\": {", "  }"] }
+    ])("should indent properties added to an $layout empty object", ({ lines }) => {
+      const packageJsonText = [
+        "{",
+        "  \"name\": \"test-project\",",
+        ...lines,
+        "}"
+      ].join("\n")
+      const result = runComputeChanges({
+        packageJsonText,
+        prepareScript: false,
+        editors: [],
+        vscodeTargetSettings: null
+      })
+      const change = result.codeActions
+        .flatMap((action) => action.changes)
+        .find((change) => change.fileName === "/test/package.json")
+      const updated = applyTextChanges(packageJsonText, change?.textChanges ?? [])
+
+      expect(updated).toBe([
+        "{",
+        "  \"name\": \"test-project\",",
+        "  \"devDependencies\": {",
+        `    "typescript": "${TEST_TYPESCRIPT_VERSION}",`,
+        "    \"@effect/tsgo\": \"0.0.4\"",
+        "  }",
+        "}"
+      ].join("\n"))
+      expect(() => JSON.parse(updated)).not.toThrow()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- detect indentation and newline conventions from each existing JSON configuration file
- preserve two-space, four-space, and tab indentation when inserting properties or array elements
- preserve LF and CRLF newlines
- correctly handle multiple insertions into initially empty objects
- add regression coverage for indentation styles, newlines, and empty-object layouts

## Why

Setup used fixed two-space formatting and hardcoded LF newlines. This caused inserted content to be misaligned in files using four spaces, tabs, or CRLF, and could format multiple insertions into empty objects incorrectly.

## Example

Previously, adding a dependency to a four-space-indented file could produce:

```json
{
    "devDependencies": {
        "typescript": "7.1.0",
"@effect/tsgo": "0.36.0"
    }
}
```

Now the existing formatting is preserved:

```json
{
    "devDependencies": {
        "typescript": "7.1.0",
        "@effect/tsgo": "0.36.0"
    }
}
```

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `git diff --check`