### PR TITLE
chore: update Effect beta to 4.0.0-beta.107

### DIFF
--- a/.changeset/update-effect-beta-107.md
+++ b/.changeset/update-effect-beta-107.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Update Effect v4 dependencies and embedded test fixtures to `4.0.0-beta.107`.

--- a/_packages/tsgo/package.json
+++ b/_packages/tsgo/package.json
@@ -58,12 +58,12 @@
     "@effect/tsgo-darwin-arm64": "workspace:*"
   },
   "devDependencies": {
-    "@effect/platform-node": "^4.0.0-beta.104",
-    "@effect/platform-node-shared": "^4.0.0-beta.104",
+    "@effect/platform-node": "^4.0.0-beta.107",
+    "@effect/platform-node-shared": "^4.0.0-beta.107",
     "@types/node": "^24.3.0",
     "tsdown": "^0.20.1",
     "typescript": "^5.9.2",
-    "effect": "^4.0.0-beta.104",
+    "effect": "^4.0.0-beta.107",
     "vitest": "^3.2.1"
   }
 }

--- a/_tools/repoctl/package.json
+++ b/_tools/repoctl/package.json
@@ -11,8 +11,8 @@
     "test": "node --test test/*.test.ts"
   },
   "dependencies": {
-    "@effect/platform-node": "^4.0.0-beta.104",
-    "effect": "^4.0.0-beta.104",
+    "@effect/platform-node": "^4.0.0-beta.107",
+    "effect": "^4.0.0-beta.107",
     "semver": "^7.7.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,17 +18,17 @@ importers:
   _packages/tsgo:
     devDependencies:
       '@effect/platform-node':
-        specifier: ^4.0.0-beta.104
-        version: 4.0.0-beta.104(effect@4.0.0-beta.104)(ioredis@5.9.2)
+        specifier: ^4.0.0-beta.107
+        version: 4.0.0-beta.107(effect@4.0.0-beta.107)(ioredis@5.9.2)
       '@effect/platform-node-shared':
-        specifier: ^4.0.0-beta.104
-        version: 4.0.0-beta.104(effect@4.0.0-beta.104)
+        specifier: ^4.0.0-beta.107
+        version: 4.0.0-beta.107(effect@4.0.0-beta.107)
       '@types/node':
         specifier: ^24.3.0
         version: 24.10.13
       effect:
-        specifier: ^4.0.0-beta.104
-        version: 4.0.0-beta.104
+        specifier: ^4.0.0-beta.107
+        version: 4.0.0-beta.107
       tsdown:
         specifier: ^0.20.1
         version: 0.20.3(typescript@5.9.3)
@@ -78,11 +78,11 @@ importers:
   _tools/repoctl:
     dependencies:
       '@effect/platform-node':
-        specifier: ^4.0.0-beta.104
-        version: 4.0.0-beta.104(effect@4.0.0-beta.104)(ioredis@5.9.2)
+        specifier: ^4.0.0-beta.107
+        version: 4.0.0-beta.107(effect@4.0.0-beta.107)(ioredis@5.9.2)
       effect:
-        specifier: ^4.0.0-beta.104
-        version: 4.0.0-beta.104
+        specifier: ^4.0.0-beta.107
+        version: 4.0.0-beta.107
       semver:
         specifier: ^7.7.2
         version: 7.8.5
@@ -145,8 +145,8 @@ importers:
   testdata/tests/effect-v4:
     dependencies:
       '@effect/vitest':
-        specifier: 4.0.0-beta.104
-        version: 4.0.0-beta.104(effect@4.0.0-beta.104)(vitest@4.1.10(@types/node@22.19.15)(vite@7.3.1(@types/node@22.19.15)(yaml@2.9.0)))
+        specifier: 4.0.0-beta.107
+        version: 4.0.0-beta.107(effect@4.0.0-beta.107)(vitest@4.1.10(@types/node@22.19.15)(vite@7.3.1(@types/node@22.19.15)(yaml@2.9.0)))
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
@@ -157,8 +157,8 @@ importers:
         specifier: 4.1.10
         version: 4.1.10
       effect:
-        specifier: 4.0.0-beta.104
-        version: 4.0.0-beta.104
+        specifier: 4.0.0-beta.107
+        version: 4.0.0-beta.107
       fast-check:
         specifier: ^4.4.0
         version: 4.5.3
@@ -178,8 +178,8 @@ importers:
         specifier: ^22.0.0
         version: 22.19.15
       effect:
-        specifier: 4.0.0-beta.104
-        version: 4.0.0-beta.104
+        specifier: 4.0.0-beta.107
+        version: 4.0.0-beta.107
       fast-check:
         specifier: ^4.4.0
         version: 4.5.3
@@ -196,8 +196,8 @@ importers:
         specifier: ^22.0.0
         version: 22.19.15
       effect:
-        specifier: 4.0.0-beta.104
-        version: 4.0.0-beta.104
+        specifier: 4.0.0-beta.107
+        version: 4.0.0-beta.107
       fast-check:
         specifier: ^4.4.0
         version: 4.5.3
@@ -208,8 +208,8 @@ importers:
   testdata/tests/oxlint:
     dependencies:
       effect:
-        specifier: 4.0.0-beta.104
-        version: 4.0.0-beta.104
+        specifier: 4.0.0-beta.107
+        version: 4.0.0-beta.107
 
 packages:
 
@@ -303,18 +303,18 @@ packages:
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
-  '@effect/platform-node-shared@4.0.0-beta.104':
-    resolution: {integrity: sha512-wZQWlreuCfR+Ip6E93h2Wo56lFdBTflzSErFKxvrAW06/ORa7yZMD4oq4Ow5aU5+AlQgomQSEeBKM7uao4ZewQ==}
+  '@effect/platform-node-shared@4.0.0-beta.107':
+    resolution: {integrity: sha512-y6BqcRi86BfTJv+tvDrob4ozYVHxxlHYcn/zIQqZjXI9CvKnkgD6ng+38G1o45c4f2ucU+6HRI9POCmFdMoVGA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.104
+      effect: ^4.0.0-beta.107
 
-  '@effect/platform-node@4.0.0-beta.104':
-    resolution: {integrity: sha512-edqD0sRzL3Qow26TnD+RuHNVolFB7c1M/xWGzW0TRc7PzXpRWQawM1haMXOrB8W1UXpg8T8jF5MU56vFhPGJyw==}
+  '@effect/platform-node@4.0.0-beta.107':
+    resolution: {integrity: sha512-k+6YNbV4Ck0L6YXtlgkvEnuP5tlxWD8EeWOrpn46PDqbGEwt4ONpRltTwm3tn2cyBXD0i+2P11cUH/6sdFagTA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.104
-      ioredis: ^5.7.0
+      effect: ^4.0.0-beta.107
+      ioredis: '>=5.7.0 <6.0.0'
 
   '@effect/vitest@0.27.0':
     resolution: {integrity: sha512-8bM7n9xlMUYw9GqPIVgXFwFm2jf27m/R7psI64PGpwU5+26iwyxp9eAXEsfT5S6lqztYfpQQ1Ubp5o6HfNYzJQ==}
@@ -322,11 +322,11 @@ packages:
       effect: ^3.19.0
       vitest: ^3.2.0
 
-  '@effect/vitest@4.0.0-beta.104':
-    resolution: {integrity: sha512-09AvNl3tJNR7hOEnxE8TqSlBTeqfrWu/s4mIjlv1q6c/r6izkH/qhUrByP87ebbEtCMPJDHHXNcKFs3kEbugbQ==}
+  '@effect/vitest@4.0.0-beta.107':
+    resolution: {integrity: sha512-n4/qsx4DnT4dEI/wNgMivxyUeJoeiU1TCSz0WnoHWk/dny40Oxjip2P9IXGQDgPb9fsYVnerF0QRA6nPUuExQA==}
     peerDependencies:
-      effect: ^4.0.0-beta.104
-      vitest: ^4.1.0
+      effect: ^4.0.0-beta.107
+      vitest: '>=4.1.0 <5.0.0'
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -952,8 +952,8 @@ packages:
   effect@3.19.19:
     resolution: {integrity: sha512-Yc8U/SVXo2dHnaP7zNBlAo83h/nzSJpi7vph6Hzyl4ulgMBIgPmz3UzOjb9sBgpFE00gC0iETR244sfXDNLHRg==}
 
-  effect@4.0.0-beta.104:
-    resolution: {integrity: sha512-YSSaaMc8gBoHnabYXlgHpKVctsj4ezTSoojdd8SA3NWHoZ7LMPiUDhCnP1ZSOfQ7ly6P6XLhAw216NfLEHfg2A==}
+  effect@4.0.0-beta.107:
+    resolution: {integrity: sha512-OoBAv8eF+yanc+C6xhgEUnWeXUSHA6ynnscYqpkAY9GSnzZWystsIjBowVqCkLpHGlnRtdIqYT3wHwpOY6JDnQ==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -1582,19 +1582,19 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@effect/platform-node-shared@4.0.0-beta.104(effect@4.0.0-beta.104)':
+  '@effect/platform-node-shared@4.0.0-beta.107(effect@4.0.0-beta.107)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.104
+      effect: 4.0.0-beta.107
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.104(effect@4.0.0-beta.104)(ioredis@5.9.2)':
+  '@effect/platform-node@4.0.0-beta.107(effect@4.0.0-beta.107)(ioredis@5.9.2)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.104(effect@4.0.0-beta.104)
-      effect: 4.0.0-beta.104
+      '@effect/platform-node-shared': 4.0.0-beta.107(effect@4.0.0-beta.107)
+      effect: 4.0.0-beta.107
       ioredis: 5.9.2
       mime: 4.1.0
       undici: 8.9.0
@@ -1607,9 +1607,9 @@ snapshots:
       effect: 3.19.19
       vitest: 3.2.4(@types/node@22.19.15)(yaml@2.9.0)
 
-  '@effect/vitest@4.0.0-beta.104(effect@4.0.0-beta.104)(vitest@4.1.10(@types/node@22.19.15)(vite@7.3.1(@types/node@22.19.15)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.107(effect@4.0.0-beta.107)(vitest@4.1.10(@types/node@22.19.15)(vite@7.3.1(@types/node@22.19.15)(yaml@2.9.0)))':
     dependencies:
-      effect: 4.0.0-beta.104
+      effect: 4.0.0-beta.107
       vitest: 4.1.10(@types/node@22.19.15)(vite@7.3.1(@types/node@22.19.15)(yaml@2.9.0))
 
   '@emnapi/core@1.8.1':
@@ -2063,7 +2063,7 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  effect@4.0.0-beta.104:
+  effect@4.0.0-beta.107:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.9.0

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.errors.txt
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.errors.txt
@@ -4,7 +4,10 @@ Effect version: 4.0.0
 
 
 ==== /.src/schemaMutableKey_ts2322.ts (0 errors) ====
-    import { Schema, Struct as Struct_, SchemaAST  } from "effect"
+    import { Schema, Struct as Struct_, SchemaAST } from "effect"
+    declare module "effect/SchemaAST" {
+      export function optionalKey<A extends SchemaAST.AST>(ast: A): A
+    }
     
     
     interface optionalKeyLambda extends Struct_.Lambda {

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.flows.schemaMutableKey_ts2322.mermaid
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.flows.schemaMutableKey_ts2322.mermaid
@@ -1,15 +1,16 @@
 flowchart TB
-  0[/"type: <br/>node: Struct_.Lambda"/]
-  1[["type: #40;schema: Top#41; =#gt; optionalKey#lt;Top#gt;<br/>node: #40;schema#41; =#gt; Schema.make#40;SchemaAST.optionalKey#40;schema.ast#41;, #123; schema #125;#41;"]]
-  2[/"type: optionalKey#lt;Top#gt;<br/>node: Schema.make#40;SchemaAST.optionalKey#40;schema.ast#41;, #123; schema #125;#41;"/]
-  3[/"type: AST<br/>node: schema.ast"/]
-  4["type: AST<br/>callee: SchemaAST.optionalKey<br/>args: #91;#93;"]
-  5[/"type: #lt;A extends AST#gt;#40;ast: A#41; =#gt; A<br/>node: SchemaAST.optionalKey"/]
-  6["type: optionalKeyLambda<br/>callee: Struct_.lambda<br/>args: #91;#93;"]
-  7[/"type: #lt;L extends #40;a: any#41; =#gt; any#gt;#40;f: #40;a: Parameters#lt;L#gt;#91;0#93;#41; =#gt; ReturnType#lt;L#gt;#41; =#gt; L<br/>node: Struct_.lambda"/]
-  3 -->|"kind: pipe"| 4
-  5 -->|"kind: transformCallee"| 4
-  4 -->|"kind: usedBy"| 2
-  2 -->|"kind: potentialReturn"| 1
-  1 -->|"kind: pipe"| 6
-  7 -->|"kind: transformCallee"| 6
+  0[["type: #lt;A extends SchemaAST.AST#gt;#40;ast: A#41; =#gt; A<br/>node: export function optionalKey#lt;A extends SchemaAST.AST#gt;#40;ast: A#41;: A"]]
+  1[/"type: <br/>node: Struct_.Lambda"/]
+  2[["type: #40;schema: Top#41; =#gt; optionalKey#lt;Top#gt;<br/>node: #40;schema#41; =#gt; Schema.make#40;SchemaAST.optionalKey#40;schema.ast#41;, #123; schema #125;#41;"]]
+  3[/"type: optionalKey#lt;Top#gt;<br/>node: Schema.make#40;SchemaAST.optionalKey#40;schema.ast#41;, #123; schema #125;#41;"/]
+  4[/"type: AST<br/>node: schema.ast"/]
+  5["type: AST<br/>callee: SchemaAST.optionalKey<br/>args: #91;#93;"]
+  6[/"type: #lt;A extends SchemaAST.AST#gt;#40;ast: A#41; =#gt; A<br/>node: SchemaAST.optionalKey"/]
+  7["type: optionalKeyLambda<br/>callee: Struct_.lambda<br/>args: #91;#93;"]
+  8[/"type: #lt;L extends #40;a: any#41; =#gt; any#gt;#40;f: #40;a: Parameters#lt;L#gt;#91;0#93;#41; =#gt; ReturnType#lt;L#gt;#41; =#gt; L<br/>node: Struct_.lambda"/]
+  4 -->|"kind: pipe"| 5
+  6 -->|"kind: transformCallee"| 5
+  5 -->|"kind: usedBy"| 3
+  3 -->|"kind: potentialReturn"| 2
+  2 -->|"kind: pipe"| 7
+  8 -->|"kind: transformCallee"| 7

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322.pipings.txt
@@ -1,7 +1,7 @@
 ==== /.src/schemaMutableKey_ts2322.ts (2 flows) ====
 
 === Piping Flow ===
-Location: 30:27 - 30:133
+Location: 33:27 - 33:133
 Node: Struct_.lambda<optionalKeyLambda>((schema) => Schema.make(SchemaAST.optionalKey(schema.ast), { schema }))
 Node Kind: KindCallExpression
 
@@ -15,7 +15,7 @@ Transformations (1):
       outType: optionalKeyLambda
 
 === Piping Flow ===
-Location: 30:86 - 30:119
+Location: 33:86 - 33:119
 Node: SchemaAST.optionalKey(schema.ast)
 Node Kind: KindCallExpression
 

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.errors.txt
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.errors.txt
@@ -15,7 +15,10 @@ Effect version: 4.0.0
     
 
 ==== /.src/schemaMutableKey_ts2322_pluginDisabled.ts (0 errors) ====
-    import { Schema, Struct as Struct_, SchemaAST  } from "effect"
+    import { Schema, Struct as Struct_, SchemaAST } from "effect"
+    declare module "effect/SchemaAST" {
+      export function optionalKey<A extends SchemaAST.AST>(ast: A): A
+    }
     
     
     interface optionalKeyLambda extends Struct_.Lambda {

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.flows.schemaMutableKey_ts2322_pluginDisabled.mermaid
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.flows.schemaMutableKey_ts2322_pluginDisabled.mermaid
@@ -1,15 +1,16 @@
 flowchart TB
-  0[/"type: <br/>node: Struct_.Lambda"/]
-  1[["type: #40;schema: Top#41; =#gt; optionalKey#lt;Top#gt;<br/>node: #40;schema#41; =#gt; Schema.make#40;SchemaAST.optionalKey#40;schema.ast#41;, #123; schema #125;#41;"]]
-  2[/"type: optionalKey#lt;Top#gt;<br/>node: Schema.make#40;SchemaAST.optionalKey#40;schema.ast#41;, #123; schema #125;#41;"/]
-  3[/"type: AST<br/>node: schema.ast"/]
-  4["type: AST<br/>callee: SchemaAST.optionalKey<br/>args: #91;#93;"]
-  5[/"type: #lt;A extends AST#gt;#40;ast: A#41; =#gt; A<br/>node: SchemaAST.optionalKey"/]
-  6["type: optionalKeyLambda<br/>callee: Struct_.lambda<br/>args: #91;#93;"]
-  7[/"type: #lt;L extends #40;a: any#41; =#gt; any#gt;#40;f: #40;a: Parameters#lt;L#gt;#91;0#93;#41; =#gt; ReturnType#lt;L#gt;#41; =#gt; L<br/>node: Struct_.lambda"/]
-  3 -->|"kind: pipe"| 4
-  5 -->|"kind: transformCallee"| 4
-  4 -->|"kind: usedBy"| 2
-  2 -->|"kind: potentialReturn"| 1
-  1 -->|"kind: pipe"| 6
-  7 -->|"kind: transformCallee"| 6
+  0[["type: #lt;A extends SchemaAST.AST#gt;#40;ast: A#41; =#gt; A<br/>node: export function optionalKey#lt;A extends SchemaAST.AST#gt;#40;ast: A#41;: A"]]
+  1[/"type: <br/>node: Struct_.Lambda"/]
+  2[["type: #40;schema: Top#41; =#gt; optionalKey#lt;Top#gt;<br/>node: #40;schema#41; =#gt; Schema.make#40;SchemaAST.optionalKey#40;schema.ast#41;, #123; schema #125;#41;"]]
+  3[/"type: optionalKey#lt;Top#gt;<br/>node: Schema.make#40;SchemaAST.optionalKey#40;schema.ast#41;, #123; schema #125;#41;"/]
+  4[/"type: AST<br/>node: schema.ast"/]
+  5["type: AST<br/>callee: SchemaAST.optionalKey<br/>args: #91;#93;"]
+  6[/"type: #lt;A extends SchemaAST.AST#gt;#40;ast: A#41; =#gt; A<br/>node: SchemaAST.optionalKey"/]
+  7["type: optionalKeyLambda<br/>callee: Struct_.lambda<br/>args: #91;#93;"]
+  8[/"type: #lt;L extends #40;a: any#41; =#gt; any#gt;#40;f: #40;a: Parameters#lt;L#gt;#91;0#93;#41; =#gt; ReturnType#lt;L#gt;#41; =#gt; L<br/>node: Struct_.lambda"/]
+  4 -->|"kind: pipe"| 5
+  6 -->|"kind: transformCallee"| 5
+  5 -->|"kind: usedBy"| 3
+  3 -->|"kind: potentialReturn"| 2
+  2 -->|"kind: pipe"| 7
+  8 -->|"kind: transformCallee"| 7

--- a/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/schemaMutableKey_ts2322_pluginDisabled.pipings.txt
@@ -1,7 +1,7 @@
 ==== /.src/schemaMutableKey_ts2322_pluginDisabled.ts (2 flows) ====
 
 === Piping Flow ===
-Location: 30:27 - 30:133
+Location: 33:27 - 33:133
 Node: Struct_.lambda<optionalKeyLambda>((schema) => Schema.make(SchemaAST.optionalKey(schema.ast), { schema }))
 Node Kind: KindCallExpression
 
@@ -15,7 +15,7 @@ Transformations (1):
       outType: optionalKeyLambda
 
 === Piping Flow ===
-Location: 30:86 - 30:119
+Location: 33:86 - 33:119
 Node: SchemaAST.optionalKey(schema.ast)
 Node Kind: KindCallExpression
 

--- a/testdata/tests/effect-v4-document-symbols/package.json
+++ b/testdata/tests/effect-v4-document-symbols/package.json
@@ -2,7 +2,7 @@
     "name": "effect-v4-document-symbols-tests",
     "private": true,
     "dependencies": {
-        "effect": "4.0.0-beta.104",
+        "effect": "4.0.0-beta.107",
         "@standard-schema/spec": "^1.1.0",
         "fast-check": "^4.4.0",
         "pure-rand": "^7.0.0",

--- a/testdata/tests/effect-v4-refactors/package.json
+++ b/testdata/tests/effect-v4-refactors/package.json
@@ -2,7 +2,7 @@
     "name": "effect-v4-refactors-tests",
     "private": true,
     "dependencies": {
-        "effect": "4.0.0-beta.104",
+        "effect": "4.0.0-beta.107",
         "@standard-schema/spec": "^1.1.0",
         "fast-check": "^4.4.0",
         "pure-rand": "^7.0.0",

--- a/testdata/tests/effect-v4/package.json
+++ b/testdata/tests/effect-v4/package.json
@@ -2,11 +2,11 @@
     "name": "effect-v4-tests",
     "private": true,
     "dependencies": {
-        "@effect/vitest": "4.0.0-beta.104",
+        "@effect/vitest": "4.0.0-beta.107",
         "@standard-schema/spec": "^1.1.0",
         "@types/node": "^22.0.0",
         "@vitest/runner": "4.1.10",
-        "effect": "4.0.0-beta.104",
+        "effect": "4.0.0-beta.107",
         "fast-check": "^4.4.0",
         "pure-rand": "^7.0.0",
         "vitest": "4.1.10"

--- a/testdata/tests/effect-v4/schemaMutableKey_ts2322.ts
+++ b/testdata/tests/effect-v4/schemaMutableKey_ts2322.ts
@@ -1,4 +1,7 @@
-import { Schema, Struct as Struct_, SchemaAST  } from "effect"
+import { Schema, Struct as Struct_, SchemaAST } from "effect"
+declare module "effect/SchemaAST" {
+  export function optionalKey<A extends SchemaAST.AST>(ast: A): A
+}
 
 
 interface optionalKeyLambda extends Struct_.Lambda {

--- a/testdata/tests/effect-v4/schemaMutableKey_ts2322_pluginDisabled.ts
+++ b/testdata/tests/effect-v4/schemaMutableKey_ts2322_pluginDisabled.ts
@@ -9,7 +9,10 @@
 }
 
 // @filename: schemaMutableKey_ts2322_pluginDisabled.ts
-import { Schema, Struct as Struct_, SchemaAST  } from "effect"
+import { Schema, Struct as Struct_, SchemaAST } from "effect"
+declare module "effect/SchemaAST" {
+  export function optionalKey<A extends SchemaAST.AST>(ast: A): A
+}
 
 
 interface optionalKeyLambda extends Struct_.Lambda {

--- a/testdata/tests/oxlint/package.json
+++ b/testdata/tests/oxlint/package.json
@@ -2,6 +2,6 @@
   "name": "oxlint-profile-tests",
   "private": true,
   "dependencies": {
-    "effect": "4.0.0-beta.104"
+    "effect": "4.0.0-beta.107"
   }
 }


### PR DESCRIPTION
## Summary

- Update `effect`, `@effect/platform-node`, `@effect/platform-node-shared`, and `@effect/vitest` to `4.0.0-beta.107`.
- Refresh the lockfile and all Effect v4 test fixtures.
- Preserve the `Schema.make(SchemaAST.optionalKey(...))` regression coverage with a declaration bridge for the newly internal API and update its generated baselines.
- Add a patch changeset for `@effect/tsgo`.

## Testing

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`