### PR TITLE
Fix stale patched binaries after upgrades

### DIFF
--- a/.changeset/refresh-patched-binaries.md
+++ b/.changeset/refresh-patched-binaries.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Refresh patched binaries when an updated `@effect/tsgo` package provides a different replacement artifact.

--- a/_packages/tsgo/src/patcher/discovery.ts
+++ b/_packages/tsgo/src/patcher/discovery.ts
@@ -3,6 +3,7 @@ import * as Data from "effect/Data"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
+import { hashFile } from "./fileHash.js"
 import type { Component, DiscoveredBinary } from "./types.js"
 
 export const defaultTypescriptPackageNames = ["typescript", "@typescript/native"] as const
@@ -18,6 +19,8 @@ interface PackageMetadata {
   readonly version: string
   readonly main?: string
 }
+
+type DiscoveredBinaryLocation = Omit<DiscoveredBinary, "fileHash">
 
 const isNativeTypescriptVersion = (version: string) => {
   const match = /\d+/.exec(version.trim())
@@ -82,7 +85,7 @@ export const experimentalOxlintTarget = (platform: NodeJS.Platform, arch: string
 const discoverTypeScript: (
   cwdRequire: NodeJS.Require,
   preferredPackage?: string
-) => Effect.Effect<DiscoveredBinary[], DiscoveryError, FileSystem.FileSystem | Path.Path> = (
+) => Effect.Effect<DiscoveredBinaryLocation[], DiscoveryError, FileSystem.FileSystem | Path.Path> = (
   cwdRequire,
   preferredPackage
 ) => Effect.gen(function*() {
@@ -102,14 +105,14 @@ const discoverTypeScript: (
       packageName: platformPackageName,
       packageVersion: platformPackage.version,
       binaryPath: path.join(path.dirname(platformPackage.packageJsonPath), "lib", binaryName)
-    } satisfies DiscoveredBinary]
+    } satisfies DiscoveredBinaryLocation]
   }
   return []
 })
 
 const discoverOxlint: (
   cwdRequire: NodeJS.Require
-) => Effect.Effect<DiscoveredBinary[], DiscoveryError, FileSystem.FileSystem | Path.Path> = (cwdRequire) =>
+) => Effect.Effect<DiscoveredBinaryLocation[], DiscoveryError, FileSystem.FileSystem | Path.Path> = (cwdRequire) =>
   Effect.gen(function*() {
     const path = yield* Path.Path
     const oxlint = yield* optionally(readPackage(cwdRequire, "oxlint"))
@@ -121,7 +124,7 @@ const discoverOxlint: (
         ? error
         : new DiscoveryError({ reason: "Unable to determine the Oxlint platform target." })
     })
-    const discovered: Array<DiscoveredBinary> = []
+    const discovered: Array<DiscoveredBinaryLocation> = []
     if (oxlint !== undefined) {
       const binding = yield* readPackage(nodeModule.createRequire(oxlint.packageJsonPath), target.oxlintPackage)
       if (binding.main === undefined) {
@@ -157,7 +160,7 @@ const discoverOxlint: (
 
 const discoverVitePlusOxlint: (
   cwdRequire: NodeJS.Require
-) => Effect.Effect<DiscoveredBinary[], DiscoveryError, FileSystem.FileSystem | Path.Path> = (cwdRequire) =>
+) => Effect.Effect<DiscoveredBinaryLocation[], DiscoveryError, FileSystem.FileSystem | Path.Path> = (cwdRequire) =>
   Effect.gen(function*() {
     const vitePlus = yield* optionally(readPackage(cwdRequire, "vite-plus"))
     if (vitePlus === undefined) return []
@@ -170,9 +173,13 @@ export const discoverBinaries = (cwd: string, preferredTypescriptPackage?: strin
   const typescript = yield* discoverTypeScript(cwdRequire, preferredTypescriptPackage)
   const oxlint = yield* discoverOxlint(cwdRequire)
   const vitePlusOxlint = yield* discoverVitePlusOxlint(cwdRequire)
-  return [...new Map(
+  const discovered = [...new Map(
     [...typescript, ...oxlint, ...vitePlusOxlint].map((binary) => [binary.binaryPath, binary])
   ).values()]
+  return yield* Effect.forEach(discovered, (binary) => hashFile(binary.binaryPath).pipe(
+    Effect.map((fileHash) => ({ ...binary, fileHash })),
+    Effect.mapError(() => new DiscoveryError({ reason: `Unable to read discovered binary ${binary.binaryPath}.` }))
+  ))
 })
 
 export const selectComponents = (

--- a/_packages/tsgo/src/patcher/fileHash.ts
+++ b/_packages/tsgo/src/patcher/fileHash.ts
@@ -1,11 +1,17 @@
-import { createHash } from "node:crypto"
+import * as Crypto from "effect/Crypto"
 import * as Effect from "effect/Effect"
+import * as Encoding from "effect/Encoding"
 import * as FileSystem from "effect/FileSystem"
 
-export const hashBytes = (contents: string | Uint8Array): string =>
-  createHash("sha256").update(contents).digest("hex")
+const textEncoder = new TextEncoder()
+
+export const hashBytes = (contents: string | Uint8Array) => Effect.gen(function*() {
+  const crypto = yield* Crypto.Crypto
+  const digest = yield* crypto.digest("SHA-256", typeof contents === "string" ? textEncoder.encode(contents) : contents)
+  return Encoding.encodeHex(digest)
+})
 
 export const hashFile = (filePath: string) => Effect.gen(function*() {
   const fs = yield* FileSystem.FileSystem
-  return hashBytes(yield* fs.readFile(filePath))
+  return yield* hashBytes(yield* fs.readFile(filePath))
 })

--- a/_packages/tsgo/src/patcher/fileHash.ts
+++ b/_packages/tsgo/src/patcher/fileHash.ts
@@ -1,0 +1,11 @@
+import { createHash } from "node:crypto"
+import * as Effect from "effect/Effect"
+import * as FileSystem from "effect/FileSystem"
+
+export const hashBytes = (contents: string | Uint8Array): string =>
+  createHash("sha256").update(contents).digest("hex")
+
+export const hashFile = (filePath: string) => Effect.gen(function*() {
+  const fs = yield* FileSystem.FileSystem
+  return hashBytes(yield* fs.readFile(filePath))
+})

--- a/_packages/tsgo/src/patcher/index.ts
+++ b/_packages/tsgo/src/patcher/index.ts
@@ -7,6 +7,7 @@ import * as Path from "effect/Path"
 import * as Scope from "effect/Scope"
 import metadataJson from "../metadata.json" with { type: "json" }
 import { discoverBinaries, requireComponents, selectComponents } from "./discovery.js"
+import { hashBytes, hashFile } from "./fileHash.js"
 import type {
   Component,
   DiscoveredBinary,
@@ -40,6 +41,7 @@ const exists = (fs: FileSystem.FileSystem, filePath: string) => fs.exists(filePa
 
 export interface ResolvedReplacement {
   readonly path: string
+  readonly fileHash: string
 }
 
 export type ReplacementResolver = (
@@ -96,9 +98,11 @@ export const renderOxlintDeclarations = (source: string): string => {
 const resolveOxlintDeclarations = (target: DiscoveredBinary) => Effect.gen(function*() {
   const fs = yield* FileSystem.FileSystem
   const path = yield* Path.Path
-  const source = yield* fs.readFileString(target.binaryPath).pipe(
+  const backupPath = `${target.binaryPath}.original`
+  const sourcePath = (yield* exists(fs, backupPath)) ? backupPath : target.binaryPath
+  const source = yield* fs.readFileString(sourcePath).pipe(
     Effect.mapError((error) => new PatcherError({
-      reason: `Unable to read Oxlint declarations at ${target.binaryPath}: ${error.message}`
+      reason: `Unable to read Oxlint declarations at ${sourcePath}: ${error.message}`
     }))
   )
   const replacement = yield* Effect.try({
@@ -117,7 +121,7 @@ const resolveOxlintDeclarations = (target: DiscoveredBinary) => Effect.gen(funct
       reason: `Unable to write generated Oxlint declarations at ${replacementPath}: ${error.message}`
     }))
   )
-  return { path: replacementPath }
+  return { path: replacementPath, fileHash: hashBytes(replacement) }
 })
 
 const resolvePlatformPackage = (target: DiscoveredBinary) => Effect.gen(function*() {
@@ -152,7 +156,12 @@ export const resolveReplacement: ReplacementResolver = (target) => Effect.gen(fu
       reason: `Missing packaged artifact ${replacementPath}.`
     })
   }
-  return { path: replacementPath }
+  const fileHash = yield* hashFile(replacementPath).pipe(
+    Effect.mapError((error) => new PatcherError({
+      reason: `Unable to hash packaged artifact ${replacementPath}: ${error.message}`
+    }))
+  )
+  return { path: replacementPath, fileHash }
 })
 
 export interface PreparePatchOptions {
@@ -169,8 +178,13 @@ export const preparePatch = (
   const fs = yield* FileSystem.FileSystem
   const resolver = options.resolveReplacement ?? resolveReplacement
   const operations: Array<FileSystemOperation> = []
+  const cleanup: Array<RemoveOperation> = []
   const skipped: Array<SkippedTarget> = []
-  const available: Array<{ readonly target: DiscoveredBinary; readonly replacementPath: string }> = []
+  const available: Array<{
+    readonly target: DiscoveredBinary
+    readonly replacementPath: string
+    readonly backupExists: boolean
+  }> = []
 
   for (const target of targets) {
     const backupPath = `${target.binaryPath}.original`
@@ -178,14 +192,6 @@ export const preparePatch = (
     const backupExists = yield* exists(fs, backupPath)
     if (!targetExists) {
       return yield* new PatcherError({ reason: `Installed binary does not exist: ${target.binaryPath}` })
-    }
-    if (backupExists) {
-      skipped.push({
-        target,
-        reason: "already-patched",
-        message: `${target.component} skipped because backup already exists at ${backupPath}.`
-      })
-      continue
     }
     const replacement = yield* resolver(target).pipe(
       Effect.catchTag("ReplacementUnavailableError", (error) => {
@@ -195,12 +201,26 @@ export const preparePatch = (
       })
     )
     if (replacement === undefined) continue
-    available.push({ target, replacementPath: replacement.path })
+    if (backupExists && target.fileHash === replacement.fileHash) {
+      skipped.push({
+        target,
+        reason: "already-patched",
+        message: `${target.component} skipped because its hash matches the replacement.`
+      })
+      continue
+    }
+    available.push({ target, replacementPath: replacement.path, backupExists })
   }
 
-  for (const { replacementPath, target } of available) {
+  for (const { backupExists, replacementPath, target } of available) {
     const backupPath = `${target.binaryPath}.original`
-    operations.push({ _tag: "Rename", sourcePath: target.binaryPath, destinationPath: backupPath })
+    if (backupExists) {
+      const quarantinePath = `${target.binaryPath}.${randomUUID()}.patched`
+      operations.push({ _tag: "Rename", sourcePath: target.binaryPath, destinationPath: quarantinePath })
+      cleanup.push({ _tag: "Remove", path: quarantinePath })
+    } else {
+      operations.push({ _tag: "Rename", sourcePath: target.binaryPath, destinationPath: backupPath })
+    }
     operations.push({
       _tag: "Copy",
       sourcePath: replacementPath,
@@ -211,7 +231,7 @@ export const preparePatch = (
     }
   }
 
-  return { operations, cleanup: [], skipped } satisfies PreparedPatch
+  return { operations, cleanup, skipped } satisfies PreparedPatch
 })
 
 export const prepareUnpatch = (targets: ReadonlyArray<DiscoveredBinary>) => Effect.gen(function*() {

--- a/_packages/tsgo/src/patcher/index.ts
+++ b/_packages/tsgo/src/patcher/index.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto"
 import * as nodeModule from "node:module"
+import * as Crypto from "effect/Crypto"
 import * as Data from "effect/Data"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
@@ -49,7 +50,7 @@ export type ReplacementResolver = (
 ) => Effect.Effect<
   ResolvedReplacement,
   PatcherError | ReplacementUnavailableError,
-  FileSystem.FileSystem | Path.Path | Scope.Scope
+  Crypto.Crypto | FileSystem.FileSystem | Path.Path | Scope.Scope
 >
 
 const toKebabCase = (value: string): string => {
@@ -121,7 +122,12 @@ const resolveOxlintDeclarations = (target: DiscoveredBinary) => Effect.gen(funct
       reason: `Unable to write generated Oxlint declarations at ${replacementPath}: ${error.message}`
     }))
   )
-  return { path: replacementPath, fileHash: hashBytes(replacement) }
+  const fileHash = yield* hashBytes(replacement).pipe(
+    Effect.mapError((error) => new PatcherError({
+      reason: `Unable to hash generated Oxlint declarations: ${error.message}`
+    }))
+  )
+  return { path: replacementPath, fileHash }
 })
 
 const resolvePlatformPackage = (target: DiscoveredBinary) => Effect.gen(function*() {

--- a/_packages/tsgo/src/patcher/types.ts
+++ b/_packages/tsgo/src/patcher/types.ts
@@ -5,6 +5,7 @@ export interface DiscoveredBinary {
   readonly packageName: string
   readonly packageVersion: string
   readonly binaryPath: string
+  readonly fileHash: string
 }
 
 export type FileSystemOperation = RenameOperation | CopyOperation | ChmodOperation | RemoveOperation

--- a/_packages/tsgo/test/experimental-oxlint.test.ts
+++ b/_packages/tsgo/test/experimental-oxlint.test.ts
@@ -1,12 +1,15 @@
 import * as NodeServices from "@effect/platform-node/NodeServices"
 import * as Effect from "effect/Effect"
+import { createHash } from "node:crypto"
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
 import { discoverBinaries, experimentalOxlintTarget } from "../src/patcher/index.js"
 
 const temporaryDirectories: Array<string> = []
+
+const hash = (value: string) => createHash("sha256").update(value).digest("hex")
 
 const makeTemporaryDirectory = async () => {
   const directory = await mkdtemp(join(tmpdir(), "effect-tsgo-oxlint-"))
@@ -19,6 +22,11 @@ const writePackage = async (directory: string, packageName: string, packageJson:
   await mkdir(packageDirectory, { recursive: true })
   await writeFile(join(packageDirectory, "package.json"), JSON.stringify(packageJson))
   return packageDirectory
+}
+
+const writeBinary = async (filePath: string, contents: string) => {
+  await mkdir(dirname(filePath), { recursive: true })
+  await writeFile(filePath, contents)
 }
 
 afterEach(async () => {
@@ -53,6 +61,11 @@ describe("experimental Oxlint discovery", () => {
       main: "oxlint.node"
     })
     const tsgolintDirectory = await writePackage(directory, platform.tsgolintPackage, { version: "2.0.1" })
+    await Promise.all([
+      writeBinary(join(bindingDirectory, "oxlint.node"), "oxlint"),
+      writeBinary(join(oxlintDirectory, "dist", "index.d.ts"), "declarations"),
+      writeBinary(join(tsgolintDirectory, platform.tsgolintExecutable), "tsgolint")
+    ])
 
     const discovered = await Effect.runPromise(
       discoverBinaries(directory).pipe(Effect.provide(NodeServices.layer))
@@ -62,19 +75,22 @@ describe("experimental Oxlint discovery", () => {
         component: "oxlint",
         packageName: platform.oxlintPackage,
         packageVersion: "1.0.1",
-        binaryPath: join(bindingDirectory, "oxlint.node")
+        binaryPath: join(bindingDirectory, "oxlint.node"),
+        fileHash: hash("oxlint")
       },
       {
         component: "oxlint-dts",
         packageName: "oxlint",
         packageVersion: "1.0.0",
-        binaryPath: join(oxlintDirectory, "dist", "index.d.ts")
+        binaryPath: join(oxlintDirectory, "dist", "index.d.ts"),
+        fileHash: hash("declarations")
       },
       {
         component: "oxlint-tsgolint",
         packageName: platform.tsgolintPackage,
         packageVersion: "2.0.1",
-        binaryPath: join(tsgolintDirectory, platform.tsgolintExecutable)
+        binaryPath: join(tsgolintDirectory, platform.tsgolintExecutable),
+        fileHash: hash("tsgolint")
       }
     ])
   })
@@ -84,6 +100,8 @@ describe("experimental Oxlint discovery", () => {
     await writePackage(directory, "typescript", { version: "7.0.0" })
     const platformPackage = `@typescript/typescript-${process.platform}-${process.arch}`
     const platformDirectory = await writePackage(directory, platformPackage, { version: "7.0.1" })
+    const binaryPath = join(platformDirectory, "lib", process.platform === "win32" ? "tsc.exe" : "tsc")
+    await writeBinary(binaryPath, "typescript")
 
     const discovered = await Effect.runPromise(
       discoverBinaries(directory).pipe(Effect.provide(NodeServices.layer))
@@ -92,7 +110,8 @@ describe("experimental Oxlint discovery", () => {
       component: "typescript",
       packageName: platformPackage,
       packageVersion: "7.0.1",
-      binaryPath: join(platformDirectory, "lib", process.platform === "win32" ? "tsc.exe" : "tsc")
+      binaryPath,
+      fileHash: hash("typescript")
     })
   })
 
@@ -111,6 +130,11 @@ describe("experimental Oxlint discovery", () => {
       platform.tsgolintPackage,
       { version: "2.0.1" }
     )
+    await Promise.all([
+      writeBinary(join(bindingDirectory, "oxlint.node"), "oxlint"),
+      writeBinary(join(oxlintDirectory, "dist", "index.d.ts"), "declarations"),
+      writeBinary(join(tsgolintDirectory, platform.tsgolintExecutable), "tsgolint")
+    ])
 
     const discovered = await Effect.runPromise(
       discoverBinaries(directory).pipe(Effect.provide(NodeServices.layer))
@@ -120,19 +144,22 @@ describe("experimental Oxlint discovery", () => {
         component: "oxlint",
         packageName: platform.oxlintPackage,
         packageVersion: "1.0.1",
-        binaryPath: join(bindingDirectory, "oxlint.node")
+        binaryPath: join(bindingDirectory, "oxlint.node"),
+        fileHash: hash("oxlint")
       },
       {
         component: "oxlint-dts",
         packageName: "oxlint",
         packageVersion: "1.0.0",
-        binaryPath: join(oxlintDirectory, "dist", "index.d.ts")
+        binaryPath: join(oxlintDirectory, "dist", "index.d.ts"),
+        fileHash: hash("declarations")
       },
       {
         component: "oxlint-tsgolint",
         packageName: platform.tsgolintPackage,
         packageVersion: "2.0.1",
-        binaryPath: join(tsgolintDirectory, platform.tsgolintExecutable)
+        binaryPath: join(tsgolintDirectory, platform.tsgolintExecutable),
+        fileHash: hash("tsgolint")
       }
     ])
   })

--- a/_packages/tsgo/test/patcher.test.ts
+++ b/_packages/tsgo/test/patcher.test.ts
@@ -1,4 +1,5 @@
 import * as NodeServices from "@effect/platform-node/NodeServices"
+import * as Crypto from "effect/Crypto"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
@@ -29,7 +30,7 @@ const makeTemporaryDirectory = async () => {
   return directory
 }
 
-const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path | Scope.Scope>) =>
+const run = <A, E>(effect: Effect.Effect<A, E, Crypto.Crypto | FileSystem.FileSystem | Path.Path | Scope.Scope>) =>
   Effect.runPromise(Effect.scoped(effect).pipe(Effect.provide(NodeServices.layer)))
 
 afterEach(async () => {

--- a/_packages/tsgo/test/patcher.test.ts
+++ b/_packages/tsgo/test/patcher.test.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
 import * as Scope from "effect/Scope"
+import { createHash } from "node:crypto"
 import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -19,6 +20,8 @@ import {
 } from "../src/patcher/index.js"
 
 const temporaryDirectories: Array<string> = []
+
+const hash = (value: string) => createHash("sha256").update(value).digest("hex")
 
 const makeTemporaryDirectory = async () => {
   const directory = await mkdtemp(join(tmpdir(), "effect-tsgo-patcher-"))
@@ -47,14 +50,27 @@ describe("patcher", () => {
       writeFile(secondReplacement, "second-effect")
     ])
     const targets: ReadonlyArray<DiscoveredBinary> = [
-      { component: "oxlint-dts", packageName: "oxlint", packageVersion: "1", binaryPath: first },
-      { component: "oxlint-tsgolint", packageName: "oxlint-tsgolint", packageVersion: "2", binaryPath: second }
+      {
+        component: "oxlint-dts",
+        packageName: "oxlint",
+        packageVersion: "1",
+        binaryPath: first,
+        fileHash: hash("first")
+      },
+      {
+        component: "oxlint-tsgolint",
+        packageName: "oxlint-tsgolint",
+        packageVersion: "2",
+        binaryPath: second,
+        fileHash: hash("second")
+      }
     ]
 
     const plan = await run(preparePatch(targets, {
       skipMissing: false,
       resolveReplacement: (target) => Effect.succeed({
-        path: target.component === "oxlint-dts" ? firstReplacement : secondReplacement
+        path: target.component === "oxlint-dts" ? firstReplacement : secondReplacement,
+        fileHash: hash(target.component === "oxlint-dts" ? "first-effect" : "second-effect")
       })
     }))
     expect(plan.operations).toEqual([
@@ -69,19 +85,21 @@ describe("patcher", () => {
   it("generates an Oxlint declaration replacement in the temporary directory", async () => {
     const directory = await makeTemporaryDirectory()
     const declarationPath = join(directory, "index.d.ts")
-    await writeFile(declarationPath, [
+    const declarations = [
       'type LintPluginOptionsSchema = "eslint" | "typescript";',
       "type RuleNoConfig = unknown;",
       "interface DummyRuleMap {",
       '  "eslint/no-unused-vars"?: RuleNoConfig;',
       "}",
       ""
-    ].join("\n"))
+    ].join("\n")
+    await writeFile(declarationPath, declarations)
     const target: DiscoveredBinary = {
       component: "oxlint-dts",
       packageName: "oxlint",
       packageVersion: "1.0.0",
-      binaryPath: declarationPath
+      binaryPath: declarationPath,
+      fileHash: hash(await readFile(declarationPath, "utf8"))
     }
 
     const replacement = await run(Effect.gen(function*() {
@@ -96,6 +114,15 @@ describe("patcher", () => {
     expect(replacement.source).toContain('"effecttsgo/floating-effect"?: RuleNoConfig;')
     expect(replacement.source).toContain('"eslint/no-unused-vars"?: RuleNoConfig;')
     await expect(access(replacement.path)).rejects.toThrow()
+
+    await writeFile(`${declarationPath}.original`, declarations)
+    await writeFile(declarationPath, replacement.source)
+    const refreshed = await run(Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const resolved = yield* resolveReplacement(target)
+      return yield* fs.readFileString(resolved.path)
+    }))
+    expect(refreshed).toBe(replacement.source)
   })
 
   it("rejects declarations whose expected anchors changed", () => {
@@ -120,7 +147,7 @@ describe("patcher", () => {
     await expect(access(`${target}.original`)).rejects.toThrow()
   })
 
-  it("treats the persisted original backup as already patched", async () => {
+  it("refreshes a stale patch while preserving the original backup", async () => {
     const directory = await makeTemporaryDirectory()
     const targetPath = join(directory, "binary")
     const replacementPath = join(directory, "replacement")
@@ -131,18 +158,45 @@ describe("patcher", () => {
       component: "oxlint-tsgolint",
       packageName: "oxlint-tsgolint",
       packageVersion: "1",
-      binaryPath: targetPath
+      binaryPath: targetPath,
+      fileHash: hash("patched")
     }
     const plan = await run(preparePatch([target], {
       skipMissing: false,
-      resolveReplacement: () => Effect.succeed({ path: replacementPath })
+      resolveReplacement: () => Effect.succeed({ path: replacementPath, fileHash: hash("replacement") })
+    }))
+    expect(plan.operations.map(({ _tag }) => _tag)).toEqual(["Rename", "Copy", "Chmod"])
+    expect(plan.cleanup).toHaveLength(1)
+    expect(plan.skipped).toEqual([])
+    await run(applyPlan(plan))
+    expect(await readFile(targetPath, "utf8")).toBe("replacement")
+    expect(await readFile(`${targetPath}.original`, "utf8")).toBe("original")
+    expect((await readdir(directory)).filter((name) => name.endsWith(".patched"))).toEqual([])
+  })
+
+  it("skips a patch whose target already matches the replacement", async () => {
+    const directory = await makeTemporaryDirectory()
+    const targetPath = join(directory, "binary")
+    const replacementPath = join(directory, "replacement")
+    await writeFile(targetPath, "replacement")
+    await writeFile(`${targetPath}.original`, "original")
+    await writeFile(replacementPath, "replacement")
+    const target: DiscoveredBinary = {
+      component: "oxlint-tsgolint",
+      packageName: "oxlint-tsgolint",
+      packageVersion: "1",
+      binaryPath: targetPath,
+      fileHash: hash("replacement")
+    }
+    const plan = await run(preparePatch([target], {
+      skipMissing: false,
+      resolveReplacement: () => Effect.succeed({ path: replacementPath, fileHash: hash("replacement") })
     }))
     expect(plan.operations).toEqual([])
     expect(plan.skipped[0]?.reason).toBe("already-patched")
     expect(plan.skipped[0]?.message).toBe(
-      `oxlint-tsgolint skipped because backup already exists at ${targetPath}.original.`
+      `oxlint-tsgolint skipped because its hash matches the replacement.`
     )
-    await expect(access(`${targetPath}.original.1`)).rejects.toThrow()
   })
 
   it("rolls back prior reversible operations when mutation fails", async () => {
@@ -170,7 +224,8 @@ describe("patcher", () => {
       component: "typescript",
       packageName: "typescript",
       packageVersion: "7.0.0",
-      binaryPath: targetPath
+      binaryPath: targetPath,
+      fileHash: hash("patched")
     }
     await writeFile(targetPath, "patched")
     await writeFile(`${targetPath}.original`, "original")
@@ -190,7 +245,8 @@ describe("patcher", () => {
       component: "oxlint",
       packageName: "oxlint",
       packageVersion: "missing",
-      binaryPath: targetPath
+      binaryPath: targetPath,
+      fileHash: hash("original")
     }
     const unavailable = () => Effect.fail(new ReplacementUnavailableError({ target, reason: "not packaged" }))
     const plan = await run(preparePatch([target], {


### PR DESCRIPTION
## Summary

- hash discovered binaries and packaged replacements with SHA-256
- refresh an existing patched target when its hash differs from the current replacement while preserving the original backup
- regenerate Oxlint declarations from the original backup during refresh
- add regression coverage for stale patches and already-current replacements

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`