### PR TITLE
Fix declaration emit for ignored Effect diagnostics

### DIFF
--- a/.changeset/fix-no-emit-ignored-diagnostics.md
+++ b/.changeset/fix-no-emit-ignored-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Allow declaration emit with `noEmitOnError` when all diagnostics are ignored Effect diagnostics.

--- a/_patches/typescript-go/009-execute-tsc-emit.patch
+++ b/_patches/typescript-go/009-execute-tsc-emit.patch
@@ -70,9 +70,11 @@ index 3a1e3de69..8cb7c24c0 100644
 diff --git a/internal/compiler/program.go b/internal/compiler/program.go
 --- a/internal/compiler/program.go
 +++ b/internal/compiler/program.go
-@@ -1762,6 +1762,16 @@ type ProgramLike interface {
- 	Program() *Program
- }
+@@ -30,6 +30,16 @@ import (
+ 	"github.com/microsoft/typescript-go/internal/tracing"
+ 	"github.com/microsoft/typescript-go/internal/tsoptions"
+ 	"github.com/microsoft/typescript-go/internal/tspath"
+ )
  
 +// FilterDiagnosticsForNoEmitOnErrorCallback is invoked before diagnostics
 +// suppress emit when noEmitOnError is enabled.
@@ -84,10 +86,8 @@ diff --git a/internal/compiler/program.go b/internal/compiler/program.go
 +	FilterDiagnosticsForNoEmitOnErrorCallback = cb
 +}
 +
- func HandleNoEmitOnError(ctx context.Context, program ProgramLike, files []*ast.SourceFile) *EmitResult {
- 	if !program.Options().NoEmitOnError.IsTrue() {
- 		return nil // No emit on error is not set, so we can proceed with emitting
-@@ -1775,6 +1786,9 @@ func HandleNoEmitOnError(ctx context.Context, program ProgramLike, files []*ast.
+ type ProgramOptions struct {
+@@ -1743,6 +1753,9 @@ func HandleNoEmitOnError(ctx context.Context, program ProgramLike, file *ast.Sou
  		program.GetBindDiagnostics,
  		program.GetSemanticDiagnostics,
  	)

--- a/_patches/typescript-go/009-execute-tsc-emit.patch
+++ b/_patches/typescript-go/009-execute-tsc-emit.patch
@@ -67,3 +67,33 @@ index 3a1e3de69..8cb7c24c0 100644
  		result.Status = ExitStatusDiagnosticsPresent_OutputsGenerated
  	}
  	return result, statistics
+diff --git a/internal/compiler/program.go b/internal/compiler/program.go
+--- a/internal/compiler/program.go
++++ b/internal/compiler/program.go
+@@ -1762,6 +1762,16 @@ type ProgramLike interface {
+ 	Program() *Program
+ }
+ 
++// FilterDiagnosticsForNoEmitOnErrorCallback is invoked before diagnostics
++// suppress emit when noEmitOnError is enabled.
++var FilterDiagnosticsForNoEmitOnErrorCallback func(*core.CompilerOptions, []*ast.Diagnostic) []*ast.Diagnostic
++
++// RegisterFilterDiagnosticsForNoEmitOnErrorCallback registers a callback to
++// filter diagnostics used by noEmitOnError.
++func RegisterFilterDiagnosticsForNoEmitOnErrorCallback(cb func(*core.CompilerOptions, []*ast.Diagnostic) []*ast.Diagnostic) {
++	FilterDiagnosticsForNoEmitOnErrorCallback = cb
++}
++
+ func HandleNoEmitOnError(ctx context.Context, program ProgramLike, files []*ast.SourceFile) *EmitResult {
+ 	if !program.Options().NoEmitOnError.IsTrue() {
+ 		return nil // No emit on error is not set, so we can proceed with emitting
+@@ -1775,6 +1786,9 @@ func HandleNoEmitOnError(ctx context.Context, program ProgramLike, files []*ast.
+ 		program.GetBindDiagnostics,
+ 		program.GetSemanticDiagnostics,
+ 	)
++	if FilterDiagnosticsForNoEmitOnErrorCallback != nil {
++		diagnostics = FilterDiagnosticsForNoEmitOnErrorCallback(program.Options(), diagnostics)
++	}
+ 	if len(diagnostics) == 0 {
+ 		return nil // No diagnostics, so we can proceed with emitting
+ 	}

--- a/etsexecutehooks/doc.go
+++ b/etsexecutehooks/doc.go
@@ -1,7 +1,7 @@
-// Package etsexecutehooks provides exit-code filtering for Effect diagnostics.
+// Package etsexecutehooks provides command-line filtering for Effect diagnostics.
 //
 // This package registers a FilterDiagnosticsForExitCodeCallback that filters out
-// Effect diagnostics from exit-code determination based on the
+// Effect diagnostics from exit-code and noEmitOnError determination based on the
 // IgnoreEffectSuggestionsInTscExitCode and IgnoreEffectWarningsInTscExitCode
 // configuration options.
 //

--- a/etsexecutehooks/init.go
+++ b/etsexecutehooks/init.go
@@ -4,6 +4,7 @@ import (
 	"github.com/effect-ts/tsgo/etscore"
 	"github.com/effect-ts/tsgo/internal/rule"
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/diagnostics"
 	"github.com/microsoft/typescript-go/shim/execute/tsc"
@@ -11,6 +12,7 @@ import (
 
 func init() {
 	tsc.RegisterFilterDiagnosticsForExitCodeCallback(filterDiagnosticsForExitCode)
+	compiler.RegisterFilterDiagnosticsForNoEmitOnErrorCallback(filterDiagnosticsForExitCode)
 }
 
 // filterDiagnosticsForExitCode is the callback registered with the tsc package.

--- a/etsexecutehooks/init_test.go
+++ b/etsexecutehooks/init_test.go
@@ -1,13 +1,47 @@
 package etsexecutehooks
 
 import (
+	"context"
 	"testing"
 
 	"github.com/effect-ts/tsgo/etscore"
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/compiler"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/diagnostics"
+	"github.com/microsoft/typescript-go/shim/tspath"
 )
+
+type noEmitProgram struct {
+	opts        *core.CompilerOptions
+	diagnostics []*ast.Diagnostic
+}
+
+func (p *noEmitProgram) Options() *core.CompilerOptions                     { return p.opts }
+func (p *noEmitProgram) GetSourceFile(string) *ast.SourceFile               { return nil }
+func (p *noEmitProgram) GetSourceFiles() []*ast.SourceFile                  { return nil }
+func (p *noEmitProgram) GetConfigFileParsingDiagnostics() []*ast.Diagnostic { return p.diagnostics }
+func (p *noEmitProgram) GetSyntacticDiagnostics(context.Context, *ast.SourceFile) []*ast.Diagnostic {
+	return nil
+}
+func (p *noEmitProgram) GetBindDiagnostics(context.Context, *ast.SourceFile) []*ast.Diagnostic {
+	return nil
+}
+func (p *noEmitProgram) GetProgramDiagnostics() []*ast.Diagnostic               { return nil }
+func (p *noEmitProgram) GetGlobalDiagnostics(context.Context) []*ast.Diagnostic { return nil }
+func (p *noEmitProgram) GetSemanticDiagnostics(context.Context, *ast.SourceFile) []*ast.Diagnostic {
+	return nil
+}
+func (p *noEmitProgram) GetDeclarationDiagnostics(context.Context, *ast.SourceFile) []*ast.Diagnostic {
+	return nil
+}
+func (p *noEmitProgram) GetSuggestionDiagnostics(context.Context, *ast.SourceFile) []*ast.Diagnostic {
+	return nil
+}
+func (p *noEmitProgram) Emit(context.Context, compiler.EmitOptions) *compiler.EmitResult { return nil }
+func (p *noEmitProgram) CommonSourceDirectory() string                                   { return "" }
+func (p *noEmitProgram) IsSourceFileDefaultLibrary(tspath.Path) bool                     { return false }
+func (p *noEmitProgram) Program() *compiler.Program                                      { return nil }
 
 // makeDiag creates a minimal diagnostic with the given code and category.
 func makeDiag(code int32, category diagnostics.Category) *ast.Diagnostic {
@@ -109,6 +143,29 @@ func TestFilterDiagnosticsForExitCode_IgnoreWarnings(t *testing.T) {
 	}
 	if result[2].Code() != 2304 {
 		t.Errorf("expected code 2304, got %d", result[2].Code())
+	}
+}
+
+func TestNoEmitOnError_IgnoresConfiguredEffectWarnings(t *testing.T) {
+	t.Parallel()
+	opts := &core.CompilerOptions{
+		NoEmitOnError: core.BoolToTristate(true),
+		Effect: &etscore.EffectPluginOptions{
+			IgnoreEffectWarningsInTscExitCode: true,
+		},
+	}
+	program := &noEmitProgram{
+		opts:        opts,
+		diagnostics: []*ast.Diagnostic{makeDiag(377011, diagnostics.CategoryWarning)},
+	}
+
+	if result := compiler.HandleNoEmitOnError(context.Background(), program, nil); result != nil {
+		t.Fatal("expected ignored Effect warning not to suppress emit")
+	}
+
+	program.diagnostics = []*ast.Diagnostic{makeDiag(1002, diagnostics.CategoryError)}
+	if result := compiler.HandleNoEmitOnError(context.Background(), program, nil); result == nil || !result.EmitSkipped {
+		t.Fatal("expected TypeScript error to suppress emit")
 	}
 }
 

--- a/shim/compiler/shim.go
+++ b/shim/compiler/shim.go
@@ -26,6 +26,7 @@ const EmitOnlyJs = compiler.EmitOnlyJs
 type EmitOptions = compiler.EmitOptions
 type EmitResult = compiler.EmitResult
 type FileIncludeReason = compiler.FileIncludeReason
+var FilterDiagnosticsForNoEmitOnErrorCallback = compiler.FilterDiagnosticsForNoEmitOnErrorCallback
 //go:linkname FilterNoEmitSemanticDiagnostics github.com/microsoft/typescript-go/internal/compiler.FilterNoEmitSemanticDiagnostics
 func FilterNoEmitSemanticDiagnostics(diagnostics []*ast.Diagnostic, options *core.CompilerOptions) []*ast.Diagnostic
 //go:linkname GetDiagnosticsOfAnyProgram github.com/microsoft/typescript-go/internal/compiler.GetDiagnosticsOfAnyProgram
@@ -42,6 +43,8 @@ func NewProgram(opts compiler.ProgramOptions) *compiler.Program
 type Program = compiler.Program
 type ProgramLike = compiler.ProgramLike
 type ProgramOptions = compiler.ProgramOptions
+//go:linkname RegisterFilterDiagnosticsForNoEmitOnErrorCallback github.com/microsoft/typescript-go/internal/compiler.RegisterFilterDiagnosticsForNoEmitOnErrorCallback
+func RegisterFilterDiagnosticsForNoEmitOnErrorCallback(cb func(*core.CompilerOptions, []*ast.Diagnostic) []*ast.Diagnostic)
 //go:linkname SortAndDeduplicateDiagnostics github.com/microsoft/typescript-go/internal/compiler.SortAndDeduplicateDiagnostics
 func SortAndDeduplicateDiagnostics(diagnostics []*ast.Diagnostic) []*ast.Diagnostic
 type SourceFileMayBeEmittedHost = compiler.SourceFileMayBeEmittedHost


### PR DESCRIPTION
## Summary

- filter ignored Effect diagnostics before `noEmitOnError` decides whether to suppress emit
- preserve emit blocking for TypeScript and non-ignored Effect diagnostics
- add regression coverage and a patch changeset

## Example

With `declaration`, `emitDeclarationOnly`, and `noEmitOnError` enabled, an Effect warning configured through `ignoreEffectWarningsInTscExitCode: true` is still reported but no longer prevents `.d.ts` output.

Reproduction: https://github.com/fiws/effect-tsgo-no-emit-repro

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- verified the external reproduction emits `dist/with-diagnostics/index.d.ts` while reporting the warning