### PR TITLE
Improve unsupported target package version errors

### DIFF
--- a/.changeset/friendly-unsupported-package-errors.md
+++ b/.changeset/friendly-unsupported-package-errors.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Report unsupported target package versions with the current `@effect/tsgo` version and the supported alternatives.

--- a/_packages/tsgo/src/patcher/index.ts
+++ b/_packages/tsgo/src/patcher/index.ts
@@ -6,7 +6,9 @@ import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
 import * as Scope from "effect/Scope"
+import * as pkgJson from "../../package.json" with { type: "json" }
 import metadataJson from "../metadata.json" with { type: "json" }
+import upstreamJson from "../../upstream.json" with { type: "json" }
 import { discoverBinaries, requireComponents, selectComponents } from "./discovery.js"
 import { hashBytes, hashFile } from "./fileHash.js"
 import type {
@@ -36,6 +38,18 @@ export class ReplacementUnavailableError extends Data.TaggedError("ReplacementUn
   }
 }
 
+export class UnsupportedTargetPackageVersionError extends Data.TaggedError("UnsupportedTargetPackageVersionError")<{
+  readonly target: DiscoveredBinary
+  readonly supportedVersions: ReadonlyArray<string>
+}> {
+  get message(): string {
+    return `Package ${this.target.packageName} version ${this.target.packageVersion} is not supported by @effect/tsgo version ${pkgJson.version}. `
+      + `Either change @effect/tsgo to a compatible version or set ${this.target.packageName} to one of the supported versions: ${
+        this.supportedVersions.join(", ")
+      }.`
+  }
+}
+
 const exists = (fs: FileSystem.FileSystem, filePath: string) => fs.exists(filePath).pipe(
   Effect.mapError((error) => new PatcherError({ reason: `Unable to inspect ${filePath}: ${error.message}` }))
 )
@@ -49,9 +63,12 @@ export type ReplacementResolver = (
   target: DiscoveredBinary
 ) => Effect.Effect<
   ResolvedReplacement,
-  PatcherError | ReplacementUnavailableError,
+  PatcherError | ReplacementUnavailableError | UnsupportedTargetPackageVersionError,
   Crypto.Crypto | FileSystem.FileSystem | Path.Path | Scope.Scope
 >
+
+const supportedVersions = (component: Exclude<Component, "oxlint-dts">): ReadonlyArray<string> =>
+  Object.keys(upstreamJson.components[component]).sort()
 
 const toKebabCase = (value: string): string => {
   let result = ""
@@ -157,10 +174,11 @@ export const resolveReplacement: ReplacementResolver = (target) => Effect.gen(fu
     path.basename(target.binaryPath)
   )
   if (!(yield* exists(fs, replacementPath))) {
-    return yield* new ReplacementUnavailableError({
-      target,
-      reason: `Missing packaged artifact ${replacementPath}.`
-    })
+    const versions = supportedVersions(target.component)
+    if (!versions.includes(target.packageVersion)) {
+      return yield* new UnsupportedTargetPackageVersionError({ target, supportedVersions: versions })
+    }
+    return yield* new ReplacementUnavailableError({ target, reason: `Missing packaged artifact ${replacementPath}.` })
   }
   const fileHash = yield* hashFile(replacementPath).pipe(
     Effect.mapError((error) => new PatcherError({
@@ -199,11 +217,15 @@ export const preparePatch = (
     if (!targetExists) {
       return yield* new PatcherError({ reason: `Installed binary does not exist: ${target.binaryPath}` })
     }
+    const onUnavailable = (error: ReplacementUnavailableError | UnsupportedTargetPackageVersionError) => {
+      if (!options.skipMissing) return Effect.fail(error)
+      skipped.push({ target, reason: "replacement-unavailable", message: error.message })
+      return Effect.succeed(undefined)
+    }
     const replacement = yield* resolver(target).pipe(
-      Effect.catchTag("ReplacementUnavailableError", (error) => {
-        if (!options.skipMissing) return Effect.fail(error)
-        skipped.push({ target, reason: "replacement-unavailable", message: error.message })
-        return Effect.succeed(undefined)
+      Effect.catchTags({
+        ReplacementUnavailableError: onUnavailable,
+        UnsupportedTargetPackageVersionError: onUnavailable
       })
     )
     if (replacement === undefined) continue

--- a/_packages/tsgo/test/patcher.test.ts
+++ b/_packages/tsgo/test/patcher.test.ts
@@ -9,6 +9,7 @@ import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:f
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
+import * as pkgJson from "../package.json" with { type: "json" }
 import {
   applyPlan,
   type DiscoveredBinary,
@@ -17,7 +18,8 @@ import {
   prepareUnpatch,
   renderOxlintDeclarations,
   ReplacementUnavailableError,
-  resolveReplacement
+  resolveReplacement,
+  UnsupportedTargetPackageVersionError
 } from "../src/patcher/index.js"
 
 const temporaryDirectories: Array<string> = []
@@ -130,6 +132,37 @@ describe("patcher", () => {
     expect(() => renderOxlintDeclarations("interface OtherRuleMap {}\n")).toThrow(
       "Unable to locate the Oxlint plugin declaration."
     )
+  })
+
+  it("explains how to resolve an unsupported package version", () => {
+    const target: DiscoveredBinary = {
+      component: "typescript",
+      packageName: "@typescript/typescript-linux-x64",
+      packageVersion: "7.2.0",
+      binaryPath: "/typescript/lib/tsc",
+      fileHash: hash("typescript")
+    }
+    const error = new UnsupportedTargetPackageVersionError({
+      target,
+      supportedVersions: ["7.0.2", "7.1.0-dev.20260812.1"]
+    })
+    expect(error._tag).toBe("UnsupportedTargetPackageVersionError")
+    expect(error.message).toBe(
+      `Package @typescript/typescript-linux-x64 version 7.2.0 is not supported by @effect/tsgo version ${pkgJson.version}. `
+      + "Either change @effect/tsgo to a compatible version or set @typescript/typescript-linux-x64 to one of the "
+      + "supported versions: 7.0.2, 7.1.0-dev.20260812.1."
+    )
+  })
+
+  it("rejects unsupported target package versions with a distinct error", async () => {
+    const target: DiscoveredBinary = {
+      component: "typescript",
+      packageName: "@typescript/typescript-linux-x64",
+      packageVersion: "unsupported",
+      binaryPath: "/typescript/lib/tsc",
+      fileHash: hash("typescript")
+    }
+    await expect(run(resolveReplacement(target))).rejects.toBeInstanceOf(UnsupportedTargetPackageVersionError)
   })
 
   it("preflights the whole plan without mutation", async () => {
@@ -263,6 +296,17 @@ describe("patcher", () => {
       skipMissing: false,
       resolveReplacement: unavailable
     }))).rejects.toThrow("not packaged")
+
+    const unsupported = () => Effect.fail(new UnsupportedTargetPackageVersionError({
+      target,
+      supportedVersions: ["1", "2"]
+    }))
+    const unsupportedPlan = await run(preparePatch([target], {
+      skipMissing: true,
+      resolveReplacement: unsupported
+    }))
+    expect(unsupportedPlan.skipped[0]?.message).toContain("is not supported by @effect/tsgo")
+
     await expect(run(preparePatch([{ ...target, binaryPath: join(directory, "absent") }], {
       skipMissing: true,
       resolveReplacement: () => Effect.fail(new PatcherError({ reason: "must not be reached" }))


### PR DESCRIPTION
## Summary

- report unsupported target package versions with a distinct `UnsupportedTargetPackageVersionError`
- include the installed target package version, current `@effect/tsgo` version, and supported alternatives
- retain `ReplacementUnavailableError` for genuinely missing packaged artifacts and preserve `--skip-missing` behavior

## Example

```text
Package @typescript/typescript-linux-x64 version 7.2.0 is not supported by @effect/tsgo version 0.36.4. Either change @effect/tsgo to a compatible version or set @typescript/typescript-linux-x64 to one of the supported versions: 7.0.2, 7.1.0-dev.20260812.1.
```

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`