### PR TITLE
Document published supported component versions

### DIFF
--- a/.changeset/published-component-versions.md
+++ b/.changeset/published-component-versions.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Document the target package versions supported by each published release.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ When running in `tsc` mode, the Effect diagnostics are emitted as standard TypeS
 
 When running in dedicated diagnostics mode, the Effect diagnostics can be emitted in structured formats, which can be further processed by other tools.
 
+<!-- supported-components:start -->
+## Supported Package Versions
+
+The following target package versions are supported by `@effect/tsgo@0.36.4`:
+
+| Component | Supported versions |
+|---|---|
+| TypeScript | `7.0.2`, `7.1.0-dev.20260808.1` |
+| Oxlint | `1.76.0`, `1.77.0` |
+| oxlint-tsgolint | `7.0.2001` |
+<!-- supported-components:end -->
+
 ## Diagnostic Status
 
 Some diagnostics are off by default or have a default severity of suggestion, but you can always enable them or change their default severity in the plugin options.

--- a/_tools/repoctl/src/changesets.ts
+++ b/_tools/repoctl/src/changesets.ts
@@ -3,7 +3,9 @@ import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
 import * as Schema from "effect/Schema"
+import { compare } from "semver"
 import { runCommand } from "./process.ts"
+import { readUpstream } from "./upstream.ts"
 
 const PackageJson = Schema.fromJsonString(Schema.Struct({
   version: Schema.String.check(Schema.isNonEmpty())
@@ -14,6 +16,14 @@ export class PackageVersionError extends Data.TaggedError("PackageVersionError")
 }> {
   get message(): string {
     return `Unable to generate etscore/version_generated.go: ${this.reason}`
+  }
+}
+
+export class SupportedComponentsReadmeError extends Data.TaggedError("SupportedComponentsReadmeError")<{
+  readonly reason: string
+}> {
+  get message(): string {
+    return `Unable to generate the supported package versions README section: ${this.reason}`
   }
 }
 
@@ -78,9 +88,63 @@ export const writeGeneratedVersion = Effect.fnUntraced(function*(repositoryRoot:
   )
 })
 
+const supportedComponentsStart = "<!-- supported-components:start -->"
+const supportedComponentsEnd = "<!-- supported-components:end -->"
+
+export const writeSupportedComponentsReadme = Effect.fnUntraced(function*(repositoryRoot: string) {
+  const fs = yield* FileSystem.FileSystem
+  const path = yield* Path.Path
+  const packageJsonPath = path.join(repositoryRoot, "_packages", "tsgo", "package.json")
+  const packageJsonText = yield* fs.readFileString(packageJsonPath).pipe(
+    Effect.mapError((error) => new SupportedComponentsReadmeError({ reason: error.message }))
+  )
+  const { version } = yield* Schema.decodeUnknownEffect(PackageJson)(packageJsonText).pipe(
+    Effect.mapError((error) => new SupportedComponentsReadmeError({ reason: error.message }))
+  )
+  const upstream = yield* readUpstream(repositoryRoot).pipe(
+    Effect.mapError((error) => new SupportedComponentsReadmeError({ reason: error.message }))
+  )
+  const readmePath = path.join(repositoryRoot, "README.md")
+  const readme = yield* fs.readFileString(readmePath).pipe(
+    Effect.mapError((error) => new SupportedComponentsReadmeError({ reason: error.message }))
+  )
+  const lines = readme.split("\n")
+  if (lines.filter((line) => line === supportedComponentsStart).length !== 1 ||
+    lines.filter((line) => line === supportedComponentsEnd).length !== 1) {
+    return yield* new SupportedComponentsReadmeError({ reason: "Generated section markers are missing or invalid" })
+  }
+  const start = readme.indexOf(supportedComponentsStart)
+  const end = readme.indexOf(supportedComponentsEnd)
+  if (end < start) {
+    return yield* new SupportedComponentsReadmeError({ reason: "Generated section markers are missing or invalid" })
+  }
+  const rows = [
+    ["TypeScript", Object.keys(upstream.components.typescript)],
+    ["Oxlint", Object.keys(upstream.components.oxlint)],
+    ["oxlint-tsgolint", Object.keys(upstream.components["oxlint-tsgolint"])]
+  ] as const
+  const section = [
+    supportedComponentsStart,
+    "## Supported Package Versions",
+    "",
+    `The following target package versions are supported by \`@effect/tsgo@${version}\`:`,
+    "",
+    "| Component | Supported versions |",
+    "|---|---|",
+    ...rows.map(([component, versions]) =>
+      `| ${component} | ${versions.sort(compare).map((version) => `\`${version}\``).join(", ")} |`),
+    supportedComponentsEnd
+  ].join("\n")
+  const updated = readme.slice(0, start) + section + readme.slice(end + supportedComponentsEnd.length)
+  yield* fs.writeFileString(readmePath, updated).pipe(
+    Effect.mapError((error) => new SupportedComponentsReadmeError({ reason: error.message }))
+  )
+})
+
 export const versionChangeset = Effect.fnUntraced(function*(repositoryRoot: string) {
   yield* runCommand("pnpm", repositoryRoot, ["exec", "changeset", "version"])
   yield* writeGeneratedVersion(repositoryRoot)
+  yield* writeSupportedComponentsReadme(repositoryRoot)
 })
 
 export const publishChangeset = (repositoryRoot: string) =>

--- a/_tools/repoctl/test/changesets.test.ts
+++ b/_tools/repoctl/test/changesets.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import assert from "node:assert/strict"
 import test from "node:test"
-import { addChangeset, writeGeneratedVersion } from "../src/changesets.ts"
+import { addChangeset, writeGeneratedVersion, writeSupportedComponentsReadme } from "../src/changesets.ts"
 
 test("generates the Go version from the CLI package", async() => {
   const repository = mkdtempSync(join(tmpdir(), "repoctl-version-"))
@@ -52,6 +52,83 @@ test("adds a changeset", async() => {
       "Update upstream metadata.",
       ""
     ].join("\n"))
+  } finally {
+    rmSync(repository, { recursive: true, force: true })
+  }
+})
+
+test("generates the supported package versions README section", async() => {
+  const repository = mkdtempSync(join(tmpdir(), "repoctl-supported-components-"))
+
+  try {
+    mkdirSync(join(repository, "_packages", "tsgo"), { recursive: true })
+    writeFileSync(join(repository, "_packages", "tsgo", "package.json"), JSON.stringify({ version: "1.2.3" }))
+    writeFileSync(join(repository, "_packages", "tsgo", "upstream.json"), JSON.stringify({
+      schemaVersion: 4,
+      tags: {
+        typescript: { latest: "7.0.2", next: "7.1.0-dev.10" },
+        oxlint: { latest: "1.10.0" },
+        "oxlint-tsgolint": { latest: "7.0.2001" }
+      },
+      components: {
+        typescript: {
+          "7.1.0-dev.10": { gitHead: "2222222222222222222222222222222222222222" },
+          "7.1.0-dev.2": { gitHead: "6666666666666666666666666666666666666666" },
+          "7.0.2": { gitHead: "1111111111111111111111111111111111111111" }
+        },
+        oxlint: {
+          "1.10.0": { gitHead: "4444444444444444444444444444444444444444" },
+          "1.9.0": { gitHead: "3333333333333333333333333333333333333333" }
+        },
+        "oxlint-tsgolint": {
+          "7.0.2001": {
+            gitHead: "5555555555555555555555555555555555555555",
+            dependencies: { typescript: "7.0.2" }
+          }
+        }
+      },
+      profiles: [{
+        name: "vite-plus",
+        description: "Vite+ compatibility runtime",
+        dependencies: { oxlint: "1.9.0", "oxlint-tsgolint": "7.0.2001" }
+      }]
+    }))
+    writeFileSync(join(repository, "README.md"), [
+      "Before",
+      "<!-- supported-components:start -->",
+      "stale",
+      "<!-- supported-components:end -->",
+      "After",
+      ""
+    ].join("\n"))
+
+    await Effect.runPromise(
+      writeSupportedComponentsReadme(repository).pipe(Effect.provide(NodeServices.layer))
+    )
+
+    const generated = [
+      "Before",
+      "<!-- supported-components:start -->",
+      "## Supported Package Versions",
+      "",
+      "The following target package versions are supported by `@effect/tsgo@1.2.3`:",
+      "",
+      "| Component | Supported versions |",
+      "|---|---|",
+      "| TypeScript | `7.0.2`, `7.1.0-dev.2`, `7.1.0-dev.10` |",
+      "| Oxlint | `1.9.0`, `1.10.0` |",
+      "| oxlint-tsgolint | `7.0.2001` |",
+      "<!-- supported-components:end -->",
+      "After",
+      ""
+    ].join("\n")
+    assert.equal(readFileSync(join(repository, "README.md"), "utf8"), generated)
+
+    writeFileSync(join(repository, "README.md"), `${generated}<!-- supported-components:end -->\n`)
+    await assert.rejects(
+      Effect.runPromise(writeSupportedComponentsReadme(repository).pipe(Effect.provide(NodeServices.layer))),
+      /Generated section markers are missing or invalid/
+    )
   } finally {
     rmSync(repository, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

- add a supported package version table before the diagnostic status section
- seed the table from the published `@effect/tsgo@0.36.4` release snapshot
- regenerate the table during `repoctl changeset version` using the bumped package version and release manifest
- validate generated markers and sort component versions using SemVer ordering

## Generated output

```md
The following target package versions are supported by `@effect/tsgo@0.36.4`:

| Component | Supported versions |
|---|---|
| TypeScript | `7.0.2`, `7.1.0-dev.20260808.1` |
| Oxlint | `1.76.0`, `1.77.0` |
| oxlint-tsgolint | `7.0.2001` |
```

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm --dir _tools/repoctl test`