### PR TITLE
Suppress unsafe unnecessaryPipeChain rewrites

### DIFF
--- a/.changeset/quiet-pipe-chains.md
+++ b/.changeset/quiet-pipe-chains.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Suppress the `unnecessaryPipeChain` diagnostic when merging chained pipe calls would exceed the available overload arity.

--- a/internal/rules/unnecessary_pipe_chain.go
+++ b/internal/rules/unnecessary_pipe_chain.go
@@ -43,7 +43,7 @@ type UnnecessaryPipeChainMatch struct {
 // AnalyzeUnnecessaryPipeChain finds all chained pipe() and .pipe() calls
 // (outer pipe whose subject is also a pipe call), returning matches with
 // the diagnostic and both parsed results.
-func AnalyzeUnnecessaryPipeChain(tp *typeparser.TypeParser, _ *checker.Checker, sf *ast.SourceFile) []UnnecessaryPipeChainMatch {
+func AnalyzeUnnecessaryPipeChain(tp *typeparser.TypeParser, c *checker.Checker, sf *ast.SourceFile) []UnnecessaryPipeChainMatch {
 	var matches []UnnecessaryPipeChainMatch
 
 	var walk ast.Visitor
@@ -55,12 +55,14 @@ func AnalyzeUnnecessaryPipeChain(tp *typeparser.TypeParser, _ *checker.Checker, 
 		if n.Kind == ast.KindCallExpression {
 			if result := tp.ParsePipeCall(n); result != nil {
 				if inner := tp.ParsePipeCall(result.Subject); inner != nil {
-					matches = append(matches, UnnecessaryPipeChainMatch{
-						SourceFile: sf,
-						Location:   scanner.GetErrorRangeForNode(sf, result.Node.AsNode()),
-						Outer:      result,
-						Inner:      inner,
-					})
+					if pipeMergeSupportsArity(tp, c, inner, result) {
+						matches = append(matches, UnnecessaryPipeChainMatch{
+							SourceFile: sf,
+							Location:   scanner.GetErrorRangeForNode(sf, result.Node.AsNode()),
+							Outer:      result,
+							Inner:      inner,
+						})
+					}
 				}
 			}
 		}
@@ -71,4 +73,35 @@ func AnalyzeUnnecessaryPipeChain(tp *typeparser.TypeParser, _ *checker.Checker, 
 
 	walk(sf.AsNode())
 	return matches
+}
+
+func pipeMergeSupportsArity(tp *typeparser.TypeParser, c *checker.Checker, inner, outer *typeparser.ParsedPipeCallResult) bool {
+	if containsSpreadArgument(inner.Args) || containsSpreadArgument(outer.Args) {
+		return false
+	}
+
+	argumentCount := len(inner.Args) + len(outer.Args)
+	if inner.Kind == typeparser.TransformationKindPipe {
+		argumentCount++ // Standalone pipe retains its subject as the first argument.
+	}
+
+	calleeType := tp.GetTypeAtLocation(inner.Node.Expression)
+	for _, signature := range c.GetSignaturesOfType(calleeType, checker.SignatureKindCall) {
+		if argumentCount < signature.MinArgumentCount() {
+			continue
+		}
+		if signature.HasRestParameter() || argumentCount <= len(signature.Parameters()) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsSpreadArgument(args []*ast.Node) bool {
+	for _, arg := range args {
+		if arg != nil && arg.Kind == ast.KindSpreadElement {
+			return true
+		}
+	}
+	return false
 }

--- a/testdata/baselines/reference/effect-v4/unnecessaryPipeChain.errors.txt
+++ b/testdata/baselines/reference/effect-v4/unnecessaryPipeChain.errors.txt
@@ -3,9 +3,12 @@ Effect version: 4.0.0
 
 /.src/unnecessaryPipeChain.ts(5,27): suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
 /.src/unnecessaryPipeChain.ts(8,23): suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+/.src/unnecessaryPipeChain.ts(22,38): suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+/.src/unnecessaryPipeChain.ts(38,40): suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+/.src/unnecessaryPipeChain.ts(70,41): suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
 
 
-==== /.src/unnecessaryPipeChain.ts (2 errors) ====
+==== /.src/unnecessaryPipeChain.ts (5 errors) ====
     import * as Effect from "effect/Effect"
     import { pipe } from "effect/Function"
     
@@ -27,4 +30,86 @@ Effect version: 4.0.0
     
     // Should NOT trigger: pipe with non-pipe subject
     export const nonPipeSubject = pipe(Effect.succeed(1), Effect.map((x) => x + 2))
+    
+    const bump = Effect.map((x: number) => x + 1)
+    
+    // Should trigger: merging reaches the 20-transformation .pipe() limit
+    export const pipeableAtMergedLimit = Effect.succeed(0).pipe(
+                                         ~~~~~~~~~~~~~~~~~~~~~~~
+      bump, bump, bump, bump, bump,
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      bump, bump, bump, bump, bump,
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      bump, bump, bump, bump, bump,
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      bump, bump, bump, bump
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+    ).pipe(bump)
+    ~~~~~~~~~~~~
+!!! suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+    
+    // Should NOT trigger: merging exceeds the 20-transformation .pipe() limit
+    export const pipeableOverMergedLimit = Effect.succeed(0).pipe(
+      bump, bump, bump, bump, bump,
+      bump, bump, bump, bump, bump,
+      bump, bump, bump, bump, bump,
+      bump, bump, bump, bump, bump
+    ).pipe(bump)
+    
+    // Should trigger: merging reaches the 19-transformation pipe() limit
+    export const standaloneAtMergedLimit = pipe(
+                                           ~~~~~
+      pipe(
+    ~~~~~~~
+        Effect.succeed(0),
+    ~~~~~~~~~~~~~~~~~~~~~~
+        bump, bump, bump, bump, bump,
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        bump, bump, bump, bump
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ),
+    ~~~~
+      bump, bump, bump, bump, bump,
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      bump, bump, bump, bump, bump
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    )
+    ~
+!!! suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+    
+    // Should NOT trigger: merging exceeds the 19-transformation pipe() limit
+    export const standaloneOverMergedLimit = pipe(
+      pipe(
+        Effect.succeed(0),
+        bump, bump, bump, bump, bump,
+        bump, bump, bump, bump, bump
+      ),
+      bump, bump, bump, bump, bump,
+      bump, bump, bump, bump, bump
+    )
+    
+    // Should NOT trigger: the merged arity is unknown because of a spread argument
+    export const unknownMergedArity = Effect.succeed(0).pipe(
+      ...([
+        bump, bump, bump, bump, bump,
+        bump, bump, bump, bump, bump,
+        bump, bump, bump, bump, bump,
+        bump, bump, bump, bump, bump
+      ] as const)
+    ).pipe(bump)
+    
+    // Should still trigger for the safe inner merge when the outer merge exceeds the limit
+    export const nestedWithinSnoozedChain = Effect.succeed(0)
+                                            ~~~~~~~~~~~~~~~~~
+      .pipe(bump)
+    ~~~~~~~~~~~~~
+      .pipe(bump)
+    ~~~~~~~~~~~~~
+!!! suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+      .pipe(
+        bump, bump, bump, bump, bump,
+        bump, bump, bump, bump, bump,
+        bump, bump, bump, bump, bump,
+        bump, bump, bump, bump, bump
+      )
     

--- a/testdata/baselines/reference/effect-v4/unnecessaryPipeChain.flows.unnecessaryPipeChain.mermaid
+++ b/testdata/baselines/reference/effect-v4/unnecessaryPipeChain.flows.unnecessaryPipeChain.mermaid
@@ -50,6 +50,131 @@ flowchart TB
   48[/"type: #123; #lt;A, B#gt;#40;f: #40;a: A#41; =#gt; B#41;: #lt;E, R#gt;#40;self: Effect#lt;A, E, R#gt;#41; =#gt; Effect#lt;B, E, R#gt;; #lt;A, E, R, B#gt;#40;self: Effect#lt;A, E, R#gt;, f: #40;a: A#41; =#gt; B#41;: Effect#lt;B, E, R#gt;; #125;<br/>node: Effect.map"/]
   49[["type: #40;x: number#41; =#gt; number<br/>node: #40;x#41; =#gt; x + 2"]]
   50[/"type: number<br/>node: x + 2"/]
+  51[/"type: #lt;E, R#gt;#40;self: Effect#lt;number, E, R#gt;#41; =#gt; Effect#lt;number, E, R#gt;<br/>node: Effect.map#40;#40;x: number#41; =#gt; x + 1#41;"/]
+  52[["type: #40;x: number#41; =#gt; number<br/>node: #40;x: number#41; =#gt; x + 1"]]
+  53[/"type: number<br/>node: x + 1"/]
+  54[/"type: 0<br/>node: 0"/]
+  55["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  56[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  57["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  58["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  59["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  60["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  61["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  62["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  63["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  64["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  65["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  66["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  67["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  68["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  69["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  70["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  71["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  72["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  73["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  74["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  75["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  76["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  77[/"type: 0<br/>node: 0"/]
+  78["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  79[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  80["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  81["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  82["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  83["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  84["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  85["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  86["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  87["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  88["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  89["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  90["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  91["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  92["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  93["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  94["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  95["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  96["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  97["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  98["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  99["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  100["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  101[/"type: 0<br/>node: 0"/]
+  102["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  103[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  104["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  105["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  106["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  107["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  108["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  109["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  110["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  111["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  112["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  113["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  114["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  115["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  116["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  117["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  118["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  119["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  120["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  121["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  122["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  123[/"type: 0<br/>node: 0"/]
+  124["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  125[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  126["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  127["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  128["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  129["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  130["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  131["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  132["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  133["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  134["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  135["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  136["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  137["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  138["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  139["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  140["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  141["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  142["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  143["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  144["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  145["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  146[/"type: 0<br/>node: 0"/]
+  147["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  148[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  149["type: Effect#lt;number, never, never#gt;<br/>callee: ...#40;#91;#92;n    bump, bump, bump, bump, bump,#92;n    bump, bump, bump, bump, bump,#92;n    bump, bump, bump, bump, bump,#92;n    bump, bump, bump, bump, bump#92;n  #93; as const#41;<br/>args: #91;#93;"]
+  150["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  151[/"type: 0<br/>node: 0"/]
+  152["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  153[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  154["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  155["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  156["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  157["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  158["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  159["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  160["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  161["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  162["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  163["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  164["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  165["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  166["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  167["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  168["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  169["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  170["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  171["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  172["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  173["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  174["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
+  175["type: Effect#lt;number, never, never#gt;<br/>callee: bump<br/>args: #91;#93;"]
   0 -->|"kind: pipe"| 1
   2 -->|"kind: transformCallee"| 1
   4 -->|"kind: transformCallee"| 3
@@ -96,3 +221,121 @@ flowchart TB
   50 -->|"kind: potentialReturn"| 49
   49 -->|"kind: transformArg"| 47
   45 -->|"kind: pipe"| 47
+  53 -->|"kind: potentialReturn"| 52
+  52 -->|"kind: usedBy"| 51
+  54 -->|"kind: pipe"| 55
+  56 -->|"kind: transformCallee"| 55
+  55 -->|"kind: pipe"| 57
+  57 -->|"kind: pipe"| 58
+  58 -->|"kind: pipe"| 59
+  59 -->|"kind: pipe"| 60
+  60 -->|"kind: pipe"| 61
+  61 -->|"kind: pipe"| 62
+  62 -->|"kind: pipe"| 63
+  63 -->|"kind: pipe"| 64
+  64 -->|"kind: pipe"| 65
+  65 -->|"kind: pipe"| 66
+  66 -->|"kind: pipe"| 67
+  67 -->|"kind: pipe"| 68
+  68 -->|"kind: pipe"| 69
+  69 -->|"kind: pipe"| 70
+  70 -->|"kind: pipe"| 71
+  71 -->|"kind: pipe"| 72
+  72 -->|"kind: pipe"| 73
+  73 -->|"kind: pipe"| 74
+  74 -->|"kind: pipe"| 75
+  75 -->|"kind: pipe"| 76
+  77 -->|"kind: pipe"| 78
+  79 -->|"kind: transformCallee"| 78
+  78 -->|"kind: pipe"| 80
+  80 -->|"kind: pipe"| 81
+  81 -->|"kind: pipe"| 82
+  82 -->|"kind: pipe"| 83
+  83 -->|"kind: pipe"| 84
+  84 -->|"kind: pipe"| 85
+  85 -->|"kind: pipe"| 86
+  86 -->|"kind: pipe"| 87
+  87 -->|"kind: pipe"| 88
+  88 -->|"kind: pipe"| 89
+  89 -->|"kind: pipe"| 90
+  90 -->|"kind: pipe"| 91
+  91 -->|"kind: pipe"| 92
+  92 -->|"kind: pipe"| 93
+  93 -->|"kind: pipe"| 94
+  94 -->|"kind: pipe"| 95
+  95 -->|"kind: pipe"| 96
+  96 -->|"kind: pipe"| 97
+  97 -->|"kind: pipe"| 98
+  98 -->|"kind: pipe"| 99
+  99 -->|"kind: pipe"| 100
+  101 -->|"kind: pipe"| 102
+  103 -->|"kind: transformCallee"| 102
+  102 -->|"kind: pipe"| 104
+  104 -->|"kind: pipe"| 105
+  105 -->|"kind: pipe"| 106
+  106 -->|"kind: pipe"| 107
+  107 -->|"kind: pipe"| 108
+  108 -->|"kind: pipe"| 109
+  109 -->|"kind: pipe"| 110
+  110 -->|"kind: pipe"| 111
+  111 -->|"kind: pipe"| 112
+  112 -->|"kind: pipe"| 113
+  113 -->|"kind: pipe"| 114
+  114 -->|"kind: pipe"| 115
+  115 -->|"kind: pipe"| 116
+  116 -->|"kind: pipe"| 117
+  117 -->|"kind: pipe"| 118
+  118 -->|"kind: pipe"| 119
+  119 -->|"kind: pipe"| 120
+  120 -->|"kind: pipe"| 121
+  121 -->|"kind: pipe"| 122
+  123 -->|"kind: pipe"| 124
+  125 -->|"kind: transformCallee"| 124
+  124 -->|"kind: pipe"| 126
+  126 -->|"kind: pipe"| 127
+  127 -->|"kind: pipe"| 128
+  128 -->|"kind: pipe"| 129
+  129 -->|"kind: pipe"| 130
+  130 -->|"kind: pipe"| 131
+  131 -->|"kind: pipe"| 132
+  132 -->|"kind: pipe"| 133
+  133 -->|"kind: pipe"| 134
+  134 -->|"kind: pipe"| 135
+  135 -->|"kind: pipe"| 136
+  136 -->|"kind: pipe"| 137
+  137 -->|"kind: pipe"| 138
+  138 -->|"kind: pipe"| 139
+  139 -->|"kind: pipe"| 140
+  140 -->|"kind: pipe"| 141
+  141 -->|"kind: pipe"| 142
+  142 -->|"kind: pipe"| 143
+  143 -->|"kind: pipe"| 144
+  144 -->|"kind: pipe"| 145
+  146 -->|"kind: pipe"| 147
+  148 -->|"kind: transformCallee"| 147
+  147 -->|"kind: pipe"| 149
+  149 -->|"kind: pipe"| 150
+  151 -->|"kind: pipe"| 152
+  153 -->|"kind: transformCallee"| 152
+  152 -->|"kind: pipe"| 154
+  154 -->|"kind: pipe"| 155
+  155 -->|"kind: pipe"| 156
+  156 -->|"kind: pipe"| 157
+  157 -->|"kind: pipe"| 158
+  158 -->|"kind: pipe"| 159
+  159 -->|"kind: pipe"| 160
+  160 -->|"kind: pipe"| 161
+  161 -->|"kind: pipe"| 162
+  162 -->|"kind: pipe"| 163
+  163 -->|"kind: pipe"| 164
+  164 -->|"kind: pipe"| 165
+  165 -->|"kind: pipe"| 166
+  166 -->|"kind: pipe"| 167
+  167 -->|"kind: pipe"| 168
+  168 -->|"kind: pipe"| 169
+  169 -->|"kind: pipe"| 170
+  170 -->|"kind: pipe"| 171
+  171 -->|"kind: pipe"| 172
+  172 -->|"kind: pipe"| 173
+  173 -->|"kind: pipe"| 174
+  174 -->|"kind: pipe"| 175

--- a/testdata/baselines/reference/effect-v4/unnecessaryPipeChain.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/unnecessaryPipeChain.pipings.txt
@@ -1,4 +1,4 @@
-==== /.src/unnecessaryPipeChain.ts (5 flows) ====
+==== /.src/unnecessaryPipeChain.ts (12 flows) ====
 
 === Piping Flow ===
 Location: 5:26 - 5:106
@@ -104,4 +104,518 @@ Transformations (2):
   [1] kind: pipe
       callee: Effect.map
       args: [(x) => x + 2]
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 19:13 - 19:46
+Node: Effect.map((x: number) => x + 1)
+Node Kind: KindCallExpression
+
+Subject: (x: number) => x + 1
+Subject Type: (x: number) => number
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.map
+      args: (constant)
+      outType: <E, R>(self: Effect<number, E, R>) => Effect<number, E, R>
+
+=== Piping Flow ===
+Location: 22:37 - 27:13
+Node: Effect.succeed(0).pipe(\n  bump, bump, bump, bump, bump,\n  bump, bump, bump, bump, bump,\n  bump, bump, bump, bump, bump,\n  bump, bump, bump, bump\n).pipe(bump)
+Node Kind: KindCallExpression
+
+Subject: 0
+Subject Type: 0
+
+Transformations (21):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+  [1] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [2] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [3] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [4] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [5] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [6] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [7] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [8] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [9] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [10] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [11] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [12] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [13] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [14] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [15] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [16] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [17] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [18] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [19] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [20] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 30:39 - 35:13
+Node: Effect.succeed(0).pipe(\n  bump, bump, bump, bump, bump,\n  bump, bump, bump, bump, bump,\n  bump, bump, bump, bump, bump,\n  bump, bump, bump, bump, bump\n).pipe(bump)
+Node Kind: KindCallExpression
+
+Subject: 0
+Subject Type: 0
+
+Transformations (22):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+  [1] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [2] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [3] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [4] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [5] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [6] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [7] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [8] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [9] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [10] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [11] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [12] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [13] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [14] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [15] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [16] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [17] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [18] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [19] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [20] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [21] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 38:39 - 46:2
+Node: pipe(\n  pipe(\n    Effect.succeed(0),\n    bump, bump, bump, bump, bump,\n    bump, bump, bump, bump\n  ),\n  bump, bump, bump, bump, bump,\n  bump, bump, bump, bump, bump\n)
+Node Kind: KindCallExpression
+
+Subject: 0
+Subject Type: 0
+
+Transformations (20):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+  [1] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [2] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [3] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [4] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [5] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [6] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [7] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [8] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [9] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [10] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [11] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [12] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [13] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [14] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [15] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [16] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [17] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [18] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [19] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 49:41 - 57:2
+Node: pipe(\n  pipe(\n    Effect.succeed(0),\n    bump, bump, bump, bump, bump,\n    bump, bump, bump, bump, bump\n  ),\n  bump, bump, bump, bump, bump,\n  bump, bump, bump, bump, bump\n)
+Node Kind: KindCallExpression
+
+Subject: 0
+Subject Type: 0
+
+Transformations (21):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+  [1] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [2] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [3] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [4] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [5] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [6] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [7] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [8] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [9] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [10] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [11] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [12] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [13] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [14] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [15] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [16] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [17] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [18] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [19] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [20] kind: pipe
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 60:34 - 67:13
+Node: Effect.succeed(0).pipe(\n  ...([\n    bump, bump, bump, bump, bump,\n    bump, bump, bump, bump, bump,\n    bump, bump, bump, bump, bump,\n    bump, bump, bump, bump, bump\n  ] as const)\n).pipe(bump)
+Node Kind: KindCallExpression
+
+Subject: 0
+Subject Type: 0
+
+Transformations (3):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+  [1] kind: pipeable
+      callee: ...([\n    bump, bump, bump, bump, bump,\n    bump, bump, bump, bump, bump,\n    bump, bump, bump, bump, bump,\n    bump, bump, bump, bump, bump\n  ] as const)
+      args: (constant)
+      outType: Effect<number, never, never>
+  [2] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+
+=== Piping Flow ===
+Location: 70:40 - 78:4
+Node: Effect.succeed(0)\n  .pipe(bump)\n  .pipe(bump)\n  .pipe(\n    bump, bump, bump, bump, bump,\n    bump, bump, bump, bump, bump,\n    bump, bump, bump, bump, bump,\n    bump, bump, bump, bump, bump\n  )
+Node Kind: KindCallExpression
+
+Subject: 0
+Subject Type: 0
+
+Transformations (23):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+  [1] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [2] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [3] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [4] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [5] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [6] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [7] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [8] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [9] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [10] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [11] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [12] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [13] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [14] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [15] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [16] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [17] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [18] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [19] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [20] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [21] kind: pipeable
+      callee: bump
+      args: (constant)
+      outType: Effect<number, never, never>
+  [22] kind: pipeable
+      callee: bump
+      args: (constant)
       outType: Effect<number, never, never>

--- a/testdata/baselines/reference/effect-v4/unnecessaryPipeChain.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/unnecessaryPipeChain.quickfixes.txt
@@ -10,6 +10,21 @@
   Fix 1: "Disable unnecessaryPipeChain for entire file"
   Fix 2: "Rewrite as single pipe call"
 
+[D3] (22:38-27:13) TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+  Fix 0: "Disable unnecessaryPipeChain for this line"
+  Fix 1: "Disable unnecessaryPipeChain for entire file"
+  Fix 2: "Rewrite as single pipe call"
+
+[D4] (38:40-46:2) TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+  Fix 0: "Disable unnecessaryPipeChain for this line"
+  Fix 1: "Disable unnecessaryPipeChain for entire file"
+  Fix 2: "Rewrite as single pipe call"
+
+[D5] (70:41-72:14) TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+  Fix 0: "Disable unnecessaryPipeChain for this line"
+  Fix 1: "Disable unnecessaryPipeChain for entire file"
+  Fix 2: "Rewrite as single pipe call"
+
 === Quick Fix Application Results ===
 
 === [D1] Fix 0: "Disable unnecessaryPipeChain for this line" ===
@@ -39,6 +54,67 @@ export const singlePipeable = Effect.succeed(1).pipe(Effect.map((x) => x + 2), E
 // Should NOT trigger: pipe with non-pipe subject
 export const nonPipeSubject = pipe(Effect.succeed(1), Effect.map((x) => x + 2))
 
+const bump = Effect.map((x: number) => x + 1)
+
+// Should trigger: merging reaches the 20-transformation .pipe() limit
+export const pipeableAtMergedLimit = Effect.succeed(0).pipe(
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump
+).pipe(bump)
+
+// Should NOT trigger: merging exceeds the 20-transformation .pipe() limit
+export const pipeableOverMergedLimit = Effect.succeed(0).pipe(
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+).pipe(bump)
+
+// Should trigger: merging reaches the 19-transformation pipe() limit
+export const standaloneAtMergedLimit = pipe(
+  pipe(
+    Effect.succeed(0),
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump
+  ),
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+)
+
+// Should NOT trigger: merging exceeds the 19-transformation pipe() limit
+export const standaloneOverMergedLimit = pipe(
+  pipe(
+    Effect.succeed(0),
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  ),
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+)
+
+// Should NOT trigger: the merged arity is unknown because of a spread argument
+export const unknownMergedArity = Effect.succeed(0).pipe(
+  ...([
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  ] as const)
+).pipe(bump)
+
+// Should still trigger for the safe inner merge when the outer merge exceeds the limit
+export const nestedWithinSnoozedChain = Effect.succeed(0)
+  .pipe(bump)
+  .pipe(bump)
+  .pipe(
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  )
+
 
 === [D2] Fix 0: "Disable unnecessaryPipeChain for this line" ===
 skipped by default
@@ -66,4 +142,317 @@ export const singlePipeable = Effect.succeed(1).pipe(Effect.map((x) => x + 2), E
 
 // Should NOT trigger: pipe with non-pipe subject
 export const nonPipeSubject = pipe(Effect.succeed(1), Effect.map((x) => x + 2))
+
+const bump = Effect.map((x: number) => x + 1)
+
+// Should trigger: merging reaches the 20-transformation .pipe() limit
+export const pipeableAtMergedLimit = Effect.succeed(0).pipe(
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump
+).pipe(bump)
+
+// Should NOT trigger: merging exceeds the 20-transformation .pipe() limit
+export const pipeableOverMergedLimit = Effect.succeed(0).pipe(
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+).pipe(bump)
+
+// Should trigger: merging reaches the 19-transformation pipe() limit
+export const standaloneAtMergedLimit = pipe(
+  pipe(
+    Effect.succeed(0),
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump
+  ),
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+)
+
+// Should NOT trigger: merging exceeds the 19-transformation pipe() limit
+export const standaloneOverMergedLimit = pipe(
+  pipe(
+    Effect.succeed(0),
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  ),
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+)
+
+// Should NOT trigger: the merged arity is unknown because of a spread argument
+export const unknownMergedArity = Effect.succeed(0).pipe(
+  ...([
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  ] as const)
+).pipe(bump)
+
+// Should still trigger for the safe inner merge when the outer merge exceeds the limit
+export const nestedWithinSnoozedChain = Effect.succeed(0)
+  .pipe(bump)
+  .pipe(bump)
+  .pipe(
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  )
+
+
+=== [D3] Fix 0: "Disable unnecessaryPipeChain for this line" ===
+skipped by default
+
+=== [D3] Fix 1: "Disable unnecessaryPipeChain for entire file" ===
+skipped by default
+
+=== [D3] Fix 2: "Rewrite as single pipe call" ===
+
+--- file:///.src/unnecessaryPipeChain.ts ---
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+
+// Should trigger: chained .pipe() calls
+export const asPipeable = Effect.succeed(1).pipe(Effect.map((x) => x + 2)).pipe(Effect.map((x) => x + 3))
+
+// Should trigger: nested pipe() calls
+export const asPipe = pipe(pipe(Effect.succeed(1), Effect.map((x) => x + 2)), Effect.map((x) => x + 3))
+
+// Should NOT trigger: single pipe with multiple args
+export const singlePipe = pipe(Effect.succeed(1), Effect.map((x) => x + 2), Effect.map((x) => x + 3))
+
+// Should NOT trigger: single .pipe() with multiple args
+export const singlePipeable = Effect.succeed(1).pipe(Effect.map((x) => x + 2), Effect.map((x) => x + 3))
+
+// Should NOT trigger: pipe with non-pipe subject
+export const nonPipeSubject = pipe(Effect.succeed(1), Effect.map((x) => x + 2))
+
+const bump = Effect.map((x: number) => x + 1)
+
+// Should trigger: merging reaches the 20-transformation .pipe() limit
+export const pipeableAtMergedLimit = Effect.succeed(0).pipe(bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump)
+
+// Should NOT trigger: merging exceeds the 20-transformation .pipe() limit
+export const pipeableOverMergedLimit = Effect.succeed(0).pipe(
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+).pipe(bump)
+
+// Should trigger: merging reaches the 19-transformation pipe() limit
+export const standaloneAtMergedLimit = pipe(
+  pipe(
+    Effect.succeed(0),
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump
+  ),
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+)
+
+// Should NOT trigger: merging exceeds the 19-transformation pipe() limit
+export const standaloneOverMergedLimit = pipe(
+  pipe(
+    Effect.succeed(0),
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  ),
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+)
+
+// Should NOT trigger: the merged arity is unknown because of a spread argument
+export const unknownMergedArity = Effect.succeed(0).pipe(
+  ...([
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  ] as const)
+).pipe(bump)
+
+// Should still trigger for the safe inner merge when the outer merge exceeds the limit
+export const nestedWithinSnoozedChain = Effect.succeed(0)
+  .pipe(bump)
+  .pipe(bump)
+  .pipe(
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  )
+
+
+=== [D4] Fix 0: "Disable unnecessaryPipeChain for this line" ===
+skipped by default
+
+=== [D4] Fix 1: "Disable unnecessaryPipeChain for entire file" ===
+skipped by default
+
+=== [D4] Fix 2: "Rewrite as single pipe call" ===
+
+--- file:///.src/unnecessaryPipeChain.ts ---
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+
+// Should trigger: chained .pipe() calls
+export const asPipeable = Effect.succeed(1).pipe(Effect.map((x) => x + 2)).pipe(Effect.map((x) => x + 3))
+
+// Should trigger: nested pipe() calls
+export const asPipe = pipe(pipe(Effect.succeed(1), Effect.map((x) => x + 2)), Effect.map((x) => x + 3))
+
+// Should NOT trigger: single pipe with multiple args
+export const singlePipe = pipe(Effect.succeed(1), Effect.map((x) => x + 2), Effect.map((x) => x + 3))
+
+// Should NOT trigger: single .pipe() with multiple args
+export const singlePipeable = Effect.succeed(1).pipe(Effect.map((x) => x + 2), Effect.map((x) => x + 3))
+
+// Should NOT trigger: pipe with non-pipe subject
+export const nonPipeSubject = pipe(Effect.succeed(1), Effect.map((x) => x + 2))
+
+const bump = Effect.map((x: number) => x + 1)
+
+// Should trigger: merging reaches the 20-transformation .pipe() limit
+export const pipeableAtMergedLimit = Effect.succeed(0).pipe(
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump
+).pipe(bump)
+
+// Should NOT trigger: merging exceeds the 20-transformation .pipe() limit
+export const pipeableOverMergedLimit = Effect.succeed(0).pipe(
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+).pipe(bump)
+
+// Should trigger: merging reaches the 19-transformation pipe() limit
+export const standaloneAtMergedLimit = pipe(Effect.succeed(0), bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump, bump)
+
+// Should NOT trigger: merging exceeds the 19-transformation pipe() limit
+export const standaloneOverMergedLimit = pipe(
+  pipe(
+    Effect.succeed(0),
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  ),
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+)
+
+// Should NOT trigger: the merged arity is unknown because of a spread argument
+export const unknownMergedArity = Effect.succeed(0).pipe(
+  ...([
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  ] as const)
+).pipe(bump)
+
+// Should still trigger for the safe inner merge when the outer merge exceeds the limit
+export const nestedWithinSnoozedChain = Effect.succeed(0)
+  .pipe(bump)
+  .pipe(bump)
+  .pipe(
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  )
+
+
+=== [D5] Fix 0: "Disable unnecessaryPipeChain for this line" ===
+skipped by default
+
+=== [D5] Fix 1: "Disable unnecessaryPipeChain for entire file" ===
+skipped by default
+
+=== [D5] Fix 2: "Rewrite as single pipe call" ===
+
+--- file:///.src/unnecessaryPipeChain.ts ---
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+
+// Should trigger: chained .pipe() calls
+export const asPipeable = Effect.succeed(1).pipe(Effect.map((x) => x + 2)).pipe(Effect.map((x) => x + 3))
+
+// Should trigger: nested pipe() calls
+export const asPipe = pipe(pipe(Effect.succeed(1), Effect.map((x) => x + 2)), Effect.map((x) => x + 3))
+
+// Should NOT trigger: single pipe with multiple args
+export const singlePipe = pipe(Effect.succeed(1), Effect.map((x) => x + 2), Effect.map((x) => x + 3))
+
+// Should NOT trigger: single .pipe() with multiple args
+export const singlePipeable = Effect.succeed(1).pipe(Effect.map((x) => x + 2), Effect.map((x) => x + 3))
+
+// Should NOT trigger: pipe with non-pipe subject
+export const nonPipeSubject = pipe(Effect.succeed(1), Effect.map((x) => x + 2))
+
+const bump = Effect.map((x: number) => x + 1)
+
+// Should trigger: merging reaches the 20-transformation .pipe() limit
+export const pipeableAtMergedLimit = Effect.succeed(0).pipe(
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump
+).pipe(bump)
+
+// Should NOT trigger: merging exceeds the 20-transformation .pipe() limit
+export const pipeableOverMergedLimit = Effect.succeed(0).pipe(
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+).pipe(bump)
+
+// Should trigger: merging reaches the 19-transformation pipe() limit
+export const standaloneAtMergedLimit = pipe(
+  pipe(
+    Effect.succeed(0),
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump
+  ),
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+)
+
+// Should NOT trigger: merging exceeds the 19-transformation pipe() limit
+export const standaloneOverMergedLimit = pipe(
+  pipe(
+    Effect.succeed(0),
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  ),
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+)
+
+// Should NOT trigger: the merged arity is unknown because of a spread argument
+export const unknownMergedArity = Effect.succeed(0).pipe(
+  ...([
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  ] as const)
+).pipe(bump)
+
+// Should still trigger for the safe inner merge when the outer merge exceeds the limit
+export const nestedWithinSnoozedChain = Effect.succeed(0).pipe(bump, bump)
+  .pipe(
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  )
 

--- a/testdata/tests/effect-v4/unnecessaryPipeChain.ts
+++ b/testdata/tests/effect-v4/unnecessaryPipeChain.ts
@@ -15,3 +15,64 @@ export const singlePipeable = Effect.succeed(1).pipe(Effect.map((x) => x + 2), E
 
 // Should NOT trigger: pipe with non-pipe subject
 export const nonPipeSubject = pipe(Effect.succeed(1), Effect.map((x) => x + 2))
+
+const bump = Effect.map((x: number) => x + 1)
+
+// Should trigger: merging reaches the 20-transformation .pipe() limit
+export const pipeableAtMergedLimit = Effect.succeed(0).pipe(
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump
+).pipe(bump)
+
+// Should NOT trigger: merging exceeds the 20-transformation .pipe() limit
+export const pipeableOverMergedLimit = Effect.succeed(0).pipe(
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+).pipe(bump)
+
+// Should trigger: merging reaches the 19-transformation pipe() limit
+export const standaloneAtMergedLimit = pipe(
+  pipe(
+    Effect.succeed(0),
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump
+  ),
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+)
+
+// Should NOT trigger: merging exceeds the 19-transformation pipe() limit
+export const standaloneOverMergedLimit = pipe(
+  pipe(
+    Effect.succeed(0),
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  ),
+  bump, bump, bump, bump, bump,
+  bump, bump, bump, bump, bump
+)
+
+// Should NOT trigger: the merged arity is unknown because of a spread argument
+export const unknownMergedArity = Effect.succeed(0).pipe(
+  ...([
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  ] as const)
+).pipe(bump)
+
+// Should still trigger for the safe inner merge when the outer merge exceeds the limit
+export const nestedWithinSnoozedChain = Effect.succeed(0)
+  .pipe(bump)
+  .pipe(bump)
+  .pipe(
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump,
+    bump, bump, bump, bump, bump
+  )


### PR DESCRIPTION
## Summary

- derive the merged pipe-call arity from the overloads visible on the original callee
- suppress unnecessaryPipeChain when flattening would exceed the supported arity or when spread arguments make it unknown
- retain diagnostics for safe nested merges and add Effect v4 diagnostic and quick-fix baselines

## Example

A valid chain with 20 transformations in the first .pipe call and another transformation in the chained call previously received a rewrite suggestion. Flattening that suggestion produced TS2554 because .pipe supports at most 20 transformations. The diagnostic is now snoozed, while chains that fit the available overloads are still reported.

## Validation

- pnpm setup-repo
- pnpm lint
- pnpm check
- pnpm test