### PR TITLE
Fix Nix flake for TypeScript monorepo

### DIFF
--- a/.changeset/fix-nix-typescript-source.md
+++ b/.changeset/fix-nix-typescript-source.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Build the Nix package from the migrated TypeScript monorepo source and update the pinned compiler revision correctly.

--- a/_tools/repoctl/src/flake.ts
+++ b/_tools/repoctl/src/flake.ts
@@ -2,10 +2,9 @@ import * as Data from "effect/Data"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
-import { runCommand, runCommandCapture, runCommandString } from "./process.ts"
+import { runCommand, runCommandCapture } from "./process.ts"
 import { readUpstream } from "./upstream.ts"
 
-const gitRevisionPattern = /^[0-9a-f]{40}$/
 const vendorHashPattern = /vendorHash = (?:("[^"]+")|lib\.fakeHash);/
 
 export class FlakeUpdateError extends Data.TaggedError("FlakeUpdateError")<{
@@ -23,21 +22,13 @@ const replaceRequired = (text: string, pattern: RegExp, replacement: string, nam
   return text.replace(pattern, replacement)
 }
 
-export const updateFlakeInputs = (flake: string, typescriptGoRevision: string, typescriptRevision: string) => {
-  let updated = replaceRequired(
+export const updateFlakeInputs = (flake: string, typescriptRevision: string) =>
+  replaceRequired(
     flake,
-    /github:microsoft\/typescript-go\/[0-9a-f]{40}\?submodules=1/,
-    `github:microsoft/typescript-go/${typescriptGoRevision}?submodules=1`,
-    "typescript-go-src"
-  )
-  updated = replaceRequired(
-    updated,
     /github:microsoft\/TypeScript\/[0-9a-f]{40}/,
     `github:microsoft/TypeScript/${typescriptRevision}`,
     "typescript-src"
   )
-  return updated
-}
 
 export const updateVendorHash = (flake: string, hash: string) =>
   replaceRequired(flake, vendorHashPattern, `vendorHash = ${JSON.stringify(hash)};`, "vendorHash")
@@ -67,17 +58,9 @@ export const updateFlake = Effect.fnUntraced(function*(repositoryRoot: string) {
   const path = yield* Path.Path
   const upstream = yield* readUpstream(repositoryRoot)
   const next = upstream.components.typescript[upstream.tags.typescript.next]!
-  const tree = yield* runCommandString("git", repositoryRoot, [
-    "-C",
-    "typescript-go",
-    "ls-tree",
-    next.gitHead,
-    "_submodules/TypeScript"
-  ])
-  const typescriptRevision = tree.trim().split(/\s+/)[2]
-  if (typescriptRevision === undefined || !gitRevisionPattern.test(typescriptRevision)) {
+  if (next.provider !== "typescript") {
     return yield* new FlakeUpdateError({
-      reason: `Cannot derive the TypeScript revision from TypeScript-Go ${next.gitHead}`
+      reason: `The Nix flake requires the TypeScript provider, but ${upstream.tags.typescript.next} uses ${next.provider}`
     })
   }
 
@@ -86,7 +69,7 @@ export const updateFlake = Effect.fnUntraced(function*(repositoryRoot: string) {
     Effect.mapError((error) => new FlakeUpdateError({ reason: error.message }))
   )
   const updatedInputs = yield* Effect.try({
-    try: () => updateFlakeInputs(flake, next.gitHead, typescriptRevision),
+    try: () => updateFlakeInputs(flake, next.gitHead),
     catch: (error) => error instanceof FlakeUpdateError
       ? error
       : new FlakeUpdateError({ reason: String(error) })

--- a/_tools/repoctl/test/flake.test.ts
+++ b/_tools/repoctl/test/flake.test.ts
@@ -3,17 +3,14 @@ import test from "node:test"
 import { invalidateVendorHash, updateFlakeInputs, updateVendorHash } from "../src/flake.ts"
 
 const oldRevision = "0123456789abcdef0123456789abcdef01234567"
-const newTsgoRevision = "1123456789abcdef0123456789abcdef01234567"
 const newTsRevision = "2123456789abcdef0123456789abcdef01234567"
 
 test("updates pinned flake inputs", () => {
   const flake = [
-    `url = "github:microsoft/typescript-go/${oldRevision}?submodules=1";`,
     `url = "github:microsoft/TypeScript/${oldRevision}";`
   ].join("\n")
 
-  assert.equal(updateFlakeInputs(flake, newTsgoRevision, newTsRevision), [
-    `url = "github:microsoft/typescript-go/${newTsgoRevision}?submodules=1";`,
+  assert.equal(updateFlakeInputs(flake, newTsRevision), [
     `url = "github:microsoft/TypeScript/${newTsRevision}";`
   ].join("\n"))
 })

--- a/flake.lock
+++ b/flake.lock
@@ -36,41 +36,23 @@
       "inputs": {
         "nixpkgs": "nixpkgs",
         "nixpkgsUnstable": "nixpkgsUnstable",
-        "typescript-go-src": "typescript-go-src",
         "typescript-src": "typescript-src"
-      }
-    },
-    "typescript-go-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1786751962,
-        "narHash": "sha256-Zl4yGFOqC33NcXaja0ep8F5mmsPkMallNcKjDbR6VQg=",
-        "owner": "microsoft",
-        "repo": "typescript-go",
-        "rev": "1bcfa18d79a3be41772223d5c05dfe4480e614ff",
-        "type": "github"
-      },
-      "original": {
-        "owner": "microsoft",
-        "repo": "typescript-go",
-        "rev": "1bcfa18d79a3be41772223d5c05dfe4480e614ff",
-        "type": "github"
       }
     },
     "typescript-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1786582947,
-        "narHash": "sha256-Mjcz54Ff6/L0lsxwEV4Z0BfG1AZENNwBhliXzvhnpjg=",
+        "lastModified": 1787343392,
+        "narHash": "sha256-FFDcGq9yZugvj8AwhazTnBIbdOCLnJwoHGHNKsznBRQ=",
         "owner": "microsoft",
         "repo": "TypeScript",
-        "rev": "5848bc5157b22ff7f4e3369f4645a514a433b15f",
+        "rev": "d6c4afddb2c55f4a9dea7b59293a99a8fdea1799",
         "type": "github"
       },
       "original": {
         "owner": "microsoft",
         "repo": "TypeScript",
-        "rev": "5848bc5157b22ff7f4e3369f4645a514a433b15f",
+        "rev": "d6c4afddb2c55f4a9dea7b59293a99a8fdea1799",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -5,13 +5,8 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     nixpkgsUnstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     /* Source of truth: the next profile in `_packages/tsgo/upstream.json`. */
-    typescript-go-src = {
-      url = "github:microsoft/typescript-go/1bcfa18d79a3be41772223d5c05dfe4480e614ff?submodules=1";
-      flake = false;
-    };
-    /* Derived from the selected TypeScript-Go revision and recorded in the manifest. */
     typescript-src = {
-      url = "github:microsoft/TypeScript/5848bc5157b22ff7f4e3369f4645a514a433b15f";
+      url = "github:microsoft/TypeScript/d6c4afddb2c55f4a9dea7b59293a99a8fdea1799";
       flake = false;
     };
   };
@@ -22,7 +17,6 @@
       nixpkgs,
       nixpkgsUnstable,
       typescript-src,
-      typescript-go-src,
     }:
     let
       lib = nixpkgs.lib;
@@ -36,7 +30,7 @@
        Go module vendor hash for buildGoModule (proxyVendor mode).
        proxyVendor is required because this project has deps with
        mixed-case module paths (Microsoft/go-winio vs microsoft/
-       typescript-go) — `go work vendor` produces different directory
+       TypeScript/tsc) — `go work vendor` produces different directory
        layouts on case-sensitive (Linux) vs case-insensitive (macOS)
        filesystems. The download cache uses `!` escaping for uppercase
        letters, making it deterministic across both.
@@ -44,7 +38,7 @@
        Refresh: pnpm exec repoctl flake update
        Manual:  set to lib.fakeHash, build, copy the reported hash.
       */
-      vendorHash = "sha256-wm9mss5lyJ2BGBjnD/hB1UxC9ZUohlNRL7AA7FtEEH4=";
+      vendorHash = "sha256-TJ7UC5SFk3kcWjKyEkAzOfvWwfK1C7BpA5WR/2dy3+Q=";
       forAllSystems =
         f: lib.genAttrs supportedSystems (system: f system (import nixpkgs { inherit system; }));
     in
@@ -54,7 +48,7 @@
         let
           root = toString ./.;
           pkgsUnstable = import nixpkgsUnstable { inherit system; };
-          patchEntries = builtins.readDir ./_patches/typescript-go;
+          patchEntries = builtins.readDir ./_patches/typescript;
           patchFiles = builtins.filter (
             name: patchEntries.${name} == "regular" && lib.hasSuffix ".patch" name
           ) (builtins.attrNames patchEntries);
@@ -78,25 +72,21 @@
                 "coverage"
                 "node_modules"
                 "tmp"
+                "typescript"
                 "typescript-go"
               ];
           };
-          patchedTypescriptGo = pkgs.applyPatches {
-            name = "patched-typescript-go-source";
-            src = typescript-go-src;
-            patches = builtins.map (name: ./. + "/_patches/typescript-go/${name}") sortedPatchFiles;
+          patchedTypeScript = pkgs.applyPatches {
+            name = "patched-typescript-source";
+            src = typescript-src;
+            patches = builtins.map (name: ./. + "/_patches/typescript/${name}") sortedPatchFiles;
           };
           src = pkgs.runCommandNoCC "effect-tsgo-source" { } ''
             mkdir source
             cp -R ${rootSrc}/. source/
             chmod -R u+w source
-            cp -R ${patchedTypescriptGo} source/typescript-go
-            chmod -R u+w source/typescript-go
-            mkdir -p source/typescript-go/_submodules
-            if [ -d source/typescript-go/_submodules/TypeScript ]; then
-              rmdir source/typescript-go/_submodules/TypeScript
-            fi
-            ln -s ${typescript-src} source/typescript-go/_submodules/TypeScript
+            cp -R ${patchedTypeScript} source/typescript
+            chmod -R u+w source/typescript
             cp -R source $out
             chmod -R a-w $out
           '';
@@ -121,12 +111,16 @@
               _saved_goflags="$GOFLAGS"
               export GOFLAGS="''${GOFLAGS//-trimpath/}"
               (
-                cd typescript-go/internal/diagnostics
+                cd typescript/tsc/internal/diagnostics
+                export GOWORK=off
                 go run generate.go -diagnostics ./diagnostics_generated.go -loc ./loc_generated.go -locdir ./loc
               )
               export GOFLAGS="$_saved_goflags"
             '';
-            subPackages = [ "typescript-go/cmd/tsgo" ];
+            subPackages = [ "typescript/tsc/cmd/tsc" ];
+            postInstall = ''
+              mv $out/bin/tsc $out/bin/tsgo
+            '';
             ldflags = [
               "-s"
               "-w"


### PR DESCRIPTION
## Summary

- build the Nix package from the migrated `microsoft/TypeScript` monorepo and apply `_patches/typescript`
- update the TypeScript input directly from the selected `next` component instead of querying the removed `typescript-go` checkout
- isolate diagnostics generation from the monorepo tools workspace, retain the `tsgo` binary name, and refresh the lock file and vendor hash
- add a patch changeset for `@effect/tsgo`

This fixes the `Update Nix flake` failure in https://github.com/Effect-TS/tsgo/actions/runs/32745710137/job/97490607996.

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm exec repoctl flake update`
- `nix build .#effect-tsgo --no-write-lock-file -L`
- `result/bin/tsgo --version`