### PR TITLE
refactor: use UnwrapIdentityForwarder in mapSomeToAsSome

### DIFF
--- a/.changeset/map-some-to-as-some-identity-forwarder.md
+++ b/.changeset/map-some-to-as-some-identity-forwarder.md
@@ -1,0 +1,16 @@
+---
+"@effect/tsgo": minor
+---
+
+Refactor the `mapSomeToAsSome` mapper detection onto the shared `UnwrapIdentityForwarder` helper. The diagnostic and quick fix now also recognize identity-forwarding function expressions:
+
+```ts
+// now triggers, alongside Effect.map(Option.some) and Effect.map((v) => Option.some(v))
+numberEffect.pipe(
+  Effect.map(function (value) {
+    return Option.some(value)
+  })
+)
+```
+
+Annotated or optional mapper parameters and explicit type arguments on the inner `Option.some` call still do not trigger, since they can intentionally widen the resulting `Option` type.

--- a/internal/rules/catch_die_to_or_die.go
+++ b/internal/rules/catch_die_to_or_die.go
@@ -67,7 +67,7 @@ func AnalyzeCatchDieToOrDie(tp *typeparser.TypeParser, _ *checker.Checker, sf *a
 			callee, args, isCurriedApplication := catchDieTransformationCall(transformation)
 			methodName, effectModule, ok := catchDieMethod(tp, callee)
 			if ok && len(args) == 1 {
-				handler, _ := tp.UnwrapIdentityForwarder(args[0])
+				handler, _, _ := tp.UnwrapIdentityForwarder(args[0])
 				if tp.IsNodeReferenceToEffectModuleApi(handler, "die") {
 					inputEffect := tp.StrictEffectType(inputType, callee)
 					if inputEffect != nil && inputEffect.E != nil && inputEffect.E.Flags()&checker.TypeFlagsNever == 0 {

--- a/internal/rules/map_some_to_as_some.go
+++ b/internal/rules/map_some_to_as_some.go
@@ -47,8 +47,8 @@ type MapSomeToAsSomeMatch struct {
 }
 
 // AnalyzeMapSomeToAsSome finds data-last and data-first Effect.map calls whose
-// mapper is Option.some or the exact eta-expansion value => Option.some(value).
-func AnalyzeMapSomeToAsSome(tp *typeparser.TypeParser, c *checker.Checker, sf *ast.SourceFile) []MapSomeToAsSomeMatch {
+// mapper is Option.some or an identity forwarder such as value => Option.some(value).
+func AnalyzeMapSomeToAsSome(tp *typeparser.TypeParser, _ *checker.Checker, sf *ast.SourceFile) []MapSomeToAsSomeMatch {
 	var matches []MapSomeToAsSomeMatch
 	seen := make(map[*ast.Node]struct{})
 	for _, flow := range tp.PipingFlows(sf, true) {
@@ -61,7 +61,7 @@ func AnalyzeMapSomeToAsSome(tp *typeparser.TypeParser, c *checker.Checker, sf *a
 
 			call := transformation.Node.AsCallExpression()
 			if call == nil || call.TypeArguments != nil && len(call.TypeArguments.Nodes) > 0 ||
-				!isOptionSomeMapper(tp, c, transformation.Args[0]) {
+				!isOptionSomeMapper(tp, transformation.Args[0]) {
 				continue
 			}
 			if _, ok := seen[transformation.Node]; ok {
@@ -91,47 +91,16 @@ func AnalyzeMapSomeToAsSome(tp *typeparser.TypeParser, c *checker.Checker, sf *a
 	return matches
 }
 
-func isOptionSomeMapper(tp *typeparser.TypeParser, c *checker.Checker, node *ast.Node) bool {
-	node = ast.SkipParentheses(node)
-	if node == nil {
+func isOptionSomeMapper(tp *typeparser.TypeParser, node *ast.Node) bool {
+	mapper, typeArguments, parameter := tp.UnwrapIdentityForwarder(node)
+	if typeArguments != nil && len(typeArguments.Nodes) > 0 {
 		return false
 	}
-	if tp.IsNodeReferenceToEffectOptionModuleApi(node, "some") {
-		return true
+	if parameter != nil {
+		parameterDeclaration := parameter.AsParameterDeclaration()
+		if parameterDeclaration == nil || parameterDeclaration.QuestionToken != nil || parameterDeclaration.Type != nil {
+			return false
+		}
 	}
-	lazy := typeparser.ParseLazyExpression(node, false)
-	if lazy == nil || lazy.Node.Kind != ast.KindArrowFunction || ast.GetCombinedModifierFlags(lazy.Node)&ast.ModifierFlagsAsync != 0 ||
-		len(lazy.Params) != 1 {
-		return false
-	}
-	parameter := lazy.Params[0]
-	if parameter == nil || parameter.Name() == nil || parameter.Name().Kind != ast.KindIdentifier {
-		return false
-	}
-	parameterDeclaration := parameter.AsParameterDeclaration()
-	if parameterDeclaration == nil || parameterDeclaration.DotDotDotToken != nil || parameterDeclaration.QuestionToken != nil ||
-		parameterDeclaration.Type != nil || parameterDeclaration.Initializer != nil {
-		return false
-	}
-
-	body := ast.SkipParentheses(lazy.Expression)
-	if body == nil || body.Kind != ast.KindCallExpression {
-		return false
-	}
-	someCall := body.AsCallExpression()
-	if someCall == nil || someCall.Expression == nil ||
-		someCall.TypeArguments != nil && len(someCall.TypeArguments.Nodes) > 0 ||
-		someCall.Arguments == nil || len(someCall.Arguments.Nodes) != 1 ||
-		!tp.IsNodeReferenceToEffectOptionModuleApi(someCall.Expression, "some") {
-		return false
-	}
-
-	argument := ast.SkipParentheses(someCall.Arguments.Nodes[0])
-	if argument == nil || argument.Kind != ast.KindIdentifier {
-		return false
-	}
-	parameterSymbol := tp.GetSymbolAtLocation(parameter.Name())
-	argumentSymbol := tp.GetSymbolAtLocation(argument)
-	return parameterSymbol != nil && argumentSymbol != nil &&
-		checker.Checker_getSymbolIfSameReference(c, parameterSymbol, argumentSymbol) != nil
+	return tp.IsNodeReferenceToEffectOptionModuleApi(mapper, "some")
 }

--- a/internal/typeparser/identity_forwarder.go
+++ b/internal/typeparser/identity_forwarder.go
@@ -6,65 +6,66 @@ import (
 )
 
 // UnwrapIdentityForwarder returns the callee of a one-argument function that
-// forwards its argument unchanged and any explicit type arguments on the
-// forwarded call. All other expressions are returned as-is with no type
-// arguments.
+// forwards its argument unchanged, any explicit type arguments on the
+// forwarded call, and the forwarder's parameter declaration so that callers
+// can apply stricter checks (e.g. reject annotated parameters). All other
+// expressions are returned as-is with no type arguments and no parameter.
 //
 // For example, both fn and value => fn(value) normalize to fn.
-func (tp *TypeParser) UnwrapIdentityForwarder(node *ast.Node) (target *ast.Node, typeArguments *ast.NodeList) {
+func (tp *TypeParser) UnwrapIdentityForwarder(node *ast.Node) (target *ast.Node, typeArguments *ast.NodeList, parameter *ast.Node) {
 	if node == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	node = ast.SkipParentheses(node)
 	if tp == nil || tp.checker == nil {
-		return node, nil
+		return node, nil, nil
 	}
 	if ast.GetCombinedModifierFlags(node)&ast.ModifierFlagsAsync != 0 {
-		return node, nil
+		return node, nil, nil
 	}
 	if node.Kind == ast.KindFunctionExpression {
 		function := node.AsFunctionExpression()
 		if function != nil && function.AsteriskToken != nil {
-			return node, nil
+			return node, nil, nil
 		}
 	}
 
 	lazy := ParseLazyExpression(node, false)
 	if lazy == nil || len(lazy.Params) != 1 || lazy.Expression == nil {
-		return node, nil
+		return node, nil, nil
 	}
 
 	parameterNode := lazy.Params[0]
 	if parameterNode == nil || parameterNode.Kind != ast.KindParameter {
-		return node, nil
+		return node, nil, nil
 	}
-	parameter := parameterNode.AsParameterDeclaration()
-	if parameter == nil || parameter.Name() == nil || parameter.Name().Kind != ast.KindIdentifier ||
-		parameter.DotDotDotToken != nil || parameter.Initializer != nil {
-		return node, nil
+	parameterDeclaration := parameterNode.AsParameterDeclaration()
+	if parameterDeclaration == nil || parameterDeclaration.Name() == nil || parameterDeclaration.Name().Kind != ast.KindIdentifier ||
+		parameterDeclaration.DotDotDotToken != nil || parameterDeclaration.Initializer != nil {
+		return node, nil, nil
 	}
 
 	expression := ast.SkipParentheses(lazy.Expression)
 	if expression == nil || expression.Kind != ast.KindCallExpression {
-		return node, nil
+		return node, nil, nil
 	}
 	call := expression.AsCallExpression()
 	if call == nil || call.Expression == nil || call.Arguments == nil || len(call.Arguments.Nodes) != 1 {
-		return node, nil
+		return node, nil, nil
 	}
 
 	argument := ast.SkipParentheses(call.Arguments.Nodes[0])
 	if argument == nil || argument.Kind != ast.KindIdentifier {
-		return node, nil
+		return node, nil, nil
 	}
 
-	parameterSymbol := tp.GetSymbolAtLocation(parameter.Name())
+	parameterSymbol := tp.GetSymbolAtLocation(parameterDeclaration.Name())
 	argumentSymbol := tp.GetSymbolAtLocation(argument)
 	if parameterSymbol == nil || argumentSymbol == nil ||
 		checker.Checker_getSymbolIfSameReference(tp.checker, parameterSymbol, argumentSymbol) == nil {
-		return node, nil
+		return node, nil, nil
 	}
 
-	return ast.SkipParentheses(call.Expression), call.TypeArguments
+	return ast.SkipParentheses(call.Expression), call.TypeArguments, parameterNode
 }

--- a/internal/typeparser/identity_forwarder_test.go
+++ b/internal/typeparser/identity_forwarder_test.go
@@ -64,7 +64,10 @@ const notACall = (value: unknown) => value
 	for _, test := range tests {
 		initializer := findVariableInitializer(t, sf, test.name)
 		original := ast.SkipParentheses(initializer)
-		got, typeArguments := tp.UnwrapIdentityForwarder(initializer)
+		got, typeArguments, parameter := tp.UnwrapIdentityForwarder(initializer)
+		if test.wantUnwrap != (parameter != nil) {
+			t.Fatalf("UnwrapIdentityForwarder(%s) returned parameter %v, want returned = %v", test.name, parameter, test.wantUnwrap)
+		}
 		gotTypeArguments := 0
 		if typeArguments != nil {
 			gotTypeArguments = len(typeArguments.Nodes)

--- a/testdata/baselines/reference/effect-v3/mapSomeToAsSome.errors.txt
+++ b/testdata/baselines/reference/effect-v3/mapSomeToAsSome.errors.txt
@@ -7,9 +7,10 @@ Effect version: 3.19.19
 /.src/mapSomeToAsSome.ts(29,3): suggestion TS377114: `Effect.asSome` expresses wrapping the success value in `Option.some` directly. effect(mapSomeToAsSome)
 /.src/mapSomeToAsSome.ts(34,3): suggestion TS377114: `Effect.asSome` expresses wrapping the success value in `Option.some` directly. effect(mapSomeToAsSome)
 /.src/mapSomeToAsSome.ts(79,3): suggestion TS377114: `Effect.asSome` expresses wrapping the success value in `Option.some` directly. effect(mapSomeToAsSome)
+/.src/mapSomeToAsSome.ts(86,3): suggestion TS377114: `Effect.asSome` expresses wrapping the success value in `Option.some` directly. effect(mapSomeToAsSome)
 
 
-==== /.src/mapSomeToAsSome.ts (6 errors) ====
+==== /.src/mapSomeToAsSome.ts (7 errors) ====
     import {
       Effect,
       Effect as Fx,
@@ -99,6 +100,15 @@ Effect version: 3.19.19
     // Should trigger: ParseLazyExpression normalizes a single-return block body
     export const shouldTriggerBlockBody = numberEffect.pipe(
       Effect.map((value) => {
+      ~~~~~~~~~~
+!!! suggestion TS377114: `Effect.asSome` expresses wrapping the success value in `Option.some` directly. effect(mapSomeToAsSome)
+        return Option.some(value)
+      })
+    )
+    
+    // Should trigger: function expressions forward the value unchanged too
+    export const shouldTriggerFunctionExpression = numberEffect.pipe(
+      Effect.map(function (value) {
       ~~~~~~~~~~
 !!! suggestion TS377114: `Effect.asSome` expresses wrapping the success value in `Option.some` directly. effect(mapSomeToAsSome)
         return Option.some(value)

--- a/testdata/baselines/reference/effect-v3/mapSomeToAsSome.flows.mapSomeToAsSome.mermaid
+++ b/testdata/baselines/reference/effect-v3/mapSomeToAsSome.flows.mapSomeToAsSome.mermaid
@@ -88,6 +88,13 @@ flowchart TB
   86[/"type: number<br/>node: value"/]
   87["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
   88[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
+  89[/"type: Effect#lt;number, never, never#gt;<br/>node: numberEffect"/]
+  90["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.map<br/>args: #91;function #40;value#41; #123;#92;n    return Option.some#40;value#41;#92;n  #125;#93;"]
+  91[/"type: #123; #lt;A, B#gt;#40;f: #40;a: A#41; =#gt; B#41;: #lt;E, R#gt;#40;self: Effect#lt;A, E, R#gt;#41; =#gt; Effect#lt;B, E, R#gt;; #lt;A, E, R, B#gt;#40;self: Effect#lt;A, E, R#gt;, f: #40;a: A#41; =#gt; B#41;: Effect#lt;B, E, R#gt;; #125;<br/>node: Effect.map"/]
+  92[["type: #40;value: number#41; =#gt; Option#lt;number#gt;<br/>node: function #40;value#41; #123;#92;n    return Option.some#40;value#41;#92;n  #125;"]]
+  93[/"type: number<br/>node: value"/]
+  94["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
+  95[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
   0 -->|"kind: pipe"| 1
   2 -->|"kind: transformCallee"| 1
   5 -->|"kind: transformCallee"| 4
@@ -162,3 +169,10 @@ flowchart TB
   87 -->|"kind: usedBy"| 85
   85 -->|"kind: transformArg"| 83
   82 -->|"kind: pipe"| 83
+  91 -->|"kind: transformCallee"| 90
+  93 -->|"kind: pipe"| 94
+  95 -->|"kind: transformCallee"| 94
+  94 -->|"kind: potentialReturn"| 92
+  94 -->|"kind: usedBy"| 92
+  92 -->|"kind: transformArg"| 90
+  89 -->|"kind: pipe"| 90

--- a/testdata/baselines/reference/effect-v3/mapSomeToAsSome.pipings.txt
+++ b/testdata/baselines/reference/effect-v3/mapSomeToAsSome.pipings.txt
@@ -1,4 +1,4 @@
-==== /.src/mapSomeToAsSome.ts (22 flows) ====
+==== /.src/mapSomeToAsSome.ts (24 flows) ====
 
 === Piping Flow ===
 Location: 11:44 - 11:62
@@ -316,6 +316,34 @@ Transformations (1):
 
 === Piping Flow ===
 Location: 80:11 - 80:30
+Node: Option.some(value)
+Node Kind: KindCallExpression
+
+Subject: value
+Subject Type: number
+
+Transformations (1):
+  [0] kind: call
+      callee: Option.some
+      args: (constant)
+      outType: Option<number>
+
+=== Piping Flow ===
+Location: 85:47 - 89:2
+Node: numberEffect.pipe(\n  Effect.map(function (value) {\n    return Option.some(value)\n  })\n)
+Node Kind: KindCallExpression
+
+Subject: numberEffect
+Subject Type: Effect<number, never, never>
+
+Transformations (1):
+  [0] kind: pipeable
+      callee: Effect.map
+      args: [function (value) {\n    return Option.some(value)\n  }]
+      outType: Effect<Option<number>, never, never>
+
+=== Piping Flow ===
+Location: 87:11 - 87:30
 Node: Option.some(value)
 Node Kind: KindCallExpression
 

--- a/testdata/baselines/reference/effect-v3/mapSomeToAsSome.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/mapSomeToAsSome.quickfixes.txt
@@ -30,6 +30,11 @@
   Fix 1: "Disable mapSomeToAsSome for entire file"
   Fix 2: "Replace with Effect.asSome"
 
+[D7] (86:3-86:13) TS377114: `Effect.asSome` expresses wrapping the success value in `Option.some` directly. effect(mapSomeToAsSome)
+  Fix 0: "Disable mapSomeToAsSome for this line"
+  Fix 1: "Disable mapSomeToAsSome for entire file"
+  Fix 2: "Replace with Effect.asSome"
+
 === Quick Fix Application Results ===
 
 === [D1] Fix 0: "Disable mapSomeToAsSome for this line" ===
@@ -120,6 +125,13 @@ export const shouldNotTriggerAnnotated = Effect.succeed(1 as const).pipe(
 // Should trigger: ParseLazyExpression normalizes a single-return block body
 export const shouldTriggerBlockBody = numberEffect.pipe(
   Effect.map((value) => {
+    return Option.some(value)
+  })
+)
+
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
+  Effect.map(function (value) {
     return Option.some(value)
   })
 )
@@ -217,6 +229,13 @@ export const shouldTriggerBlockBody = numberEffect.pipe(
   })
 )
 
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
+  Effect.map(function (value) {
+    return Option.some(value)
+  })
+)
+
 
 === [D3] Fix 0: "Disable mapSomeToAsSome for this line" ===
 skipped by default
@@ -306,6 +325,13 @@ export const shouldNotTriggerAnnotated = Effect.succeed(1 as const).pipe(
 // Should trigger: ParseLazyExpression normalizes a single-return block body
 export const shouldTriggerBlockBody = numberEffect.pipe(
   Effect.map((value) => {
+    return Option.some(value)
+  })
+)
+
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
+  Effect.map(function (value) {
     return Option.some(value)
   })
 )
@@ -403,6 +429,13 @@ export const shouldTriggerBlockBody = numberEffect.pipe(
   })
 )
 
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
+  Effect.map(function (value) {
+    return Option.some(value)
+  })
+)
+
 
 === [D5] Fix 0: "Disable mapSomeToAsSome for this line" ===
 skipped by default
@@ -496,6 +529,13 @@ export const shouldTriggerBlockBody = numberEffect.pipe(
   })
 )
 
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
+  Effect.map(function (value) {
+    return Option.some(value)
+  })
+)
+
 
 === [D6] Fix 0: "Disable mapSomeToAsSome for this line" ===
 skipped by default
@@ -584,6 +624,111 @@ export const shouldNotTriggerAnnotated = Effect.succeed(1 as const).pipe(
 
 // Should trigger: ParseLazyExpression normalizes a single-return block body
 export const shouldTriggerBlockBody = numberEffect.pipe(
+  Effect.asSome
+)
+
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
+  Effect.map(function (value) {
+    return Option.some(value)
+  })
+)
+
+
+=== [D7] Fix 0: "Disable mapSomeToAsSome for this line" ===
+skipped by default
+
+=== [D7] Fix 1: "Disable mapSomeToAsSome for entire file" ===
+skipped by default
+
+=== [D7] Fix 2: "Replace with Effect.asSome" ===
+
+--- file:///.src/mapSomeToAsSome.ts ---
+import {
+  Effect,
+  Effect as Fx,
+  Option,
+  Option as O,
+  Stream,
+  pipe
+} from "effect"
+import { some as optionSome } from "effect/Option"
+
+const numberEffect: Effect.Effect<number> = Effect.succeed(1)
+
+// Should trigger: point-free mapper in a pipeable flow
+export const shouldTriggerPointFree = numberEffect.pipe(
+  Effect.map(Option.some)
+)
+
+// Should trigger: exact eta-expansion
+export const shouldTriggerEtaExpanded = numberEffect.pipe(
+  Effect.map((value) => Option.some(value))
+)
+
+// Should trigger: data-first form
+export const shouldTriggerDataFirst = Effect.map(numberEffect, Option.some)
+
+// Should trigger: function pipe form and aliased modules
+export const shouldTriggerAliases = pipe(
+  numberEffect,
+  Fx.map(O.some)
+)
+
+// Should trigger: named Option.some import
+export const shouldTriggerNamedImport = numberEffect.pipe(
+  Effect.map(optionSome)
+)
+
+// Should NOT trigger: already using asSome
+export const shouldNotTriggerAsSome = numberEffect.pipe(Effect.asSome)
+
+// Should NOT trigger: Stream.map is a different API
+export const shouldNotTriggerStream = Stream.make(1).pipe(
+  Stream.map(Option.some)
+)
+
+// Should NOT trigger: Option.map is a different API
+export const shouldNotTriggerOption = Option.some(1).pipe(
+  Option.map(Option.some)
+)
+
+const localSome = <A>(value: A): Option.Option<A> => Option.some(value)
+
+// Should NOT trigger: mapper does not resolve to Effect's Option.some
+export const shouldNotTriggerLocalSome = numberEffect.pipe(
+  Effect.map(localSome)
+)
+
+// Should NOT trigger: argument is transformed
+export const shouldNotTriggerTransformed = numberEffect.pipe(
+  Effect.map((value) => Option.some(value + 1))
+)
+
+// Should NOT trigger: property access is not the untouched parameter
+export const shouldNotTriggerPropertyAccess = Effect.succeed({ value: 1 }).pipe(
+  Effect.map((input) => Option.some(input.value))
+)
+
+// Should NOT trigger: destructured parameter
+export const shouldNotTriggerDestructuring = Effect.succeed({ value: 1 }).pipe(
+  Effect.map(({ value }) => Option.some(value))
+)
+
+// Should NOT trigger: an annotation can intentionally widen the output type
+export const shouldNotTriggerAnnotated = Effect.succeed(1 as const).pipe(
+  Effect.map((value: number) => Option.some(value))
+)
+
+// Should trigger: ParseLazyExpression normalizes a single-return block body
+export const shouldTriggerBlockBody = numberEffect.pipe(
+  Effect.map((value) => {
+    return Option.some(value)
+  })
+)
+
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
   Effect.asSome
 )
 

--- a/testdata/baselines/reference/effect-v4/mapSomeToAsSome.errors.txt
+++ b/testdata/baselines/reference/effect-v4/mapSomeToAsSome.errors.txt
@@ -7,9 +7,10 @@ Effect version: 4.0.0
 /.src/mapSomeToAsSome.ts(29,3): suggestion TS377114: `Effect.asSome` expresses wrapping the success value in `Option.some` directly. effect(mapSomeToAsSome)
 /.src/mapSomeToAsSome.ts(34,3): suggestion TS377114: `Effect.asSome` expresses wrapping the success value in `Option.some` directly. effect(mapSomeToAsSome)
 /.src/mapSomeToAsSome.ts(79,3): suggestion TS377114: `Effect.asSome` expresses wrapping the success value in `Option.some` directly. effect(mapSomeToAsSome)
+/.src/mapSomeToAsSome.ts(86,3): suggestion TS377114: `Effect.asSome` expresses wrapping the success value in `Option.some` directly. effect(mapSomeToAsSome)
 
 
-==== /.src/mapSomeToAsSome.ts (6 errors) ====
+==== /.src/mapSomeToAsSome.ts (7 errors) ====
     import {
       Effect,
       Effect as Fx,
@@ -99,6 +100,15 @@ Effect version: 4.0.0
     // Should trigger: ParseLazyExpression normalizes a single-return block body
     export const shouldTriggerBlockBody = numberEffect.pipe(
       Effect.map((value) => {
+      ~~~~~~~~~~
+!!! suggestion TS377114: `Effect.asSome` expresses wrapping the success value in `Option.some` directly. effect(mapSomeToAsSome)
+        return Option.some(value)
+      })
+    )
+    
+    // Should trigger: function expressions forward the value unchanged too
+    export const shouldTriggerFunctionExpression = numberEffect.pipe(
+      Effect.map(function (value) {
       ~~~~~~~~~~
 !!! suggestion TS377114: `Effect.asSome` expresses wrapping the success value in `Option.some` directly. effect(mapSomeToAsSome)
         return Option.some(value)

--- a/testdata/baselines/reference/effect-v4/mapSomeToAsSome.flows.mapSomeToAsSome.mermaid
+++ b/testdata/baselines/reference/effect-v4/mapSomeToAsSome.flows.mapSomeToAsSome.mermaid
@@ -88,6 +88,13 @@ flowchart TB
   86[/"type: number<br/>node: value"/]
   87["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
   88[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
+  89[/"type: Effect#lt;number, never, never#gt;<br/>node: numberEffect"/]
+  90["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.map<br/>args: #91;function #40;value#41; #123;#92;n    return Option.some#40;value#41;#92;n  #125;#93;"]
+  91[/"type: #123; #lt;A, B#gt;#40;f: #40;a: A#41; =#gt; B#41;: #lt;E, R#gt;#40;self: Effect#lt;A, E, R#gt;#41; =#gt; Effect#lt;B, E, R#gt;; #lt;A, E, R, B#gt;#40;self: Effect#lt;A, E, R#gt;, f: #40;a: A#41; =#gt; B#41;: Effect#lt;B, E, R#gt;; #125;<br/>node: Effect.map"/]
+  92[["type: #40;value: number#41; =#gt; Option#lt;number#gt;<br/>node: function #40;value#41; #123;#92;n    return Option.some#40;value#41;#92;n  #125;"]]
+  93[/"type: number<br/>node: value"/]
+  94["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
+  95[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
   0 -->|"kind: pipe"| 1
   2 -->|"kind: transformCallee"| 1
   5 -->|"kind: transformCallee"| 4
@@ -162,3 +169,10 @@ flowchart TB
   87 -->|"kind: usedBy"| 85
   85 -->|"kind: transformArg"| 83
   82 -->|"kind: pipe"| 83
+  91 -->|"kind: transformCallee"| 90
+  93 -->|"kind: pipe"| 94
+  95 -->|"kind: transformCallee"| 94
+  94 -->|"kind: potentialReturn"| 92
+  94 -->|"kind: usedBy"| 92
+  92 -->|"kind: transformArg"| 90
+  89 -->|"kind: pipe"| 90

--- a/testdata/baselines/reference/effect-v4/mapSomeToAsSome.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/mapSomeToAsSome.pipings.txt
@@ -1,4 +1,4 @@
-==== /.src/mapSomeToAsSome.ts (22 flows) ====
+==== /.src/mapSomeToAsSome.ts (24 flows) ====
 
 === Piping Flow ===
 Location: 11:44 - 11:62
@@ -316,6 +316,34 @@ Transformations (1):
 
 === Piping Flow ===
 Location: 80:11 - 80:30
+Node: Option.some(value)
+Node Kind: KindCallExpression
+
+Subject: value
+Subject Type: number
+
+Transformations (1):
+  [0] kind: call
+      callee: Option.some
+      args: (constant)
+      outType: Option<number>
+
+=== Piping Flow ===
+Location: 85:47 - 89:2
+Node: numberEffect.pipe(\n  Effect.map(function (value) {\n    return Option.some(value)\n  })\n)
+Node Kind: KindCallExpression
+
+Subject: numberEffect
+Subject Type: Effect<number, never, never>
+
+Transformations (1):
+  [0] kind: pipeable
+      callee: Effect.map
+      args: [function (value) {\n    return Option.some(value)\n  }]
+      outType: Effect<Option<number>, never, never>
+
+=== Piping Flow ===
+Location: 87:11 - 87:30
 Node: Option.some(value)
 Node Kind: KindCallExpression
 

--- a/testdata/baselines/reference/effect-v4/mapSomeToAsSome.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/mapSomeToAsSome.quickfixes.txt
@@ -30,6 +30,11 @@
   Fix 1: "Disable mapSomeToAsSome for entire file"
   Fix 2: "Replace with Effect.asSome"
 
+[D7] (86:3-86:13) TS377114: `Effect.asSome` expresses wrapping the success value in `Option.some` directly. effect(mapSomeToAsSome)
+  Fix 0: "Disable mapSomeToAsSome for this line"
+  Fix 1: "Disable mapSomeToAsSome for entire file"
+  Fix 2: "Replace with Effect.asSome"
+
 === Quick Fix Application Results ===
 
 === [D1] Fix 0: "Disable mapSomeToAsSome for this line" ===
@@ -120,6 +125,13 @@ export const shouldNotTriggerAnnotated = Effect.succeed(1 as const).pipe(
 // Should trigger: ParseLazyExpression normalizes a single-return block body
 export const shouldTriggerBlockBody = numberEffect.pipe(
   Effect.map((value) => {
+    return Option.some(value)
+  })
+)
+
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
+  Effect.map(function (value) {
     return Option.some(value)
   })
 )
@@ -217,6 +229,13 @@ export const shouldTriggerBlockBody = numberEffect.pipe(
   })
 )
 
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
+  Effect.map(function (value) {
+    return Option.some(value)
+  })
+)
+
 
 === [D3] Fix 0: "Disable mapSomeToAsSome for this line" ===
 skipped by default
@@ -306,6 +325,13 @@ export const shouldNotTriggerAnnotated = Effect.succeed(1 as const).pipe(
 // Should trigger: ParseLazyExpression normalizes a single-return block body
 export const shouldTriggerBlockBody = numberEffect.pipe(
   Effect.map((value) => {
+    return Option.some(value)
+  })
+)
+
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
+  Effect.map(function (value) {
     return Option.some(value)
   })
 )
@@ -403,6 +429,13 @@ export const shouldTriggerBlockBody = numberEffect.pipe(
   })
 )
 
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
+  Effect.map(function (value) {
+    return Option.some(value)
+  })
+)
+
 
 === [D5] Fix 0: "Disable mapSomeToAsSome for this line" ===
 skipped by default
@@ -496,6 +529,13 @@ export const shouldTriggerBlockBody = numberEffect.pipe(
   })
 )
 
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
+  Effect.map(function (value) {
+    return Option.some(value)
+  })
+)
+
 
 === [D6] Fix 0: "Disable mapSomeToAsSome for this line" ===
 skipped by default
@@ -584,6 +624,111 @@ export const shouldNotTriggerAnnotated = Effect.succeed(1 as const).pipe(
 
 // Should trigger: ParseLazyExpression normalizes a single-return block body
 export const shouldTriggerBlockBody = numberEffect.pipe(
+  Effect.asSome
+)
+
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
+  Effect.map(function (value) {
+    return Option.some(value)
+  })
+)
+
+
+=== [D7] Fix 0: "Disable mapSomeToAsSome for this line" ===
+skipped by default
+
+=== [D7] Fix 1: "Disable mapSomeToAsSome for entire file" ===
+skipped by default
+
+=== [D7] Fix 2: "Replace with Effect.asSome" ===
+
+--- file:///.src/mapSomeToAsSome.ts ---
+import {
+  Effect,
+  Effect as Fx,
+  Option,
+  Option as O,
+  Stream,
+  pipe
+} from "effect"
+import { some as optionSome } from "effect/Option"
+
+const numberEffect: Effect.Effect<number> = Effect.succeed(1)
+
+// Should trigger: point-free mapper in a pipeable flow
+export const shouldTriggerPointFree = numberEffect.pipe(
+  Effect.map(Option.some)
+)
+
+// Should trigger: exact eta-expansion
+export const shouldTriggerEtaExpanded = numberEffect.pipe(
+  Effect.map((value) => Option.some(value))
+)
+
+// Should trigger: data-first form
+export const shouldTriggerDataFirst = Effect.map(numberEffect, Option.some)
+
+// Should trigger: function pipe form and aliased modules
+export const shouldTriggerAliases = pipe(
+  numberEffect,
+  Fx.map(O.some)
+)
+
+// Should trigger: named Option.some import
+export const shouldTriggerNamedImport = numberEffect.pipe(
+  Effect.map(optionSome)
+)
+
+// Should NOT trigger: already using asSome
+export const shouldNotTriggerAsSome = numberEffect.pipe(Effect.asSome)
+
+// Should NOT trigger: Stream.map is a different API
+export const shouldNotTriggerStream = Stream.make(1).pipe(
+  Stream.map(Option.some)
+)
+
+// Should NOT trigger: Option.map is a different API
+export const shouldNotTriggerOption = Option.some(1).pipe(
+  Option.map(Option.some)
+)
+
+const localSome = <A>(value: A): Option.Option<A> => Option.some(value)
+
+// Should NOT trigger: mapper does not resolve to Effect's Option.some
+export const shouldNotTriggerLocalSome = numberEffect.pipe(
+  Effect.map(localSome)
+)
+
+// Should NOT trigger: argument is transformed
+export const shouldNotTriggerTransformed = numberEffect.pipe(
+  Effect.map((value) => Option.some(value + 1))
+)
+
+// Should NOT trigger: property access is not the untouched parameter
+export const shouldNotTriggerPropertyAccess = Effect.succeed({ value: 1 }).pipe(
+  Effect.map((input) => Option.some(input.value))
+)
+
+// Should NOT trigger: destructured parameter
+export const shouldNotTriggerDestructuring = Effect.succeed({ value: 1 }).pipe(
+  Effect.map(({ value }) => Option.some(value))
+)
+
+// Should NOT trigger: an annotation can intentionally widen the output type
+export const shouldNotTriggerAnnotated = Effect.succeed(1 as const).pipe(
+  Effect.map((value: number) => Option.some(value))
+)
+
+// Should trigger: ParseLazyExpression normalizes a single-return block body
+export const shouldTriggerBlockBody = numberEffect.pipe(
+  Effect.map((value) => {
+    return Option.some(value)
+  })
+)
+
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
   Effect.asSome
 )
 

--- a/testdata/tests/effect-v3/mapSomeToAsSome.ts
+++ b/testdata/tests/effect-v3/mapSomeToAsSome.ts
@@ -80,3 +80,10 @@ export const shouldTriggerBlockBody = numberEffect.pipe(
     return Option.some(value)
   })
 )
+
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
+  Effect.map(function (value) {
+    return Option.some(value)
+  })
+)

--- a/testdata/tests/effect-v4/mapSomeToAsSome.ts
+++ b/testdata/tests/effect-v4/mapSomeToAsSome.ts
@@ -80,3 +80,10 @@ export const shouldTriggerBlockBody = numberEffect.pipe(
     return Option.some(value)
   })
 )
+
+// Should trigger: function expressions forward the value unchanged too
+export const shouldTriggerFunctionExpression = numberEffect.pipe(
+  Effect.map(function (value) {
+    return Option.some(value)
+  })
+)


### PR DESCRIPTION
## What changed

`isOptionSomeMapper` in `internal/rules/map_some_to_as_some.go` was a hand-rolled near-duplicate of the `UnwrapIdentityForwarder` helper introduced with the `catchDieToOrDie` diagnostic (#674). This PR replaces the ~44 lines of manual lambda matching with the shared helper, keeping the rule-specific strictness on top.

To support that, `TypeParser.UnwrapIdentityForwarder` now returns a third value: the forwarder's parameter declaration (`nil` when no unwrap happened). Callers that need stricter guards than the helper — like this rule — can inspect it without re-parsing the lambda. The existing `catchDieToOrDie` call site and the helper's unit test were adapted, and the test now asserts the parameter is returned exactly when an unwrap occurs.

## Behavioral change

The rule now also recognizes identity-forwarding **function expressions**, which the previous arrow-only guard excluded:

```ts
// previously missed, now triggers with the "Replace with Effect.asSome" quick fix:
export const example = numberEffect.pipe(
  Effect.map(function (value) {
    return Option.some(value)
  })
)
// fix result:
export const example = numberEffect.pipe(
  Effect.asSome
)
```

Both intentional negative cases are preserved, since they can change the resulting `Option` type:
- annotated or optional mapper parameters: `Effect.map((value: number) => Option.some(value))` (covered by the `shouldNotTriggerAnnotated` fixture)
- explicit type arguments on the inner call: `Effect.map((value) => Option.some<number>(value))`

## Testing

- New `shouldTriggerFunctionExpression` fixture case in both `effect-v3` and `effect-v4`, with regenerated diagnostics/quickfix/pipings/flows baselines verifying the diagnostic fires and the quick fix rewrites to `Effect.asSome`.
- `pnpm setup-repo`, `pnpm lint`, `pnpm check`, and the full `pnpm test` suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)