### PR TITLE
Fix supportedEffect declarations for genericEffectServices and schemaSyncInEffect

### DIFF
--- a/.changeset/fix-supported-effect-declarations.md
+++ b/.changeset/fix-supported-effect-declarations.md
@@ -1,0 +1,10 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix `supportedEffect` metadata for two rules whose declaration disagreed with their actual behavior:
+
+- `genericEffectServices` declared `["v3", "v4"]` but is gated to run only on Effect v3 projects. It now declares `["v3"]`, so v4 users no longer enable a rule that can never fire.
+- `schemaSyncInEffect` declared `["v3"]` but fully supports Effect v4 (suggesting `decodeEffect`/`encodeEffect` variants). It now declares `["v3", "v4"]`.
+
+`metadata.json` and the generated rule docs were regenerated accordingly. No diagnostic behavior changed.

--- a/_packages/tsgo/src/metadata.json
+++ b/_packages/tsgo/src/metadata.json
@@ -208,8 +208,7 @@
       "defaultSeverity": "warning",
       "fixable": false,
       "supportedEffect": [
-        "v3",
-        "v4"
+        "v3"
       ],
       "codes": [
         377043
@@ -869,7 +868,8 @@
       "defaultSeverity": "suggestion",
       "fixable": false,
       "supportedEffect": [
-        "v3"
+        "v3",
+        "v4"
       ],
       "codes": [
         377037

--- a/docs/rules/generic-effect-services.md
+++ b/docs/rules/generic-effect-services.md
@@ -9,7 +9,7 @@ Prevents services with type parameters that cannot be discriminated at runtime
 | Category | Correctness |
 | Default severity | `warning` |
 | Fixable | No |
-| Effect versions | v3, v4 |
+| Effect versions | v3 |
 | Diagnostic codes | `TS377043` |
 | Language Service name | `genericEffectServices` |
 | Oxlint name | `effecttsgo/generic-effect-services` |

--- a/docs/rules/schema-sync-in-effect.md
+++ b/docs/rules/schema-sync-in-effect.md
@@ -9,7 +9,7 @@ Suggests using Effect-based Schema methods instead of sync methods inside Effect
 | Category | Anti-pattern |
 | Default severity | `suggestion` |
 | Fixable | No |
-| Effect versions | v3 |
+| Effect versions | v3, v4 |
 | Diagnostic codes | `TS377037` |
 | Language Service name | `schemaSyncInEffect` |
 | Oxlint name | `effecttsgo/schema-sync-in-effect` |

--- a/internal/rules/generic_effect_services.go
+++ b/internal/rules/generic_effect_services.go
@@ -16,7 +16,7 @@ var GenericEffectServices = rule.Rule{
 	Group:           "correctness",
 	Description:     "Prevents services with type parameters that cannot be discriminated at runtime",
 	DefaultSeverity: etscore.SeverityWarning,
-	SupportedEffect: []string{"v3", "v4"},
+	SupportedEffect: []string{"v3"},
 	Codes:           []int32{tsdiag.Effect_Services_with_type_parameters_are_not_supported_because_they_cannot_be_properly_discriminated_at_runtime_which_may_cause_unexpected_behavior_effect_genericEffectServices.Code()},
 	Run: func(ctx *rule.Context) []*ast.Diagnostic {
 		// V3-only rule

--- a/internal/rules/schema_sync_in_effect.go
+++ b/internal/rules/schema_sync_in_effect.go
@@ -33,7 +33,7 @@ var SchemaSyncInEffect = rule.Rule{
 	Group:           "antipattern",
 	Description:     "Suggests using Effect-based Schema methods instead of sync methods inside Effect generators",
 	DefaultSeverity: etscore.SeveritySuggestion,
-	SupportedEffect: []string{"v3"},
+	SupportedEffect: []string{"v3", "v4"},
 	Codes:           []int32{tsdiag.X_0_is_used_inside_an_Effect_generator_Schema_1_preserves_the_typed_Effect_error_channel_for_this_operation_without_throwing_effect_schemaSyncInEffect.Code()},
 	Run: func(ctx *rule.Context) []*ast.Diagnostic {
 		version := ctx.TypeParser.SupportedEffectVersion()


### PR DESCRIPTION
Closes #678

## What changed

An audit of all 100 rule declarations in `internal/rules/` against their actual version behavior (explicit `SupportedEffectVersion()` gates, implicit checker-based gates, and the per-version fixtures/baselines under `testdata/`) found exactly two mismatches:

### `genericEffectServices`: `["v3", "v4"]` → `["v3"]`

The rule declared v4 support but hard-gates to v3, so on a v4 project it is accepted by configuration yet can never emit — exactly the silent no-op reported in #678:

```go
// V3-only rule
if ctx.TypeParser.SupportedEffectVersion() != typeparser.EffectMajorV3 {
    return nil
}
```

The declaration is now narrowed to match the gate (the issue's first suggested resolution). The v3-only gate is intentional: services with type parameters are a v3 discrimination hazard, and the fixture exists only under `testdata/tests/effect-v3/`.

### `schemaSyncInEffect`: `["v3"]` → `["v3", "v4"]`

The reverse mismatch, not covered by the issue: the rule declared v3 only, but it has no version gate and ships a dedicated v4 mapping, with passing v4 baselines:

```go
var syncToEffectMethodV4 = map[string]string{
    "decodeSync":        "decodeEffect",
    "decodeUnknownSync": "decodeUnknownEffect",
    ...
}
```

Under Effect 4.0.0 it emits e.g. ``suggestion TS377037: `Schema.decodeSync` is used inside an Effect generator. `Schema.decodeEffect` preserves the typed Effect error channel…`` (see `testdata/baselines/reference/effect-v4/schemaSyncInEffect.errors.txt`), so the declaration now includes v4.

## Everything else verified clean

The twelve explicitly gated rules match their declarations, and the ungated v4-only rules (`catchTagToCatchReason`, `catchChainToFirstSuccessOf`, `abortControllerInEffect`, `cryptoRandomUUID*`, `multipleCatchTag`, `schemaLiteralNonFinite`, `lazyEffect`, `preferUnsafeConstructor`, `schemaOpaqueInstanceMember`) are correctly declared — they gate implicitly through checker lookups of v4-only exports (e.g. `hasCatchReasonApi`) or recommend v4-only APIs.

## Notes

- `_packages/tsgo/src/metadata.json` and `docs/rules/*.md` are regenerated output (`UPDATE_METADATA_JSON=1` / `UPDATE_RULE_DOCS=1`); no diagnostic behavior changed.
- `pnpm lint`, `pnpm check`, and `pnpm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)