### PR TITLE
Add list-files diagnostics output

### DIFF
--- a/_packages/tsgo/src/cli/diagnostics.ts
+++ b/_packages/tsgo/src/cli/diagnostics.ts
@@ -11,6 +11,7 @@ export interface DiagnosticsRequest {
   readonly severity?: string
   readonly progress: boolean
   readonly lspconfig?: string
+  readonly listFiles: boolean
 }
 
 export interface DiagnosticsProcessResult {

--- a/_packages/tsgo/src/cli/index.ts
+++ b/_packages/tsgo/src/cli/index.ts
@@ -174,27 +174,35 @@ const diagnosticsCommand = Command.make("diagnostics", {
   lspconfig: Flag.string("lspconfig").pipe(
     Flag.optional,
     Flag.withDescription("An optional inline JSON lsp config that replaces the current project lsp config")
+  ),
+  listFiles: Flag.boolean("list-files").pipe(
+    Flag.withDefault(false),
+    Flag.withDescription(
+      "Also emit, per checked file, the detected and supported Effect major versions"
+    )
   )
 }).pipe(
   Command.withDescription("Gets the Effect language service diagnostics on the given files or project"),
-  Command.withHandler(({ file, format, lspconfig, progress, project, severity, strict }) => Effect.gen(function*() {
-    const fs = yield* FileSystem.FileSystem
-    const replacement = yield* resolveTypeScriptExecutable
-    yield* fs.chmod(replacement.path, 0o755).pipe(
-      Effect.mapError(() => new ChmodBinaryError({ targetPath: replacement.path }))
-    )
-    const result = runDiagnosticsBinary(replacement.path, {
-      cwd: process.cwd(),
-      file: Option.getOrUndefined(file),
-      project: Option.getOrUndefined(project),
-      format,
-      strict,
-      severity: Option.getOrUndefined(severity),
-      progress,
-      lspconfig: Option.getOrUndefined(lspconfig)
-    })
-    propagateDiagnosticsExit(result)
-  }))
+  Command.withHandler(({ file, format, listFiles, lspconfig, progress, project, severity, strict }) =>
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const replacement = yield* resolveTypeScriptExecutable
+      yield* fs.chmod(replacement.path, 0o755).pipe(
+        Effect.mapError(() => new ChmodBinaryError({ targetPath: replacement.path }))
+      )
+      const result = runDiagnosticsBinary(replacement.path, {
+        cwd: process.cwd(),
+        file: Option.getOrUndefined(file),
+        project: Option.getOrUndefined(project),
+        format,
+        strict,
+        severity: Option.getOrUndefined(severity),
+        progress,
+        lspconfig: Option.getOrUndefined(lspconfig),
+        listFiles
+      })
+      propagateDiagnosticsExit(result)
+    }))
 )
 
 const rootCommand = Command.make("tsgo").pipe(

--- a/etsdiagnostics/diagnostics.go
+++ b/etsdiagnostics/diagnostics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/effect-ts/tsgo/etscore"
 	"github.com/effect-ts/tsgo/internal/rule"
 	"github.com/effect-ts/tsgo/internal/rules"
+	"github.com/effect-ts/tsgo/internal/typeparser"
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/bundled"
 	"github.com/microsoft/TypeScript/tsc/shim/collections"
@@ -36,6 +37,7 @@ type request struct {
 	Severity  string  `json:"severity,omitempty"`
 	Progress  bool    `json:"progress"`
 	LSPConfig *string `json:"lspconfig,omitempty"`
+	ListFiles bool    `json:"listFiles,omitempty"`
 }
 
 type severity string
@@ -69,8 +71,15 @@ type summary struct {
 	Messages     int `json:"messages"`
 }
 
+type fileEffectVersion struct {
+	File            string `json:"file"`
+	DetectedEffect  string `json:"detectedEffect"`
+	SupportedEffect string `json:"supportedEffect"`
+}
+
 type jsonOutput struct {
 	Diagnostics []formattedDiagnostic `json:"diagnostics"`
+	Files       []fileEffectVersion   `json:"files,omitempty"`
 	Summary     summary               `json:"summary"`
 }
 
@@ -104,12 +113,12 @@ func Run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		return 1
 	}
 
-	diagnostics, resultSummary, err := collect(ctx, req, override, overrideProvided, stderr)
+	diagnostics, files, resultSummary, err := collect(ctx, req, override, overrideProvided, stderr)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
 	}
-	if err := writeOutput(stdout, req.Format, diagnostics, resultSummary); err != nil {
+	if err := writeOutput(stdout, req.Format, diagnostics, files, resultSummary); err != nil {
 		fmt.Fprintf(stderr, "unable to write diagnostics: %v\n", err)
 		return 2
 	}
@@ -135,7 +144,7 @@ func parseLSPConfig(value *string) (*etscore.EffectPluginOptions, bool, error) {
 	return etscore.ParseFromPlugins([]any{config}), true, nil
 }
 
-func collect(ctx context.Context, req request, override *etscore.EffectPluginOptions, overrideProvided bool, stderr io.Writer) ([]formattedDiagnostic, summary, error) {
+func collect(ctx context.Context, req request, override *etscore.EffectPluginOptions, overrideProvided bool, stderr io.Writer) ([]formattedDiagnostic, []fileEffectVersion, summary, error) {
 	fs := bundled.WrapFS(osvfs.FS())
 	session := project.NewSession(&project.SessionInit{
 		BackgroundCtx: ctx,
@@ -167,7 +176,7 @@ func collect(ctx context.Context, req request, override *etscore.EffectPluginOpt
 		openProjects := &collections.Set[string]{}
 		openProjects.Add(projectName)
 		if err := updateSession(ctx, session, &project.APISnapshotRequest{OpenProjects: openProjects}); err != nil {
-			return nil, summary{}, err
+			return nil, nil, summary{}, err
 		}
 
 		session.WithSnapshotLoadingProjectTree(ctx, nil, func(snapshot *project.Snapshot) {
@@ -188,18 +197,28 @@ func collect(ctx context.Context, req request, override *etscore.EffectPluginOpt
 		openFiles := &collections.Set[lsproto.DocumentUri]{}
 		openFiles.Add(uri)
 		if err := updateSession(ctx, session, &project.APISnapshotRequest{OpenFiles: openFiles}); err != nil {
-			return nil, summary{}, err
+			return nil, nil, summary{}, err
 		}
 		addTarget(fileName)
 	}
 
 	resultSummary := summary{TotalFiles: len(targets)}
 	if len(targets) == 0 {
-		return nil, resultSummary, fmt.Errorf("%s", noFilesMessage)
+		return nil, nil, resultSummary, fmt.Errorf("%s", noFilesMessage)
 	}
 
 	severityFilter := parseSeverityFilter(req.Severity)
 	results := make([]formattedDiagnostic, 0)
+	var files []fileEffectVersion
+	type versionRecord struct {
+		detected  string
+		supported string
+	}
+	var versionCache map[any]versionRecord
+	if req.ListFiles {
+		files = make([]fileEffectVersion, 0, len(targets))
+		versionCache = make(map[any]versionRecord)
+	}
 	ctx = core.WithCheckerLifetime(ctx, core.CheckerLifetimeDiagnostics)
 	if req.Progress {
 		fmt.Fprintf(stderr, "Starting diagnostics for %d files...\n", len(targets))
@@ -226,6 +245,25 @@ func collect(ctx context.Context, req request, override *etscore.EffectPluginOpt
 			}
 			if program.Options().Effect == nil {
 				continue
+			}
+
+			if req.ListFiles {
+				record, cached := versionCache[configuredProject]
+				if !cached {
+					c, done := program.GetTypeChecker(ctx)
+					tp := typeparser.NewTypeParser(program, c)
+					record = versionRecord{
+						detected:  tp.DetectEffectVersion().String(),
+						supported: tp.SupportedEffectVersion().String(),
+					}
+					done()
+					versionCache[configuredProject] = record
+				}
+				files = append(files, fileEffectVersion{
+					File:            fileName,
+					DetectedEffect:  record.detected,
+					SupportedEffect: record.supported,
+				})
 			}
 
 			for _, diagnostic := range program.GetSemanticDiagnostics(ctx, sourceFile) {
@@ -259,9 +297,9 @@ func collect(ctx context.Context, req request, override *etscore.EffectPluginOpt
 		fmt.Fprintln(stderr)
 	}
 	if collectErr != nil {
-		return nil, resultSummary, collectErr
+		return nil, nil, resultSummary, collectErr
 	}
-	return results, resultSummary, nil
+	return results, files, resultSummary, nil
 }
 
 func updateSession(ctx context.Context, session *project.Session, request *project.APISnapshotRequest) error {
@@ -339,12 +377,12 @@ func categoryToSeverity(category tsdiag.Category) severity {
 	}
 }
 
-func writeOutput(output io.Writer, format string, diagnostics []formattedDiagnostic, resultSummary summary) error {
+func writeOutput(output io.Writer, format string, diagnostics []formattedDiagnostic, files []fileEffectVersion, resultSummary summary) error {
 	switch format {
 	case "json":
 		encoder := json.NewEncoder(output)
 		encoder.SetIndent("", "  ")
-		return encoder.Encode(jsonOutput{Diagnostics: diagnostics, Summary: resultSummary})
+		return encoder.Encode(jsonOutput{Diagnostics: diagnostics, Files: files, Summary: resultSummary})
 	case "github-actions":
 		for _, diagnostic := range diagnostics {
 			command := string(diagnostic.Severity)
@@ -363,6 +401,12 @@ func writeOutput(output io.Writer, format string, diagnostics []formattedDiagnos
 	case "pretty":
 		for _, diagnostic := range diagnostics {
 			writePrettyDiagnostic(output, diagnostic)
+		}
+	}
+	if len(files) > 0 {
+		fmt.Fprintln(output, "Effect version per file:")
+		for _, file := range files {
+			fmt.Fprintf(output, "  %s: detected=%s, supported=%s\n", file.File, file.DetectedEffect, file.SupportedEffect)
 		}
 	}
 	_, err := fmt.Fprintf(output, "Checked %d files out of %d files. \n%d errors, %d warnings and %d messages.\n",

--- a/etsdiagnostics/diagnostics_test.go
+++ b/etsdiagnostics/diagnostics_test.go
@@ -55,7 +55,7 @@ func TestWriteJSONOutput(t *testing.T) {
 	}}
 	wantSummary := summary{FilesChecked: 1, TotalFiles: 1, Errors: 1}
 	var output bytes.Buffer
-	if err := writeOutput(&output, "json", diagnostics, wantSummary); err != nil {
+	if err := writeOutput(&output, "json", diagnostics, nil, wantSummary); err != nil {
 		t.Fatal(err)
 	}
 	for _, expected := range []string{
@@ -78,12 +78,27 @@ func TestWriteGitHubActionsOutput(t *testing.T) {
 		Severity: severityMessage, Name: "floatingEffect", Message: "first%\nsecond",
 	}}
 	var output bytes.Buffer
-	if err := writeOutput(&output, "github-actions", diagnostics, summary{FilesChecked: 1, TotalFiles: 1, Messages: 1}); err != nil {
+	if err := writeOutput(&output, "github-actions", diagnostics, nil, summary{FilesChecked: 1, TotalFiles: 1, Messages: 1}); err != nil {
 		t.Fatal(err)
 	}
 	want := "::notice file=/workspace/main.ts,line=2,col=3,endLine=2,endColumn=8,title=floatingEffect::first%25%0Asecond\n"
 	if !strings.HasPrefix(output.String(), want) {
 		t.Fatalf("unexpected output:\n%s", output.String())
+	}
+}
+
+func TestWriteFilesBlock(t *testing.T) {
+	t.Parallel()
+
+	files := []fileEffectVersion{
+		{File: "/workspace/main.ts", DetectedEffect: "unknown", SupportedEffect: "v3"},
+	}
+	var output bytes.Buffer
+	if err := writeOutput(&output, "text", nil, files, summary{TotalFiles: 1, FilesChecked: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output.String(), "/workspace/main.ts: detected=unknown, supported=v3") {
+		t.Fatalf("output missing per-file version block:\n%s", output.String())
 	}
 }
 
@@ -118,5 +133,46 @@ func TestRunProjectJSON(t *testing.T) {
 	}
 	if strings.Contains(diagnostic.Message, "effect(asyncFunction)") {
 		t.Fatalf("message includes redundant rule name: %q", diagnostic.Message)
+	}
+	if output.Files != nil {
+		t.Fatalf("expected no files list without listFiles: %#v", output.Files)
+	}
+}
+
+func TestRunProjectJSONListFiles(t *testing.T) {
+	t.Parallel()
+
+	cwd, err := filepath.Abs("testdata/native-diagnostics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := json.Marshal(request{
+		CWD: cwd, Project: "tsconfig.json", Format: "json", ListFiles: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if status := Run(context.Background(), []string{string(request)}, &stdout, &stderr); status != 1 {
+		t.Fatalf("unexpected status %d; stderr:\n%s", status, stderr.String())
+	}
+	var output jsonOutput
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, stdout.String())
+	}
+	if len(output.Files) == 0 {
+		t.Fatalf("expected at least one file entry:\n%s", stdout.String())
+	}
+	for _, entry := range output.Files {
+		if entry.File == "" {
+			t.Fatalf("empty file name in entry: %#v", entry)
+		}
+		if entry.SupportedEffect != "v3" && entry.SupportedEffect != "v4" {
+			t.Fatalf("unexpected supported version %q for %s", entry.SupportedEffect, entry.File)
+		}
+		if entry.DetectedEffect == "" {
+			t.Fatalf("empty detected version for %s", entry.File)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Add a `--list-files` diagnostics option.
- Report detected and supported Effect versions per checked file.
- Support text and JSON output formats with coverage tests.

## Testing

- Added Go tests for file-version output and JSON behavior.
- Added CLI wiring for the new diagnostics flag.

Closes #681 