### PR TITLE
Fix repoctl upstream matching when a commit exists in both provider repos

### DIFF
--- a/.changeset/prioritize-typescript-provider.md
+++ b/.changeset/prioritize-typescript-provider.md
@@ -1,0 +1,9 @@
+---
+"@effect/tsgo": patch
+---
+
+Fix `repoctl upstream update` failing when a TypeScript commit is reachable from both supported provider repositories.
+
+Previously, `resolveTypeScriptProvider` and `readRemoteTypeScriptGitlink` in `_tools/repoctl/src/upstream.ts` errored out with `TypeScript commit <sha> matched 2 supported repositories` whenever a single revision existed in both `microsoft/TypeScript` (the canonical upstream) and the legacy `microsoft/typescript-go` fork. This blocked the daily "Update Upstreams" workflow for revisions shared between the two.
+
+Both functions now prefer `microsoft/TypeScript` when it matches and fall back to `microsoft/typescript-go` otherwise. A "no supported repository matched" error is still raised when neither matches.

--- a/_tools/repoctl/src/upstream.ts
+++ b/_tools/repoctl/src/upstream.ts
@@ -303,12 +303,13 @@ export const resolveTypeScriptProvider = Effect.fnUntraced(function*(revision: s
   const matches = yield* Effect.filter(providers, (source) => commitExists(source.repositorySlug, revision), {
     concurrency: "unbounded"
   })
-  if (matches.length !== 1) {
+  if (matches.length === 0) {
     return yield* new UpstreamManifestError({
-      reason: `TypeScript commit ${revision} matched ${matches.length} supported repositories`
+      reason: `TypeScript commit ${revision} did not match any supported repository`
     })
   }
-  return matches[0]!.provider
+  const preferred = matches.find((source) => source.provider === "typescript") ?? matches[0]!
+  return preferred.provider
 })
 
 const fetchTypeScriptMetadata = Effect.fnUntraced(function*(repositoryRoot: string, spec: string) {
@@ -677,12 +678,13 @@ const readRemoteTypeScriptGitlink = Effect.fnUntraced(function*(repository: stri
       Effect.option
     ), { concurrency: "unbounded" })
   const matches = entries.flatMap((entry) => entry._tag === "Some" ? [entry.value] : [])
-  if (matches.length !== 1) {
+  if (matches.length === 0) {
     return yield* new UpstreamManifestError({
-      reason: `Unable to resolve a unique TypeScript gitlink at ${revision}`
+      reason: `Unable to resolve a TypeScript gitlink at ${revision}`
     })
   }
-  return matches[0]!
+  const preferred = matches.find((entry) => entry.source.provider === "typescript") ?? matches[0]!
+  return preferred
 })
 
 const fetchLatestOxlintSelection = Effect.fnUntraced(function*(repositoryRoot: string) {


### PR DESCRIPTION
## Summary
- The daily [Update Upstreams](https://github.com/Effect-TS/tsgo/actions/workflows/update-upstreams.yml) workflow failed on [run 33048138667](https://github.com/Effect-TS/tsgo/actions/runs/33048138667) with `TypeScript commit 5739027c9a7df24e27123f453a50c011b37717b6 matched 2 supported repositories`.
- `resolveTypeScriptProvider` and `readRemoteTypeScriptGitlink` in `_tools/repoctl/src/upstream.ts` required exactly one match across the two supported provider repos. Since a single revision can be reachable from both `microsoft/TypeScript` (the canonical upstream) and the legacy `microsoft/typescript-go` fork, the workflow blocked whenever that happened.
- Both functions now prefer `microsoft/TypeScript` when it matches and fall back to `microsoft/typescript-go` otherwise; a "no supported repository matched" error is still raised when neither hits.

### Example
Before, given a commit present in both repositories:

```
UpstreamManifestError: Unable to read _packages/tsgo/upstream.json:
  TypeScript commit 5739027c9a7df24e27123f453a50c011b37717b6 matched 2 supported repositories
```

After:

```
resolveTypeScriptProvider("5739027c9a7df24e27123f453a50c011b37717b6")
  // => "typescript" (microsoft/TypeScript wins over the legacy fork)
```

## Test plan
- [x] `pnpm lint` — 0 issues
- [x] `pnpm check` — clean
- [ ] After merge, manually re-run the `Update Upstreams` workflow and confirm it resolves the shared commit to the `typescript` provider instead of erroring.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>