### PR TITLE
ci: bound Go caches with a resolved cache identity

### DIFF
--- a/.changeset/bounded-go-build-caches.md
+++ b/.changeset/bounded-go-build-caches.md
@@ -1,0 +1,11 @@
+---
+"@effect/tsgo": patch
+---
+
+Bound CI Go caches with a resolved cache identity
+
+`repoctl upstream resolve` now emits a Go cache identity derived from `upstream.json`: the `typescript` component owns and saves its Go caches, `oxlint-tsgolint` restores the compiler objects already cached by the typescript jobs under its TypeScript dependency version (Go's build cache is content-addressed, so the shared compiler packages hit directly), and the Rust-based `oxlint` component skips Go caching entirely instead of saving a duplicate GOCACHE snapshot.
+
+The go-build cache key no longer includes the commit SHA, so a multi-GB cache entry is written once per dependency state instead of on every push to main, and non-materialized setups are restore-only. Previously each push saved ~15GB of duplicate GOCACHE snapshots, evicting every other cache in the repository (GitHub caps repository caches at 10GB) and forcing all validation jobs to run cold.
+
+The generated shim cache key now also hashes `_patches/typescript/**`, so patch changes for the migrated TypeScript compiler repository invalidate cached shims correctly.

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -108,39 +108,43 @@ runs:
         echo "build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
         echo "modules=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
+    # Go caches are keyed by the resolved go-cache identity (the TypeScript
+    # dependency of the component) so oxlint-tsgolint restores the compiler
+    # objects cached by the typescript jobs. Only materialized jobs whose
+    # component owns the cache (go-cache-save) persist it, and only on main;
+    # everything else is restore-only to keep the repository cache under the
+    # 10GB eviction limit.
     - name: Cache Go modules
-      if: github.ref == 'refs/heads/main'
+      if: inputs.materialize == 'true' && steps.upstream-component.outputs.go-cache-save == 'true' && github.ref == 'refs/heads/main'
       uses: actions/cache@v6
       with:
         path: ${{ steps.go-cache.outputs.modules }}/cache/download
-        key: go-modules-1.26-${{ steps.upstream-component.outputs.component }}-${{ steps.upstream-component.outputs.version }}-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}
+        key: go-modules-1.26-${{ steps.upstream-component.outputs.go-cache-component }}-${{ steps.upstream-component.outputs.go-cache-version }}-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}
 
     - name: Restore Go modules
-      if: github.ref != 'refs/heads/main'
+      if: steps.upstream-component.outputs.go-cache-component != '' && (inputs.materialize != 'true' || steps.upstream-component.outputs.go-cache-save != 'true' || github.ref != 'refs/heads/main')
       uses: actions/cache/restore@v6
       with:
         path: ${{ steps.go-cache.outputs.modules }}/cache/download
-        key: go-modules-1.26-${{ steps.upstream-component.outputs.component }}-${{ steps.upstream-component.outputs.version }}-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}
+        key: go-modules-1.26-${{ steps.upstream-component.outputs.go-cache-component }}-${{ steps.upstream-component.outputs.go-cache-version }}-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}
 
     - name: Cache Go build
-      if: runner.os == 'Linux' && github.ref == 'refs/heads/main'
+      if: runner.os == 'Linux' && inputs.materialize == 'true' && steps.upstream-component.outputs.go-cache-save == 'true' && github.ref == 'refs/heads/main'
       uses: actions/cache@v6
       with:
         path: ${{ steps.go-cache.outputs.build }}
-        key: go-build-${{ steps.upstream-component.outputs.component }}-${{ steps.upstream-component.outputs.version }}-Linux-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}-${{ github.sha }}
+        key: go-build-${{ steps.upstream-component.outputs.go-cache-component }}-${{ steps.upstream-component.outputs.go-cache-version }}-Linux-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}
         restore-keys: |
-          go-build-${{ steps.upstream-component.outputs.component }}-${{ steps.upstream-component.outputs.version }}-Linux-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}-
-          go-build-${{ steps.upstream-component.outputs.component }}-${{ steps.upstream-component.outputs.version }}-Linux-
+          go-build-${{ steps.upstream-component.outputs.go-cache-component }}-${{ steps.upstream-component.outputs.go-cache-version }}-Linux-
 
     - name: Restore Go build cache
-      if: runner.os == 'Linux' && github.ref != 'refs/heads/main'
+      if: runner.os == 'Linux' && steps.upstream-component.outputs.go-cache-component != '' && (inputs.materialize != 'true' || steps.upstream-component.outputs.go-cache-save != 'true' || github.ref != 'refs/heads/main')
       uses: actions/cache/restore@v6
       with:
         path: ${{ steps.go-cache.outputs.build }}
-        key: go-build-${{ steps.upstream-component.outputs.component }}-${{ steps.upstream-component.outputs.version }}-Linux-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}-${{ github.sha }}
+        key: go-build-${{ steps.upstream-component.outputs.go-cache-component }}-${{ steps.upstream-component.outputs.go-cache-version }}-Linux-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}
         restore-keys: |
-          go-build-${{ steps.upstream-component.outputs.component }}-${{ steps.upstream-component.outputs.version }}-Linux-${{ hashFiles('**/go.mod', '**/go.sum', '_packages/tsgo/upstream.json', '_patches/**/*.patch') }}-
-          go-build-${{ steps.upstream-component.outputs.component }}-${{ steps.upstream-component.outputs.version }}-Linux-
+          go-build-${{ steps.upstream-component.outputs.go-cache-component }}-${{ steps.upstream-component.outputs.go-cache-version }}-Linux-
 
     - name: Configure generated shim cache
       shell: bash
@@ -151,7 +155,7 @@ runs:
       uses: actions/cache@v6
       with:
         path: ${{ runner.temp }}/gen-shims-cache
-        key: generated-shims-v1-${{ steps.go.outputs.go-version }}-${{ steps.upstream-component.outputs.component }}-${{ steps.upstream-component.outputs.version }}-${{ hashFiles('_tools/gen_shims/**', '_tools/repoctl/src/**', '_packages/tsgo/upstream.json', '_patches/typescript-go/**', '_patches/tsgolint/**') }}
+        key: generated-shims-v1-${{ steps.go.outputs.go-version }}-${{ steps.upstream-component.outputs.component }}-${{ steps.upstream-component.outputs.version }}-${{ hashFiles('_tools/gen_shims/**', '_tools/repoctl/src/**', '_packages/tsgo/upstream.json', '_patches/typescript-go/**', '_patches/typescript/**', '_patches/tsgolint/**') }}
         enableCrossOsArchive: true
 
     - name: Restore generated shim cache
@@ -159,7 +163,7 @@ runs:
       uses: actions/cache/restore@v6
       with:
         path: ${{ runner.temp }}/gen-shims-cache
-        key: generated-shims-v1-${{ steps.go.outputs.go-version }}-${{ steps.upstream-component.outputs.component }}-${{ steps.upstream-component.outputs.version }}-${{ hashFiles('_tools/gen_shims/**', '_tools/repoctl/src/**', '_packages/tsgo/upstream.json', '_patches/typescript-go/**', '_patches/tsgolint/**') }}
+        key: generated-shims-v1-${{ steps.go.outputs.go-version }}-${{ steps.upstream-component.outputs.component }}-${{ steps.upstream-component.outputs.version }}-${{ hashFiles('_tools/gen_shims/**', '_tools/repoctl/src/**', '_packages/tsgo/upstream.json', '_patches/typescript-go/**', '_patches/typescript/**', '_patches/tsgolint/**') }}
         enableCrossOsArchive: true
 
     - name: Materialize upstream component

--- a/_tools/repoctl/src/upstreamResolve.ts
+++ b/_tools/repoctl/src/upstreamResolve.ts
@@ -36,7 +36,16 @@ export const resolveUpstreamInfo = Effect.fnUntraced(function*(
     ...(target === undefined ? {} : { target }),
     ...(component === "oxlint"
       ? { rustTarget: oxlintBuildTargets[target as keyof typeof oxlintBuildTargets].rustTarget }
-      : {})
+      : {
+        // Go builds are cached under the TypeScript dependency identity so that
+        // oxlint-tsgolint restores the compiler objects already cached by the
+        // typescript validation jobs; only typescript itself persists the cache.
+        goCache: {
+          component: "typescript" as const,
+          version: selected.typescript.version,
+          save: component === "typescript"
+        }
+      })
   }
 })
 
@@ -49,9 +58,11 @@ export const printUpstreamInfo = Effect.fnUntraced(function*(
   const info = yield* resolveUpstreamInfo(yield* readUpstream(repositoryRoot), component, version, target)
   yield* Console.log(JSON.stringify(info))
   if (process.env.GITHUB_OUTPUT !== undefined) {
+    const goCache = "goCache" in info ? info.goCache : undefined
     yield* Effect.tryPromise(() => appendFile(
       process.env.GITHUB_OUTPUT!,
-      `component=${info.component}\nversion=${info.version}\nrust-target=${"rustTarget" in info ? info.rustTarget : ""}\n`
+      `component=${info.component}\nversion=${info.version}\nrust-target=${"rustTarget" in info ? info.rustTarget : ""}\n` +
+        `go-cache-component=${goCache?.component ?? ""}\ngo-cache-version=${goCache?.version ?? ""}\ngo-cache-save=${goCache?.save === true}\n`
     ))
   }
   return info

--- a/_tools/repoctl/test/upstream.test.ts
+++ b/_tools/repoctl/test/upstream.test.ts
@@ -218,7 +218,13 @@ test("resolves platform build metadata for setup actions", async() => {
 
   assert.deepEqual(await Effect.runPromise(resolveUpstreamInfo(upstream, "typescript")), {
     component: "typescript",
-    version: "7.1.0"
+    version: "7.1.0",
+    goCache: { component: "typescript", version: "7.1.0", save: true }
+  })
+  assert.deepEqual(await Effect.runPromise(resolveUpstreamInfo(upstream, "oxlint-tsgolint", "7.0.1000")), {
+    component: "oxlint-tsgolint",
+    version: "7.0.1000",
+    goCache: { component: "typescript", version: "7.0.0", save: false }
   })
   assert.deepEqual(await Effect.runPromise(resolveUpstreamInfo(upstream, "oxlint", "1.1.0", "linux-x64")), {
     component: "oxlint",


### PR DESCRIPTION
## Problem

CI validation times increased noticeably after Aug 24. The `Validate typescript latest (7.0.2)` job went from ~650–720s (Aug 15–24) to ~910–925s (Aug 25–27), with the regression concentrated in the setup step (70s → 222s) plus slower Build/Test — every Go cache (build, modules, generated shims) was missing on every run, including the loosest `go-build-typescript-7.0.2-Linux-` restore key.

Root cause: the `validate-oxlint` jobs snapshot the same GOCACHE twice per run (once under the `oxlint-tsgolint` key, once under the `oxlint` key), under keys suffixed with the commit SHA, so every push to main saved fresh multi-GB entries. The snapshots also ratcheted — each run restored the previous cache via `restore-keys`, added new build artifacts, and re-saved the union — growing from ~1GB (Aug 24) to ~5.5GB (Aug 27) each. At ~15GB of new cache writes per push against GitHub's 10GB repository cache limit, every other cache was evicted within the hour, so all validation jobs ran cold.

## Changes

- `repoctl upstream resolve` now emits a Go cache identity (`go-cache-component` / `go-cache-version` / `go-cache-save`) derived from `upstream.json`:
  - `typescript` owns and saves its Go caches (unchanged behavior);
  - `oxlint-tsgolint` is restore-only under its TypeScript dependency identity (currently `typescript-7.0.2`). Go's build cache is content-addressed, so the shared compiler objects cached by the typescript validation jobs hit directly; only tsgolint's own packages rebuild in-job;
  - `oxlint` (Rust) skips Go caching entirely — its previous `go-build-oxlint-*` entries were duplicate snapshots of the GOCACHE left over from the tsgolint build in the same job.
- Dropped the `-${{ github.sha }}` suffix from the go-build key: a save now happens once per dependency state (`go.mod`/`go.sum`/`upstream.json`/patches) instead of on every push, which also stops the restore-and-resave ratchet.
- Saves additionally require `materialize == 'true'`, so the scheduled `update-upstreams` run (which resolves before bumping `upstream.json`) can't claim a state key with a stale or empty GOCACHE.
- The generated shim cache key now hashes `_patches/typescript/**` (added in #666 for the migrated TypeScript compiler repository but missing from the key), so patch-only changes there invalidate cached shims correctly.

Example of the resolved outputs for `oxlint-tsgolint`:

```
component=oxlint-tsgolint
version=7.0.2001
go-cache-component=typescript
go-cache-version=7.0.2
go-cache-save=false
```

## Validation

- `pnpm lint` — 0 issues, deadcode clean
- `pnpm check` — clean
- `pnpm test` — pass (125 tests)
- `test:repoctl` — 48/48, including a new case asserting the dependency-derived restore-only identity

The two bloated 5.47GB `go-build-oxlint-*` entries have already been deleted from the repository cache, so the pool restarts from a clean baseline once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
