### PR TITLE
feat(effectMapVoid): detect data-first Effect.map via piping flows

### DIFF
--- a/.changeset/effect-map-void-data-first.md
+++ b/.changeset/effect-map-void-data-first.md
@@ -1,0 +1,21 @@
+---
+"@effect/tsgo": minor
+---
+
+Detect the data-first form of `effectMapVoid` by driving detection off piping flows.
+
+`effectMapVoid` previously matched only the data-last / pipeable form of the pattern, so a data-first `Effect.map(self, () => {})` was missed. Detection now runs over the piping-flow transformations, which normalize the subject away, so both forms are reported uniformly and the quick fix rewrites each one correctly.
+
+For example, the data-first call:
+
+```ts
+Effect.map(Effect.succeed(1), () => {})
+```
+
+is now flagged and fixed to:
+
+```ts
+Effect.asVoid(Effect.succeed(1))
+```
+
+while the existing data-last form (`pipe(self, Effect.map(() => {}))`) continues to be fixed to a bare `Effect.asVoid`.

--- a/internal/fixables/effect_map_void.go
+++ b/internal/fixables/effect_map_void.go
@@ -2,12 +2,11 @@ package fixables
 
 import (
 	"github.com/effect-ts/tsgo/internal/fixable"
+	"github.com/effect-ts/tsgo/internal/rewriter"
 	"github.com/effect-ts/tsgo/internal/rules"
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	tsdiag "github.com/microsoft/TypeScript/tsc/shim/diagnostics"
 	"github.com/microsoft/TypeScript/tsc/shim/ls"
-	"github.com/effect-ts/tsgo/internal/rewriter"
-	"github.com/microsoft/TypeScript/tsc/shim/scanner"
 )
 
 var EffectMapVoidFix = fixable.Fixable{
@@ -19,32 +18,38 @@ var EffectMapVoidFix = fixable.Fixable{
 }
 
 func runEffectMapVoidFix(ctx *fixable.Context) []ls.CodeAction {
-
-	c := ctx.Checker
-
 	sf := ctx.SourceFile
 
-	matches := rules.AnalyzeEffectMapVoid(ctx.TypeParser, c, sf)
+	matches := rules.AnalyzeEffectMapVoid(ctx.TypeParser, ctx.Checker, sf)
 	for _, match := range matches {
 		diagRange := match.Location
 		if !diagRange.Intersects(ctx.Span) && !ctx.Span.ContainedBy(diagRange) {
 			continue
 		}
 
-		// Extract the Effect module name, preserving the import alias
-		effectModuleName := "Effect"
-		if match.EffectModuleNode != nil && match.EffectModuleNode.Kind == ast.KindIdentifier {
-			effectModuleName = scanner.GetTextOfNode(match.EffectModuleNode)
-		}
-
 		if action := ctx.NewFixAction(fixable.FixAction{
 			Description: "Replace with Effect.asVoid",
 			Run: func(tracker *rewriter.Tracker) {
-				// Build Effect.asVoid as a PropertyAccessExpression
-				effectModuleId := tracker.NewIdentifier(effectModuleName)
-				replacementNode := tracker.NewPropertyAccessExpression(effectModuleId, nil, tracker.NewIdentifier("asVoid"), ast.NodeFlagsNone)
-				ast.SetParentInChildren(replacementNode)
-				tracker.ReplaceNode(sf, match.CallNode, replacementNode, nil)
+				// Build Effect.asVoid, preserving the original module reference (and any alias).
+				asVoid := tracker.NewPropertyAccessExpression(
+					tracker.DeepCloneNode(match.EffectModuleNode),
+					nil,
+					tracker.NewIdentifier("asVoid"),
+					ast.NodeFlagsNone,
+				)
+				// Data-last/pipeable forms drop to a bare Effect.asVoid reference; the
+				// data-first form must keep its subject as Effect.asVoid(self).
+				var replacement = asVoid
+				if match.SubjectNode != nil {
+					replacement = tracker.NewCallExpression(
+						asVoid,
+						nil,
+						nil,
+						tracker.NewNodeList([]*ast.Node{tracker.DeepCloneNode(match.SubjectNode)}),
+						ast.NodeFlagsNone,
+					)
+				}
+				tracker.ReplaceNode(sf, match.CallNode, replacement, nil)
 			},
 		}); action != nil {
 			return []ls.CodeAction{*action}

--- a/internal/rules/effect_map_void.go
+++ b/internal/rules/effect_map_void.go
@@ -37,6 +37,7 @@ type EffectMapVoidMatch struct {
 	Location         core.TextRange  // The pre-computed error range for this match
 	CallNode         *ast.Node       // The Effect.map(...) call expression (replacement target)
 	EffectModuleNode *ast.Node       // The Effect module identifier (e.g., "Effect" in Effect.map)
+	SubjectNode      *ast.Node       // The data-first subject (e.g. self in Effect.map(self, () => {})); nil for data-last/pipeable forms
 }
 
 // isVoidCallback checks if a callback argument is a "void callback":
@@ -83,41 +84,52 @@ func isVoidCallback(node *ast.Node) bool {
 	return false
 }
 
-// AnalyzeEffectMapVoid finds all Effect.map calls with void callbacks
-// that can be replaced with Effect.asVoid.
+// AnalyzeEffectMapVoid finds data-last and data-first Effect.map calls with void
+// callbacks that can be replaced with Effect.asVoid. Driving detection off the
+// piping-flow transformations (rather than a raw AST walk) normalizes the subject
+// away, so both pipe(self, Effect.map(cb)) / self.pipe(Effect.map(cb)) and the
+// data-first Effect.map(self, cb) are matched uniformly.
 func AnalyzeEffectMapVoid(tp *typeparser.TypeParser, _ *checker.Checker, sf *ast.SourceFile) []EffectMapVoidMatch {
 	var matches []EffectMapVoidMatch
+	seen := make(map[*ast.Node]struct{})
 
-	var walk ast.Visitor
-	walk = func(n *ast.Node) bool {
-		if n == nil {
-			return false
-		}
-
-		if n.Kind == ast.KindCallExpression {
-			call := n.AsCallExpression()
-			if call.Expression != nil && call.Expression.Kind == ast.KindPropertyAccessExpression {
-				if tp.IsNodeReferenceToEffectModuleApi(call.Expression, "map") {
-					if call.Arguments != nil && len(call.Arguments.Nodes) >= 1 {
-						arg := call.Arguments.Nodes[0]
-						if isVoidCallback(arg) {
-							propAccess := call.Expression.AsPropertyAccessExpression()
-							matches = append(matches, EffectMapVoidMatch{
-								SourceFile:       sf,
-								Location:         scanner.GetErrorRangeForNode(sf, call.Expression),
-								CallNode:         n,
-								EffectModuleNode: propAccess.Expression,
-							})
-						}
-					}
-				}
+	for _, flow := range tp.PipingFlows(sf, true) {
+		for _, transformation := range flow.Transformations {
+			if len(transformation.Args) != 1 || transformation.Node == nil || transformation.Node.Kind != ast.KindCallExpression ||
+				transformation.Callee == nil || transformation.Callee.Kind != ast.KindPropertyAccessExpression ||
+				!tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "map") {
+				continue
 			}
-		}
+			if !isVoidCallback(transformation.Args[0]) {
+				continue
+			}
+			if _, ok := seen[transformation.Node]; ok {
+				continue
+			}
 
-		n.ForEachChild(walk)
-		return false
+			// For the data-first form the subject is a real argument that the
+			// quick-fix must preserve as Effect.asVoid(self); data-last/pipeable
+			// forms carry no subject argument.
+			var subject *ast.Node
+			if transformation.Kind == typeparser.TransformationKindDataFirst || transformation.Kind == typeparser.TransformationKindDataLast {
+				parsed := tp.DataFirstOrLastCall(transformation.Node)
+				if parsed == nil {
+					continue
+				}
+				subject = parsed.Subject
+			}
+
+			propAccess := transformation.Callee.AsPropertyAccessExpression()
+			seen[transformation.Node] = struct{}{}
+			matches = append(matches, EffectMapVoidMatch{
+				SourceFile:       sf,
+				Location:         scanner.GetErrorRangeForNode(sf, transformation.Callee),
+				CallNode:         transformation.Node,
+				EffectModuleNode: propAccess.Expression,
+				SubjectNode:      subject,
+			})
+		}
 	}
 
-	walk(sf.AsNode())
 	return matches
 }

--- a/testdata/baselines/reference/effect-v3/effectMapVoid.errors.txt
+++ b/testdata/baselines/reference/effect-v3/effectMapVoid.errors.txt
@@ -7,9 +7,11 @@ Effect version: 3.19.19
 /.src/effectMapVoid.ts(22,3): suggestion TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
 /.src/effectMapVoid.ts(27,3): suggestion TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
 /.src/effectMapVoid.ts(33,3): suggestion TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
+/.src/effectMapVoid.ts(57,49): suggestion TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
+/.src/effectMapVoid.ts(60,44): suggestion TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
 
 
-==== /.src/effectMapVoid.ts (6 errors) ====
+==== /.src/effectMapVoid.ts (8 errors) ====
     // @effect-v3
     import { Effect } from "effect"
     
@@ -76,4 +78,17 @@ Effect version: 3.19.19
     export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
       Effect.asVoid
     )
+    
+    // Should trigger: data-first Effect.map(self, () => {})
+    export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+                                                    ~~~~~~~~~~
+!!! suggestion TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
+    
+    // Should trigger: data-first Effect.map(self, () => void 0)
+    export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+                                               ~~~~~~~~~~
+!!! suggestion TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
+    
+    // Should NOT trigger: data-first Effect.map with a real transformation
+    export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
     

--- a/testdata/baselines/reference/effect-v3/effectMapVoid.flows.effectMapVoid.mermaid
+++ b/testdata/baselines/reference/effect-v3/effectMapVoid.flows.effectMapVoid.mermaid
@@ -65,6 +65,26 @@ flowchart TB
   63["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
   64[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
   65["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
+  66[/"type: 1<br/>node: 1"/]
+  67["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  68[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  69["type: Effect#lt;void, never, never#gt;<br/>callee: <br/>args: #91;#93;"]
+  70[/"type: #123; #lt;A, B#gt;#40;f: #40;a: A#41; =#gt; B#41;: #lt;E, R#gt;#40;self: Effect#lt;A, E, R#gt;#41; =#gt; Effect#lt;B, E, R#gt;; #lt;A, E, R, B#gt;#40;self: Effect#lt;A, E, R#gt;, f: #40;a: A#41; =#gt; B#41;: Effect#lt;B, E, R#gt;; #125;<br/>node: Effect.map"/]
+  71[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #123;#125;"]]
+  72[/"type: 1<br/>node: 1"/]
+  73["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  74[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  75["type: Effect#lt;undefined, never, never#gt;<br/>callee: <br/>args: #91;#93;"]
+  76[/"type: #123; #lt;A, B#gt;#40;f: #40;a: A#41; =#gt; B#41;: #lt;E, R#gt;#40;self: Effect#lt;A, E, R#gt;#41; =#gt; Effect#lt;B, E, R#gt;; #lt;A, E, R, B#gt;#40;self: Effect#lt;A, E, R#gt;, f: #40;a: A#41; =#gt; B#41;: Effect#lt;B, E, R#gt;; #125;<br/>node: Effect.map"/]
+  77[["type: #40;#41; =#gt; undefined<br/>node: #40;#41; =#gt; void 0"]]
+  78[/"type: undefined<br/>node: void 0"/]
+  79[/"type: 1<br/>node: 1"/]
+  80["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  81[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  82["type: Effect#lt;number, never, never#gt;<br/>callee: <br/>args: #91;#93;"]
+  83[/"type: #123; #lt;A, B#gt;#40;f: #40;a: A#41; =#gt; B#41;: #lt;E, R#gt;#40;self: Effect#lt;A, E, R#gt;#41; =#gt; Effect#lt;B, E, R#gt;; #lt;A, E, R, B#gt;#40;self: Effect#lt;A, E, R#gt;, f: #40;a: A#41; =#gt; B#41;: Effect#lt;B, E, R#gt;; #125;<br/>node: Effect.map"/]
+  84[["type: #40;n: number#41; =#gt; number<br/>node: #40;n#41; =#gt; n * 2"]]
+  85[/"type: number<br/>node: n * 2"/]
   0 -->|"kind: pipe"| 1
   2 -->|"kind: transformCallee"| 1
   4 -->|"kind: transformCallee"| 3
@@ -121,3 +141,20 @@ flowchart TB
   62 -->|"kind: pipe"| 63
   64 -->|"kind: transformCallee"| 63
   63 -->|"kind: pipe"| 65
+  66 -->|"kind: pipe"| 67
+  68 -->|"kind: transformCallee"| 67
+  67 -->|"kind: pipe"| 69
+  70 -->|"kind: transformCallee"| 66
+  71 -->|"kind: transformArg"| 66
+  72 -->|"kind: pipe"| 73
+  74 -->|"kind: transformCallee"| 73
+  73 -->|"kind: pipe"| 75
+  76 -->|"kind: transformCallee"| 72
+  78 -->|"kind: potentialReturn"| 77
+  77 -->|"kind: transformArg"| 72
+  79 -->|"kind: pipe"| 80
+  81 -->|"kind: transformCallee"| 80
+  80 -->|"kind: pipe"| 82
+  83 -->|"kind: transformCallee"| 79
+  85 -->|"kind: potentialReturn"| 84
+  84 -->|"kind: transformArg"| 79

--- a/testdata/baselines/reference/effect-v3/effectMapVoid.pipings.txt
+++ b/testdata/baselines/reference/effect-v3/effectMapVoid.pipings.txt
@@ -1,4 +1,4 @@
-==== /.src/effectMapVoid.ts (10 flows) ====
+==== /.src/effectMapVoid.ts (13 flows) ====
 
 === Piping Flow ===
 Location: 5:34 - 7:2
@@ -179,3 +179,57 @@ Transformations (2):
       callee: Effect.asVoid
       args: (constant)
       outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 57:48 - 57:88
+Node: Effect.map(Effect.succeed(1), () => {})
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (2):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+  [1] kind: dataFirst
+      callee: Effect.map
+      args: [() => {}]
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 60:43 - 60:87
+Node: Effect.map(Effect.succeed(1), () => void 0)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (2):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+  [1] kind: dataFirst
+      callee: Effect.map
+      args: [() => void 0]
+      outType: Effect<undefined, never, never>
+
+=== Piping Flow ===
+Location: 63:50 - 63:94
+Node: Effect.map(Effect.succeed(1), (n) => n * 2)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (2):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+  [1] kind: dataFirst
+      callee: Effect.map
+      args: [(n) => n * 2]
+      outType: Effect<number, never, never>

--- a/testdata/baselines/reference/effect-v3/effectMapVoid.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/effectMapVoid.quickfixes.txt
@@ -30,6 +30,16 @@
   Fix 1: "Disable effectMapVoid for entire file"
   Fix 2: "Replace with Effect.asVoid"
 
+[D7] (57:49-57:59) TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
+  Fix 0: "Disable effectMapVoid for this line"
+  Fix 1: "Disable effectMapVoid for entire file"
+  Fix 2: "Replace with Effect.asVoid"
+
+[D8] (60:44-60:54) TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
+  Fix 0: "Disable effectMapVoid for this line"
+  Fix 1: "Disable effectMapVoid for entire file"
+  Fix 2: "Replace with Effect.asVoid"
+
 === Quick Fix Application Results ===
 
 === [D1] Fix 0: "Disable effectMapVoid for this line" ===
@@ -96,6 +106,15 @@ export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
   Effect.asVoid
 )
 
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
+
 
 === [D2] Fix 0: "Disable effectMapVoid for this line" ===
 skipped by default
@@ -160,6 +179,15 @@ export const shouldNotTriggerString = Effect.succeed(1).pipe(
 export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
   Effect.asVoid
 )
+
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
 
 
 === [D3] Fix 0: "Disable effectMapVoid for this line" ===
@@ -226,6 +254,15 @@ export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
   Effect.asVoid
 )
 
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
+
 
 === [D4] Fix 0: "Disable effectMapVoid for this line" ===
 skipped by default
@@ -290,6 +327,15 @@ export const shouldNotTriggerString = Effect.succeed(1).pipe(
 export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
   Effect.asVoid
 )
+
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
 
 
 === [D5] Fix 0: "Disable effectMapVoid for this line" ===
@@ -356,6 +402,15 @@ export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
   Effect.asVoid
 )
 
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
+
 
 === [D6] Fix 0: "Disable effectMapVoid for this line" ===
 skipped by default
@@ -420,4 +475,161 @@ export const shouldNotTriggerString = Effect.succeed(1).pipe(
 export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
   Effect.asVoid
 )
+
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
+
+
+=== [D7] Fix 0: "Disable effectMapVoid for this line" ===
+skipped by default
+
+=== [D7] Fix 1: "Disable effectMapVoid for entire file" ===
+skipped by default
+
+=== [D7] Fix 2: "Replace with Effect.asVoid" ===
+
+--- file:///.src/effectMapVoid.ts ---
+// @effect-v3
+import { Effect } from "effect"
+
+// Should trigger: Effect.map(() => void 0)
+export const shouldTriggerVoid0 = Effect.succeed(1).pipe(
+  Effect.map(() => void 0)
+)
+
+// Should trigger: Effect.map(() => undefined)
+export const shouldTriggerUndefined = Effect.succeed(1).pipe(
+  Effect.map(() => undefined)
+)
+
+// Should trigger: Effect.map(() => {})
+export const shouldTriggerEmptyBlock = Effect.succeed(1).pipe(
+  Effect.map(() => {})
+)
+
+// Should trigger: Effect.map(() => (undefined)) - parenthesized
+export const shouldTriggerParenthesizedUndefined = Effect.succeed(1).pipe(
+  // eslint-disable-next-line @effect/dprint
+  Effect.map(() => (undefined))
+)
+
+// Should trigger: Effect.map(() => (void 0)) - parenthesized
+export const shouldTriggerParenthesizedVoid0 = Effect.succeed(1).pipe(
+  Effect.map(() => (void 0))
+)
+
+// Should trigger: Effect.map(() => ((undefined))) - double parenthesized
+export const shouldTriggerDoubleParenthesizedUndefined = Effect.succeed(1).pipe(
+  // eslint-disable-next-line @effect/dprint
+  Effect.map(() => ((undefined)))
+)
+
+// Should NOT trigger: Effect.map with actual transformation
+export const shouldNotTriggerTransform = Effect.succeed(1).pipe(
+  Effect.map((n) => n * 2)
+)
+
+// Should NOT trigger: Effect.map with non-void return
+export const shouldNotTriggerNonVoid = Effect.succeed(1).pipe(
+  Effect.map(() => 42)
+)
+
+// Should NOT trigger: Effect.map with string return
+export const shouldNotTriggerString = Effect.succeed(1).pipe(
+  Effect.map(() => "hello")
+)
+
+// Should NOT trigger: already using asVoid
+export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
+  Effect.asVoid
+)
+
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.asVoid(Effect.succeed(1))
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
+
+
+=== [D8] Fix 0: "Disable effectMapVoid for this line" ===
+skipped by default
+
+=== [D8] Fix 1: "Disable effectMapVoid for entire file" ===
+skipped by default
+
+=== [D8] Fix 2: "Replace with Effect.asVoid" ===
+
+--- file:///.src/effectMapVoid.ts ---
+// @effect-v3
+import { Effect } from "effect"
+
+// Should trigger: Effect.map(() => void 0)
+export const shouldTriggerVoid0 = Effect.succeed(1).pipe(
+  Effect.map(() => void 0)
+)
+
+// Should trigger: Effect.map(() => undefined)
+export const shouldTriggerUndefined = Effect.succeed(1).pipe(
+  Effect.map(() => undefined)
+)
+
+// Should trigger: Effect.map(() => {})
+export const shouldTriggerEmptyBlock = Effect.succeed(1).pipe(
+  Effect.map(() => {})
+)
+
+// Should trigger: Effect.map(() => (undefined)) - parenthesized
+export const shouldTriggerParenthesizedUndefined = Effect.succeed(1).pipe(
+  // eslint-disable-next-line @effect/dprint
+  Effect.map(() => (undefined))
+)
+
+// Should trigger: Effect.map(() => (void 0)) - parenthesized
+export const shouldTriggerParenthesizedVoid0 = Effect.succeed(1).pipe(
+  Effect.map(() => (void 0))
+)
+
+// Should trigger: Effect.map(() => ((undefined))) - double parenthesized
+export const shouldTriggerDoubleParenthesizedUndefined = Effect.succeed(1).pipe(
+  // eslint-disable-next-line @effect/dprint
+  Effect.map(() => ((undefined)))
+)
+
+// Should NOT trigger: Effect.map with actual transformation
+export const shouldNotTriggerTransform = Effect.succeed(1).pipe(
+  Effect.map((n) => n * 2)
+)
+
+// Should NOT trigger: Effect.map with non-void return
+export const shouldNotTriggerNonVoid = Effect.succeed(1).pipe(
+  Effect.map(() => 42)
+)
+
+// Should NOT trigger: Effect.map with string return
+export const shouldNotTriggerString = Effect.succeed(1).pipe(
+  Effect.map(() => "hello")
+)
+
+// Should NOT trigger: already using asVoid
+export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
+  Effect.asVoid
+)
+
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.asVoid(Effect.succeed(1))
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
 

--- a/testdata/baselines/reference/effect-v4/effectMapVoid.errors.txt
+++ b/testdata/baselines/reference/effect-v4/effectMapVoid.errors.txt
@@ -7,9 +7,11 @@ Effect version: 4.0.0
 /.src/effectMapVoid.ts(20,3): suggestion TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
 /.src/effectMapVoid.ts(25,3): suggestion TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
 /.src/effectMapVoid.ts(30,3): suggestion TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
+/.src/effectMapVoid.ts(54,49): suggestion TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
+/.src/effectMapVoid.ts(57,44): suggestion TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
 
 
-==== /.src/effectMapVoid.ts (6 errors) ====
+==== /.src/effectMapVoid.ts (8 errors) ====
     import { Effect } from "effect"
     
     // Should trigger: Effect.map(() => void 0)
@@ -73,4 +75,17 @@ Effect version: 4.0.0
     export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
       Effect.asVoid
     )
+    
+    // Should trigger: data-first Effect.map(self, () => {})
+    export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+                                                    ~~~~~~~~~~
+!!! suggestion TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
+    
+    // Should trigger: data-first Effect.map(self, () => void 0)
+    export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+                                               ~~~~~~~~~~
+!!! suggestion TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
+    
+    // Should NOT trigger: data-first Effect.map with a real transformation
+    export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
     

--- a/testdata/baselines/reference/effect-v4/effectMapVoid.flows.effectMapVoid.mermaid
+++ b/testdata/baselines/reference/effect-v4/effectMapVoid.flows.effectMapVoid.mermaid
@@ -65,6 +65,26 @@ flowchart TB
   63["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
   64[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
   65["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
+  66[/"type: 1<br/>node: 1"/]
+  67["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  68[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  69["type: Effect#lt;void, never, never#gt;<br/>callee: <br/>args: #91;#93;"]
+  70[/"type: #123; #lt;A, B#gt;#40;f: #40;a: A#41; =#gt; B#41;: #lt;E, R#gt;#40;self: Effect#lt;A, E, R#gt;#41; =#gt; Effect#lt;B, E, R#gt;; #lt;A, E, R, B#gt;#40;self: Effect#lt;A, E, R#gt;, f: #40;a: A#41; =#gt; B#41;: Effect#lt;B, E, R#gt;; #125;<br/>node: Effect.map"/]
+  71[["type: #40;#41; =#gt; void<br/>node: #40;#41; =#gt; #123;#125;"]]
+  72[/"type: 1<br/>node: 1"/]
+  73["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  74[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  75["type: Effect#lt;undefined, never, never#gt;<br/>callee: <br/>args: #91;#93;"]
+  76[/"type: #123; #lt;A, B#gt;#40;f: #40;a: A#41; =#gt; B#41;: #lt;E, R#gt;#40;self: Effect#lt;A, E, R#gt;#41; =#gt; Effect#lt;B, E, R#gt;; #lt;A, E, R, B#gt;#40;self: Effect#lt;A, E, R#gt;, f: #40;a: A#41; =#gt; B#41;: Effect#lt;B, E, R#gt;; #125;<br/>node: Effect.map"/]
+  77[["type: #40;#41; =#gt; undefined<br/>node: #40;#41; =#gt; void 0"]]
+  78[/"type: undefined<br/>node: void 0"/]
+  79[/"type: 1<br/>node: 1"/]
+  80["type: Effect#lt;number, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  81[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  82["type: Effect#lt;number, never, never#gt;<br/>callee: <br/>args: #91;#93;"]
+  83[/"type: #123; #lt;A, B#gt;#40;f: #40;a: A#41; =#gt; B#41;: #lt;E, R#gt;#40;self: Effect#lt;A, E, R#gt;#41; =#gt; Effect#lt;B, E, R#gt;; #lt;A, E, R, B#gt;#40;self: Effect#lt;A, E, R#gt;, f: #40;a: A#41; =#gt; B#41;: Effect#lt;B, E, R#gt;; #125;<br/>node: Effect.map"/]
+  84[["type: #40;n: number#41; =#gt; number<br/>node: #40;n#41; =#gt; n * 2"]]
+  85[/"type: number<br/>node: n * 2"/]
   0 -->|"kind: pipe"| 1
   2 -->|"kind: transformCallee"| 1
   4 -->|"kind: transformCallee"| 3
@@ -121,3 +141,20 @@ flowchart TB
   62 -->|"kind: pipe"| 63
   64 -->|"kind: transformCallee"| 63
   63 -->|"kind: pipe"| 65
+  66 -->|"kind: pipe"| 67
+  68 -->|"kind: transformCallee"| 67
+  67 -->|"kind: pipe"| 69
+  70 -->|"kind: transformCallee"| 66
+  71 -->|"kind: transformArg"| 66
+  72 -->|"kind: pipe"| 73
+  74 -->|"kind: transformCallee"| 73
+  73 -->|"kind: pipe"| 75
+  76 -->|"kind: transformCallee"| 72
+  78 -->|"kind: potentialReturn"| 77
+  77 -->|"kind: transformArg"| 72
+  79 -->|"kind: pipe"| 80
+  81 -->|"kind: transformCallee"| 80
+  80 -->|"kind: pipe"| 82
+  83 -->|"kind: transformCallee"| 79
+  85 -->|"kind: potentialReturn"| 84
+  84 -->|"kind: transformArg"| 79

--- a/testdata/baselines/reference/effect-v4/effectMapVoid.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/effectMapVoid.pipings.txt
@@ -1,4 +1,4 @@
-==== /.src/effectMapVoid.ts (10 flows) ====
+==== /.src/effectMapVoid.ts (13 flows) ====
 
 === Piping Flow ===
 Location: 4:34 - 6:2
@@ -179,3 +179,57 @@ Transformations (2):
       callee: Effect.asVoid
       args: (constant)
       outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 54:48 - 54:88
+Node: Effect.map(Effect.succeed(1), () => {})
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (2):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+  [1] kind: dataFirst
+      callee: Effect.map
+      args: [() => {}]
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 57:43 - 57:87
+Node: Effect.map(Effect.succeed(1), () => void 0)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (2):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+  [1] kind: dataFirst
+      callee: Effect.map
+      args: [() => void 0]
+      outType: Effect<undefined, never, never>
+
+=== Piping Flow ===
+Location: 60:50 - 60:94
+Node: Effect.map(Effect.succeed(1), (n) => n * 2)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (2):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+  [1] kind: dataFirst
+      callee: Effect.map
+      args: [(n) => n * 2]
+      outType: Effect<number, never, never>

--- a/testdata/baselines/reference/effect-v4/effectMapVoid.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/effectMapVoid.quickfixes.txt
@@ -30,6 +30,16 @@
   Fix 1: "Disable effectMapVoid for entire file"
   Fix 2: "Replace with Effect.asVoid"
 
+[D7] (54:49-54:59) TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
+  Fix 0: "Disable effectMapVoid for this line"
+  Fix 1: "Disable effectMapVoid for entire file"
+  Fix 2: "Replace with Effect.asVoid"
+
+[D8] (57:44-57:54) TS377018: This expression discards the success value through mapping. `Effect.asVoid` represents that form directly. effect(effectMapVoid)
+  Fix 0: "Disable effectMapVoid for this line"
+  Fix 1: "Disable effectMapVoid for entire file"
+  Fix 2: "Replace with Effect.asVoid"
+
 === Quick Fix Application Results ===
 
 === [D1] Fix 0: "Disable effectMapVoid for this line" ===
@@ -93,6 +103,15 @@ export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
   Effect.asVoid
 )
 
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
+
 
 === [D2] Fix 0: "Disable effectMapVoid for this line" ===
 skipped by default
@@ -154,6 +173,15 @@ export const shouldNotTriggerString = Effect.succeed(1).pipe(
 export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
   Effect.asVoid
 )
+
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
 
 
 === [D3] Fix 0: "Disable effectMapVoid for this line" ===
@@ -217,6 +245,15 @@ export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
   Effect.asVoid
 )
 
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
+
 
 === [D4] Fix 0: "Disable effectMapVoid for this line" ===
 skipped by default
@@ -278,6 +315,15 @@ export const shouldNotTriggerString = Effect.succeed(1).pipe(
 export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
   Effect.asVoid
 )
+
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
 
 
 === [D5] Fix 0: "Disable effectMapVoid for this line" ===
@@ -341,6 +387,15 @@ export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
   Effect.asVoid
 )
 
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
+
 
 === [D6] Fix 0: "Disable effectMapVoid for this line" ===
 skipped by default
@@ -402,4 +457,155 @@ export const shouldNotTriggerString = Effect.succeed(1).pipe(
 export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
   Effect.asVoid
 )
+
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
+
+
+=== [D7] Fix 0: "Disable effectMapVoid for this line" ===
+skipped by default
+
+=== [D7] Fix 1: "Disable effectMapVoid for entire file" ===
+skipped by default
+
+=== [D7] Fix 2: "Replace with Effect.asVoid" ===
+
+--- file:///.src/effectMapVoid.ts ---
+import { Effect } from "effect"
+
+// Should trigger: Effect.map(() => void 0)
+export const shouldTriggerVoid0 = Effect.succeed(1).pipe(
+  Effect.map(() => void 0)
+)
+
+// Should trigger: Effect.map(() => undefined)
+export const shouldTriggerUndefined = Effect.succeed(1).pipe(
+  Effect.map(() => undefined)
+)
+
+// Should trigger: Effect.map(() => {})
+export const shouldTriggerEmptyBlock = Effect.succeed(1).pipe(
+  Effect.map(() => {})
+)
+
+// Should trigger: Effect.map(() => (undefined)) - parenthesized
+export const shouldTriggerParenthesizedUndefined = Effect.succeed(1).pipe(
+  Effect.map(() => (undefined))
+)
+
+// Should trigger: Effect.map(() => (void 0)) - parenthesized
+export const shouldTriggerParenthesizedVoid0 = Effect.succeed(1).pipe(
+  Effect.map(() => (void 0))
+)
+
+// Should trigger: Effect.map(() => ((undefined))) - double parenthesized
+export const shouldTriggerDoubleParenthesizedUndefined = Effect.succeed(1).pipe(
+  Effect.map(() => ((undefined)))
+)
+
+// Should NOT trigger: Effect.map with actual transformation
+export const shouldNotTriggerTransform = Effect.succeed(1).pipe(
+  Effect.map((n) => n * 2)
+)
+
+// Should NOT trigger: Effect.map with non-void return
+export const shouldNotTriggerNonVoid = Effect.succeed(1).pipe(
+  Effect.map(() => 42)
+)
+
+// Should NOT trigger: Effect.map with string return
+export const shouldNotTriggerString = Effect.succeed(1).pipe(
+  Effect.map(() => "hello")
+)
+
+// Should NOT trigger: already using asVoid
+export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
+  Effect.asVoid
+)
+
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.asVoid(Effect.succeed(1))
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
+
+
+=== [D8] Fix 0: "Disable effectMapVoid for this line" ===
+skipped by default
+
+=== [D8] Fix 1: "Disable effectMapVoid for entire file" ===
+skipped by default
+
+=== [D8] Fix 2: "Replace with Effect.asVoid" ===
+
+--- file:///.src/effectMapVoid.ts ---
+import { Effect } from "effect"
+
+// Should trigger: Effect.map(() => void 0)
+export const shouldTriggerVoid0 = Effect.succeed(1).pipe(
+  Effect.map(() => void 0)
+)
+
+// Should trigger: Effect.map(() => undefined)
+export const shouldTriggerUndefined = Effect.succeed(1).pipe(
+  Effect.map(() => undefined)
+)
+
+// Should trigger: Effect.map(() => {})
+export const shouldTriggerEmptyBlock = Effect.succeed(1).pipe(
+  Effect.map(() => {})
+)
+
+// Should trigger: Effect.map(() => (undefined)) - parenthesized
+export const shouldTriggerParenthesizedUndefined = Effect.succeed(1).pipe(
+  Effect.map(() => (undefined))
+)
+
+// Should trigger: Effect.map(() => (void 0)) - parenthesized
+export const shouldTriggerParenthesizedVoid0 = Effect.succeed(1).pipe(
+  Effect.map(() => (void 0))
+)
+
+// Should trigger: Effect.map(() => ((undefined))) - double parenthesized
+export const shouldTriggerDoubleParenthesizedUndefined = Effect.succeed(1).pipe(
+  Effect.map(() => ((undefined)))
+)
+
+// Should NOT trigger: Effect.map with actual transformation
+export const shouldNotTriggerTransform = Effect.succeed(1).pipe(
+  Effect.map((n) => n * 2)
+)
+
+// Should NOT trigger: Effect.map with non-void return
+export const shouldNotTriggerNonVoid = Effect.succeed(1).pipe(
+  Effect.map(() => 42)
+)
+
+// Should NOT trigger: Effect.map with string return
+export const shouldNotTriggerString = Effect.succeed(1).pipe(
+  Effect.map(() => "hello")
+)
+
+// Should NOT trigger: already using asVoid
+export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
+  Effect.asVoid
+)
+
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.asVoid(Effect.succeed(1))
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)
 

--- a/testdata/tests/effect-v3/effectMapVoid.ts
+++ b/testdata/tests/effect-v3/effectMapVoid.ts
@@ -52,3 +52,12 @@ export const shouldNotTriggerString = Effect.succeed(1).pipe(
 export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
   Effect.asVoid
 )
+
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)

--- a/testdata/tests/effect-v4/effectMapVoid.ts
+++ b/testdata/tests/effect-v4/effectMapVoid.ts
@@ -49,3 +49,12 @@ export const shouldNotTriggerString = Effect.succeed(1).pipe(
 export const shouldNotTriggerAsVoid = Effect.succeed(1).pipe(
   Effect.asVoid
 )
+
+// Should trigger: data-first Effect.map(self, () => {})
+export const shouldTriggerDataFirstEmptyBlock = Effect.map(Effect.succeed(1), () => {})
+
+// Should trigger: data-first Effect.map(self, () => void 0)
+export const shouldTriggerDataFirstVoid0 = Effect.map(Effect.succeed(1), () => void 0)
+
+// Should NOT trigger: data-first Effect.map with a real transformation
+export const shouldNotTriggerDataFirstTransform = Effect.map(Effect.succeed(1), (n) => n * 2)


### PR DESCRIPTION
## What

Migrates the `effectMapVoid` rule from a raw AST walk to `tp.PipingFlows`, so it now detects **both** the data-last/pipeable form and the **data-first** `Effect.map(self, () => {})` form. The data-first form was previously missed: the old walk read `call.Arguments.Nodes[0]` as the callback, but in the data-first layout `Nodes[0]` is the subject (the Effect) and the callback is `Nodes[1]`.

## Why

`Effect.map` is a dual (data-first / data-last) combinator. Driving detection off the piping-flow transformations normalizes the subject away, so `Args[0]` is the callback in every form. This mirrors the pattern already used by `flatMapToMap` and `mapSomeToAsSome`, and it composes across `pipe(...)`, `.pipe(...)`, and `Effect.fn` chains for free.

## Behaviour

| Source | Before | After |
| --- | --- | --- |
| `pipe(e, Effect.map(() => {}))` | flagged | flagged (unchanged) |
| `Effect.map(e, () => {})` (data-first) | **missed** | flagged |
| `Effect.map(e, (n) => n * 2)` | ignored | ignored |

The quick fix now branches on the form:

- data-last / pipeable → bare `Effect.asVoid` (unchanged)
- data-first → `Effect.asVoid(self)`, preserving the subject argument

```ts
// before
Effect.map(Effect.succeed(1), () => {})
// quick fix →
Effect.asVoid(Effect.succeed(1))
```

## Tests

- Added data-first fixtures (trigger + negative control) to the `effectMapVoid` v3 and v4 test files and regenerated the diagnostics / piping-flow / quick-fix baselines.
- `go build ./...`, `golangci-lint run ./...` (0 issues), and the full `go test ./...` suite pass. The rest of the `effecttest` baseline suite is unchanged apart from the new fixtures, confirming the migration is behaviour-preserving for every other rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)