### PR TITLE
feat(etsgoapi): expose piping-flow extraction in the Go API

### DIFF
--- a/.changeset/etsgoapi-piping-flows.md
+++ b/.changeset/etsgoapi-piping-flows.md
@@ -1,0 +1,20 @@
+---
+"@effect/tsgo": minor
+---
+
+Expose piping-flow extraction through the `etsgoapi` Go API.
+
+The type parser already understands "piping flows" — a subject expression followed by an ordered list of transformations, unifying the `pipe(...)`, pipeable `.pipe(...)`, data-first, data-last and `Effect.fn` forms — but that analysis was only reachable from internal packages. `etsgoapi.TypeParser` now surfaces it so external Go integrations can consume it without importing `internal/...`.
+
+```go
+tp := etsgoapi.NewTypeParser(program, checker)
+for _, flow := range tp.PipingFlows(sourceFile, true /* includeEffectFn */) {
+	// flow.Subject.Node / flow.Subject.OutType — the starting expression and its type
+	for _, step := range flow.Transformations {
+		// step.Kind (pipe | pipeable | dataFirst | dataLast | call | effectFn | effectFnUntraced)
+		// step.Callee / step.Args / step.OutType
+	}
+}
+```
+
+Adds the public `PipingFlow`, `PipingFlowSubject`, `PipingFlowTransformation` and `TransformationKind` types alongside the new `(*TypeParser).PipingFlows` method.

--- a/etsgoapi/piping_flow.go
+++ b/etsgoapi/piping_flow.go
@@ -1,0 +1,91 @@
+package etsgoapi
+
+import (
+	"github.com/effect-ts/tsgo/internal/typeparser"
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/checker"
+)
+
+// TransformationKind represents how a transformation was expressed in source code.
+type TransformationKind string
+
+const (
+	TransformationKindPipe             = TransformationKind(typeparser.TransformationKindPipe)
+	TransformationKindPipeable         = TransformationKind(typeparser.TransformationKindPipeable)
+	TransformationKindDataFirst        = TransformationKind(typeparser.TransformationKindDataFirst)
+	TransformationKindDataLast         = TransformationKind(typeparser.TransformationKindDataLast)
+	TransformationKindCall             = TransformationKind(typeparser.TransformationKindCall)
+	TransformationKindEffectFn         = TransformationKind(typeparser.TransformationKindEffectFn)
+	TransformationKindEffectFnUntraced = TransformationKind(typeparser.TransformationKindEffectFnUntraced)
+)
+
+// PipingFlowTransformation represents a single transformation step in a piping flow.
+type PipingFlowTransformation struct {
+	Kind    TransformationKind // How the transformation was expressed
+	Node    *ast.Node          // The full transformation node (call expression or bare callee)
+	Callee  *ast.Node          // The function being applied (e.g., Effect.map)
+	Args    []*ast.Node        // Arguments to the transformation, or nil for constants/single-arg calls
+	OutType *checker.Type      // The resulting type after this transformation (may be nil)
+}
+
+// PipingFlowSubject is the starting expression of a piping flow.
+type PipingFlowSubject struct {
+	Node    *ast.Node     // The expression node
+	OutType *checker.Type // The type of the subject expression (may be nil)
+}
+
+// PipingFlow represents a complete piping flow: a subject followed by transformations.
+type PipingFlow struct {
+	Node            *ast.Node                  // The outermost expression encompassing the entire flow
+	Subject         PipingFlowSubject          // The starting expression and its type
+	Transformations []PipingFlowTransformation // Ordered list of transformations
+}
+
+// PipingFlows returns all piping flows found in a source file, sorted by source position.
+// When includeEffectFn is true, Effect.fn / Effect.fnUntraced calls carrying trailing
+// transformation arguments are surfaced as flows as well.
+func (tp *TypeParser) PipingFlows(sf *ast.SourceFile, includeEffectFn bool) []*PipingFlow {
+	if tp == nil || tp.inner == nil {
+		return nil
+	}
+	return pipingFlowsFromInternal(tp.inner.PipingFlows(sf, includeEffectFn))
+}
+
+func pipingFlowsFromInternal(flows []*typeparser.PipingFlow) []*PipingFlow {
+	if flows == nil {
+		return nil
+	}
+	result := make([]*PipingFlow, 0, len(flows))
+	for _, flow := range flows {
+		if converted := pipingFlowFromInternal(flow); converted != nil {
+			result = append(result, converted)
+		}
+	}
+	return result
+}
+
+func pipingFlowFromInternal(flow *typeparser.PipingFlow) *PipingFlow {
+	if flow == nil {
+		return nil
+	}
+
+	transformations := make([]PipingFlowTransformation, 0, len(flow.Transformations))
+	for _, transformation := range flow.Transformations {
+		transformations = append(transformations, PipingFlowTransformation{
+			Kind:    TransformationKind(transformation.Kind),
+			Node:    transformation.Node,
+			Callee:  transformation.Callee,
+			Args:    transformation.Args,
+			OutType: transformation.OutType,
+		})
+	}
+
+	return &PipingFlow{
+		Node: flow.Node,
+		Subject: PipingFlowSubject{
+			Node:    flow.Subject.Node,
+			OutType: flow.Subject.OutType,
+		},
+		Transformations: transformations,
+	}
+}


### PR DESCRIPTION
## What changed

The type parser already models **piping flows** — a subject expression followed by an ordered list of transformations that unifies the different ways an Effect transformation can be written:

- `pipe(self, f1, f2)` (`pipe`)
- pipeable `self.pipe(f1, f2)` (`pipeable`)
- data-first `Effect.map(self, cb)` (`dataFirst`)
- data-last `Effect.map(cb)` inside a pipe (`dataLast`)
- single-arg `call`
- `Effect.fn` / `Effect.fnUntraced` with trailing transformation args (`effectFn` / `effectFnUntraced`)

Until now this analysis was only reachable from `internal/typeparser`. This PR surfaces it through the public `etsgoapi` package so external Go integrations can consume piping flows without importing `internal/...`, following the same narrow-wrapper convention already used for `Effect`, `Layer`, `Service`, etc.

## API

New file `etsgoapi/piping_flow.go` adds:

- `TransformationKind` (+ constants: `Pipe`, `Pipeable`, `DataFirst`, `DataLast`, `Call`, `EffectFn`, `EffectFnUntraced`)
- `PipingFlowTransformation` `{ Kind, Node, Callee, Args, OutType }`
- `PipingFlowSubject` `{ Node, OutType }`
- `PipingFlow` `{ Node, Subject, Transformations }`
- `(*TypeParser).PipingFlows(sf *ast.SourceFile, includeEffectFn bool) []*PipingFlow`

Node/type fields reuse the public shim types (`*ast.Node`, `*checker.Type`), which are already the intended public surface. The wrapper converts the internal result via a nil-safe `pipingFlowFromInternal` helper; `TransformationKind` constants are derived from the internal ones so they stay in sync at compile time.

### Example

```go
tp := etsgoapi.NewTypeParser(program, checker)
for _, flow := range tp.PipingFlows(sourceFile, true /* includeEffectFn */) {
	// flow.Subject.Node / flow.Subject.OutType — the starting expression and its type
	for _, step := range flow.Transformations {
		// step.Kind (pipe | pipeable | dataFirst | dataLast | call | effectFn | effectFnUntraced)
		// step.Callee / step.Args / step.OutType
	}
}
```

## Validation

- `pnpm setup-repo` ✓
- `pnpm lint` ✓ (0 issues, deadcode clean)
- `pnpm check` ✓
- `pnpm test` ✓ (exit 0)

Purely additive — no internal behavior changed. Includes a `minor` changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)