### PR TITLE
fix: synchronize Nix TypeScript pin

### DIFF
--- a/.changeset/fix-nix-typescript-pin.md
+++ b/.changeset/fix-nix-typescript-pin.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Keep the Nix TypeScript source pin synchronized with the TypeScript next metadata so Nix builds compile generated shims against the matching compiler revision.

--- a/_tools/repoctl/test/flake.test.ts
+++ b/_tools/repoctl/test/flake.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import test from "node:test"
+import { fileURLToPath } from "node:url"
 import { invalidateVendorHash, updateFlakeInputs, updateVendorHash } from "../src/flake.ts"
 
+const repositoryRoot = fileURLToPath(new URL("../../..", import.meta.url))
 const oldRevision = "0123456789abcdef0123456789abcdef01234567"
 const newTsRevision = "2123456789abcdef0123456789abcdef01234567"
 
@@ -13,6 +17,22 @@ test("updates pinned flake inputs", () => {
   assert.equal(updateFlakeInputs(flake, newTsRevision), [
     `url = "github:microsoft/TypeScript/${newTsRevision}";`
   ].join("\n"))
+})
+
+test("keeps the pinned flake input synchronized with TypeScript next", () => {
+  const upstream = JSON.parse(
+    readFileSync(join(repositoryRoot, "_packages", "tsgo", "upstream.json"), "utf8")
+  ) as {
+    readonly tags: { readonly typescript: { readonly next: string } }
+    readonly components: {
+      readonly typescript: Readonly<Record<string, { readonly gitHead: string }>>
+    }
+  }
+  const revision = upstream.components.typescript[upstream.tags.typescript.next]?.gitHead
+  assert.ok(revision)
+
+  const flake = readFileSync(join(repositoryRoot, "flake.nix"), "utf8")
+  assert.equal(updateFlakeInputs(flake, revision), flake)
 })
 
 test("updates the vendor hash", () => {

--- a/flake.lock
+++ b/flake.lock
@@ -42,17 +42,17 @@
     "typescript-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1787787517,
-        "narHash": "sha256-9Pwt1GKB13Xj4vIP2Y/JRebKl2fcyGJZW2/SuNEaY3s=",
+        "lastModified": 1787958136,
+        "narHash": "sha256-qAr629gxJNrc2iJ8m6/iE5qf0XUeDRN9XmaiWyk9yiQ=",
         "owner": "microsoft",
         "repo": "TypeScript",
-        "rev": "e95d8e57a89f4c174604d76e683d1f14d148373d",
+        "rev": "9a8581c393a38961489cc8409ae4dfbe97fc25ec",
         "type": "github"
       },
       "original": {
         "owner": "microsoft",
         "repo": "TypeScript",
-        "rev": "e95d8e57a89f4c174604d76e683d1f14d148373d",
+        "rev": "9a8581c393a38961489cc8409ae4dfbe97fc25ec",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nixpkgsUnstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     /* Source of truth: the next profile in `_packages/tsgo/upstream.json`. */
     typescript-src = {
-      url = "github:microsoft/TypeScript/e95d8e57a89f4c174604d76e683d1f14d148373d";
+      url = "github:microsoft/TypeScript/9a8581c393a38961489cc8409ae4dfbe97fc25ec";
       flake = false;
     };
   };


### PR DESCRIPTION
## Summary

- synchronize the Nix TypeScript source and lock entry with the configured TypeScript next revision (`9a8581c393a38961489cc8409ae4dfbe97fc25ec`)
- add a repoctl regression test that keeps the flake pin aligned with `_packages/tsgo/upstream.json`
- add a patch changeset

## Root cause

The generated `ls/change` shim targeted the current TypeScript next revision, while the Nix flake still built the previous revision. That paired incompatible change-tracker range APIs and caused the Nix compiler build to fail.

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm --filter @effect/tsgo-repoctl test`
- `nix flake check --no-write-lock-file -L`