### PR TITLE
Fix schemaNumber false positives for finite refinements

### DIFF
--- a/.changeset/fix-schema-number-refinements.md
+++ b/.changeset/fix-schema-number-refinements.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Avoid reporting the `schemaNumber` diagnostic when `Schema.Number` is refined with the built-in `isFinite` or `isInt` checks, including pipe-style refinements.

--- a/_packages/tsgo/src/metadata.json
+++ b/_packages/tsgo/src/metadata.json
@@ -2273,7 +2273,7 @@
         377098
       ],
       "preview": {
-        "sourceText": "\nimport { Schema } from \"effect\"\n\nexport const User = Schema.Struct({\n  age: Schema.Number,\n  score: Schema.NumberFromString\n})\n",
+        "sourceText": "\nimport { Schema } from \"effect\"\n\nexport const User = Schema.Struct({\n  age: Schema.Number,\n  score: Schema.NumberFromString,\n  integer: Schema.Number.check(Schema.isInt()),\n  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite()))\n})\n",
         "diagnostics": [
           {
             "start": 84,

--- a/docs/rules/schema-number.md
+++ b/docs/rules/schema-number.md
@@ -24,10 +24,12 @@ export const User = Schema.Struct({
 /**
               ^^^^^^ effecttsgo(schema-number): This Schema number API accepts `NaN`, `Infinity`, and `-Infinity`. Use `Schema.Finite` for finite domain numbers. If non-finite values are intentional, disable this diagnostic for that line.
 */
-  score: Schema.NumberFromString
+  score: Schema.NumberFromString,
 /**
                 ^^^^^^^^^^^^^^^^ effecttsgo(schema-number): This Schema number API accepts `NaN`, `Infinity`, and `-Infinity`. Use `Schema.FiniteFromString` for finite domain numbers. If non-finite values are intentional, disable this diagnostic for that line.
 */
+  integer: Schema.Number.check(Schema.isInt()),
+  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite()))
 })
 ```
 

--- a/internal/rules/schema_number.go
+++ b/internal/rules/schema_number.go
@@ -102,24 +102,30 @@ func schemaNumberHasFiniteMethodCheck(tp *typeparser.TypeParser, node *ast.Node)
 			schemaExpression = node.Parent
 		}
 	}
-	if schemaExpression.Parent == nil || schemaExpression.Parent.Kind != ast.KindPropertyAccessExpression {
-		return false
-	}
+	for schemaExpression.Parent != nil && schemaExpression.Parent.Kind == ast.KindPropertyAccessExpression {
+		accessNode := schemaExpression.Parent
+		access := accessNode.AsPropertyAccessExpression()
+		if access.Expression != schemaExpression || access.Name() == nil || accessNode.Parent == nil || accessNode.Parent.Kind != ast.KindCallExpression {
+			return false
+		}
 
-	checkAccessNode := schemaExpression.Parent
-	checkAccess := checkAccessNode.AsPropertyAccessExpression()
-	if checkAccess.Expression != schemaExpression || checkAccess.Name() == nil || checkAccess.Name().Text() != "check" {
-		return false
+		call := accessNode.Parent.AsCallExpression()
+		if call.Expression != accessNode {
+			return false
+		}
+		switch access.Name().Text() {
+		case "annotate":
+			schemaExpression = accessNode.Parent
+		case "check":
+			if call.Arguments == nil {
+				return false
+			}
+			return schemaNumberHasFinitePredicate(tp, call.Arguments.Nodes)
+		default:
+			return false
+		}
 	}
-	if checkAccessNode.Parent == nil || checkAccessNode.Parent.Kind != ast.KindCallExpression {
-		return false
-	}
-
-	checkCall := checkAccessNode.Parent.AsCallExpression()
-	if checkCall.Expression != checkAccessNode || checkCall.Arguments == nil {
-		return false
-	}
-	return schemaNumberHasFinitePredicate(tp, checkCall.Arguments.Nodes)
+	return false
 }
 
 func schemaNumberHasFinitePipingCheck(tp *typeparser.TypeParser, reference *ast.Node, flows []*typeparser.PipingFlow) bool {

--- a/internal/rules/schema_number.go
+++ b/internal/rules/schema_number.go
@@ -66,7 +66,16 @@ func AnalyzeSchemaNumber(tp *typeparser.TypeParser, sf *ast.SourceFile) []Schema
 	}
 
 	walk(sf.AsNode())
-	return matches
+
+	flows := tp.PipingFlows(sf, false)
+	filtered := matches[:0]
+	for _, match := range matches {
+		if schemaNumberHasFiniteMethodCheck(tp, match.ReferenceNode) || schemaNumberHasFinitePipingCheck(tp, match.ReferenceNode, flows) {
+			continue
+		}
+		filtered = append(filtered, match)
+	}
+	return filtered
 }
 
 func analyzeSchemaNumberReference(tp *typeparser.TypeParser, sf *ast.SourceFile, node *ast.Node) *SchemaNumberMatch {
@@ -83,6 +92,72 @@ func analyzeSchemaNumberReference(tp *typeparser.TypeParser, sf *ast.SourceFile,
 		}
 	}
 	return nil
+}
+
+func schemaNumberHasFiniteMethodCheck(tp *typeparser.TypeParser, node *ast.Node) bool {
+	schemaExpression := node
+	if node.Kind == ast.KindIdentifier && node.Parent != nil && node.Parent.Kind == ast.KindPropertyAccessExpression {
+		access := node.Parent.AsPropertyAccessExpression()
+		if access.Name() == node {
+			schemaExpression = node.Parent
+		}
+	}
+	if schemaExpression.Parent == nil || schemaExpression.Parent.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+
+	checkAccessNode := schemaExpression.Parent
+	checkAccess := checkAccessNode.AsPropertyAccessExpression()
+	if checkAccess.Expression != schemaExpression || checkAccess.Name() == nil || checkAccess.Name().Text() != "check" {
+		return false
+	}
+	if checkAccessNode.Parent == nil || checkAccessNode.Parent.Kind != ast.KindCallExpression {
+		return false
+	}
+
+	checkCall := checkAccessNode.Parent.AsCallExpression()
+	if checkCall.Expression != checkAccessNode || checkCall.Arguments == nil {
+		return false
+	}
+	return schemaNumberHasFinitePredicate(tp, checkCall.Arguments.Nodes)
+}
+
+func schemaNumberHasFinitePipingCheck(tp *typeparser.TypeParser, reference *ast.Node, flows []*typeparser.PipingFlow) bool {
+	for _, flow := range flows {
+		if flow.Subject.Node == nil || !schemaNumberNodeContains(flow.Subject.Node, reference) {
+			continue
+		}
+		for _, transformation := range flow.Transformations {
+			if transformation.Callee != nil &&
+				tp.IsNodeReferenceToEffectSchemaModuleApi(transformation.Callee, "check") &&
+				schemaNumberHasFinitePredicate(tp, transformation.Args) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func schemaNumberHasFinitePredicate(tp *typeparser.TypeParser, arguments []*ast.Node) bool {
+	for _, argument := range arguments {
+		argument = ast.SkipParentheses(argument)
+		if argument.Kind != ast.KindCallExpression {
+			continue
+		}
+		predicateCall := argument.AsCallExpression()
+		if predicateCall.Expression == nil {
+			continue
+		}
+		if tp.IsNodeReferenceToEffectSchemaModuleApi(predicateCall.Expression, "isFinite") ||
+			tp.IsNodeReferenceToEffectSchemaModuleApi(predicateCall.Expression, "isInt") {
+			return true
+		}
+	}
+	return false
+}
+
+func schemaNumberNodeContains(ancestor *ast.Node, target *ast.Node) bool {
+	return ancestor != nil && target != nil && ancestor.Pos() <= target.Pos() && target.End() <= ancestor.End()
 }
 
 type schemaNumberApi struct {

--- a/testdata/baselines/reference/effect-v4/schemaNumber.errors.txt
+++ b/testdata/baselines/reference/effect-v4/schemaNumber.errors.txt
@@ -50,9 +50,15 @@ Effect version: 4.0.0
       integer: Schema.Number.check(Schema.isInt()),
       importedFinite: Schema.Number.check(isFinite()),
       importedInteger: Schema.Number.check(integer()),
+      annotated: Schema.Number.annotate({ description: "a" }).check(Schema.isFinite()),
+      annotatedPredicate: Schema.Number.check(Schema.isFinite({ description: "a" })),
       pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),
       pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),
-      pipedImported: Schema.Number.pipe(refine(integer()))
+      pipedImported: Schema.Number.pipe(refine(integer())),
+      pipedAnnotated: Schema.Number.pipe(
+        Schema.annotate({ description: "a" }),
+        Schema.check(Schema.isFinite())
+      )
     })
     // @effect-diagnostics-next-line schemaNumber:off
     export const intentionallyNonFinite = Schema.Number

--- a/testdata/baselines/reference/effect-v4/schemaNumber.errors.txt
+++ b/testdata/baselines/reference/effect-v4/schemaNumber.errors.txt
@@ -14,7 +14,7 @@ Effect version: 4.0.0
     
     import { Schema } from "effect"
     import * as SchemaModule from "effect/Schema"
-    import { Number as NumberSchema, NumberFromString } from "effect/Schema"
+    import { check as refine, isFinite, isInt as integer, Number as NumberSchema, NumberFromString } from "effect/Schema"
     
     export const user = Schema.Struct({
       age: Schema.Number,
@@ -45,6 +45,15 @@ Effect version: 4.0.0
 !!! warning TS377098: This Schema number API accepts `NaN`, `Infinity`, and `-Infinity`. Use `Schema.FiniteFromString` for finite domain numbers. If non-finite values are intentional, disable this diagnostic for that line. effect(schemaNumber)
     })
     
+    export const refinements = Schema.Struct({
+      finite: Schema.Number.check(Schema.isFinite()),
+      integer: Schema.Number.check(Schema.isInt()),
+      importedFinite: Schema.Number.check(isFinite()),
+      importedInteger: Schema.Number.check(integer()),
+      pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),
+      pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),
+      pipedImported: Schema.Number.pipe(refine(integer()))
+    })
     // @effect-diagnostics-next-line schemaNumber:off
     export const intentionallyNonFinite = Schema.Number
     

--- a/testdata/baselines/reference/effect-v4/schemaNumber.flows.schemaNumber.mermaid
+++ b/testdata/baselines/reference/effect-v4/schemaNumber.flows.schemaNumber.mermaid
@@ -8,10 +8,63 @@ flowchart TB
   6[/"type: #123; quantity: Number; amount: NumberFromString; #125;<br/>node: #123;#92;n  quantity: NumberSchema,#92;n  amount: NumberFromString#92;n#125;"/]
   7["type: Struct#lt;#123; readonly quantity: Number; readonly amount: NumberFromString; #125;#gt;<br/>callee: Schema.Struct<br/>args: #91;#93;"]
   8[/"type: #lt;const Fields extends Struct.Fields#gt;#40;fields: Fields#41; =#gt; Struct#lt;Fields#gt;<br/>node: Schema.Struct"/]
-  9[/"type: Number<br/>node: Schema.Number"/]
+  9[/"type: #123; finite: Number; integer: Number; importedFinite: Number; importedInteger: Number; pipedFinite: Number; pipedInteger: Number; pipedImported: Number; #125;<br/>node: #123;#92;n  finite: Schema.Number.check#40;Schema.isFinite#40;#41;#41;,#92;n  integer: Schema.Number.check#40;Schema.isInt#40;#41;#41;,#92;n  importedFinite: Schema.Number.check#40;isFinite#40;#41;#41;,#92;n  importedInteger: Schema.Number.check#40;integer#40;#41;#41;,#92;n  pipedFinite: Schema.Number.pipe#40;Schema.check#40;Schema.isFinite#40;#41;#41;#41;,#92;n  pipedInteger: Schema.Number.pipe#40;Schema.check#40;Schema.isInt#40;#41;#41;#41;,#92;n  pipedImported: Schema.Number.pipe#40;refine#40;integer#40;#41;#41;#41;#92;n#125;"/]
+  10[/"type: Filter#lt;number#gt;<br/>node: Schema.isFinite#40;#41;"/]
+  11["type: Number<br/>callee: Schema.Number.check<br/>args: #91;#93;"]
+  12[/"type: #40;checks_0: Check#lt;number#gt;, ...checks: Check#lt;number#gt;#91;#93;#41; =#gt; Number<br/>node: Schema.Number.check"/]
+  13[/"type: Filter#lt;number#gt;<br/>node: Schema.isInt#40;#41;"/]
+  14["type: Number<br/>callee: Schema.Number.check<br/>args: #91;#93;"]
+  15[/"type: #40;checks_0: Check#lt;number#gt;, ...checks: Check#lt;number#gt;#91;#93;#41; =#gt; Number<br/>node: Schema.Number.check"/]
+  16[/"type: Filter#lt;number#gt;<br/>node: isFinite#40;#41;"/]
+  17["type: Number<br/>callee: Schema.Number.check<br/>args: #91;#93;"]
+  18[/"type: #40;checks_0: Check#lt;number#gt;, ...checks: Check#lt;number#gt;#91;#93;#41; =#gt; Number<br/>node: Schema.Number.check"/]
+  19[/"type: Filter#lt;number#gt;<br/>node: integer#40;#41;"/]
+  20["type: Number<br/>callee: Schema.Number.check<br/>args: #91;#93;"]
+  21[/"type: #40;checks_0: Check#lt;number#gt;, ...checks: Check#lt;number#gt;#91;#93;#41; =#gt; Number<br/>node: Schema.Number.check"/]
+  22[/"type: Number<br/>node: Schema.Number"/]
+  23["type: Number<br/>callee: Schema.check<br/>args: #91;Schema.isFinite#40;#41;#93;"]
+  24[/"type: #lt;S extends Top#gt;#40;checks_0: Check#lt;S#91;#quot;Type#quot;#93;#gt;, ...checks: Check#lt;S#91;#quot;Type#quot;#93;#gt;#91;#93;#41; =#gt; #40;self: S#41; =#gt; S#91;#quot;Rebuild#quot;#93;<br/>node: Schema.check"/]
+  25[/"type: Filter#lt;number#gt;<br/>node: Schema.isFinite#40;#41;"/]
+  26[/"type: Number<br/>node: Schema.Number"/]
+  27["type: Number<br/>callee: Schema.check<br/>args: #91;Schema.isInt#40;#41;#93;"]
+  28[/"type: #lt;S extends Top#gt;#40;checks_0: Check#lt;S#91;#quot;Type#quot;#93;#gt;, ...checks: Check#lt;S#91;#quot;Type#quot;#93;#gt;#91;#93;#41; =#gt; #40;self: S#41; =#gt; S#91;#quot;Rebuild#quot;#93;<br/>node: Schema.check"/]
+  29[/"type: Filter#lt;number#gt;<br/>node: Schema.isInt#40;#41;"/]
+  30[/"type: Number<br/>node: Schema.Number"/]
+  31["type: Number<br/>callee: refine<br/>args: #91;integer#40;#41;#93;"]
+  32[/"type: #lt;S extends Top#gt;#40;checks_0: Check#lt;S#91;#quot;Type#quot;#93;#gt;, ...checks: Check#lt;S#91;#quot;Type#quot;#93;#gt;#91;#93;#41; =#gt; #40;self: S#41; =#gt; S#91;#quot;Rebuild#quot;#93;<br/>node: refine"/]
+  33[/"type: Filter#lt;number#gt;<br/>node: integer#40;#41;"/]
+  34["type: Struct#lt;#123; readonly finite: Number; readonly integer: Number; readonly importedFinite: Number; readonly importedInteger: Number; readonly pipedFinite: Number; readonly pipedInteger: Number; readonly pipedImported: Number; #125;#gt;<br/>callee: Schema.Struct<br/>args: #91;#93;"]
+  35[/"type: #lt;const Fields extends Struct.Fields#gt;#40;fields: Fields#41; =#gt; Struct#lt;Fields#gt;<br/>node: Schema.Struct"/]
+  36[/"type: Number<br/>node: Schema.Number"/]
   0 -->|"kind: pipe"| 1
   2 -->|"kind: transformCallee"| 1
   3 -->|"kind: pipe"| 4
   5 -->|"kind: transformCallee"| 4
   6 -->|"kind: pipe"| 7
   8 -->|"kind: transformCallee"| 7
+  10 -->|"kind: pipe"| 11
+  12 -->|"kind: transformCallee"| 11
+  11 -->|"kind: usedBy"| 9
+  13 -->|"kind: pipe"| 14
+  15 -->|"kind: transformCallee"| 14
+  14 -->|"kind: usedBy"| 9
+  16 -->|"kind: pipe"| 17
+  18 -->|"kind: transformCallee"| 17
+  17 -->|"kind: usedBy"| 9
+  19 -->|"kind: pipe"| 20
+  21 -->|"kind: transformCallee"| 20
+  20 -->|"kind: usedBy"| 9
+  24 -->|"kind: transformCallee"| 23
+  25 -->|"kind: transformArg"| 23
+  22 -->|"kind: pipe"| 23
+  23 -->|"kind: usedBy"| 9
+  28 -->|"kind: transformCallee"| 27
+  29 -->|"kind: transformArg"| 27
+  26 -->|"kind: pipe"| 27
+  27 -->|"kind: usedBy"| 9
+  32 -->|"kind: transformCallee"| 31
+  33 -->|"kind: transformArg"| 31
+  30 -->|"kind: pipe"| 31
+  31 -->|"kind: usedBy"| 9
+  9 -->|"kind: pipe"| 34
+  35 -->|"kind: transformCallee"| 34

--- a/testdata/baselines/reference/effect-v4/schemaNumber.flows.schemaNumber.mermaid
+++ b/testdata/baselines/reference/effect-v4/schemaNumber.flows.schemaNumber.mermaid
@@ -8,7 +8,7 @@ flowchart TB
   6[/"type: #123; quantity: Number; amount: NumberFromString; #125;<br/>node: #123;#92;n  quantity: NumberSchema,#92;n  amount: NumberFromString#92;n#125;"/]
   7["type: Struct#lt;#123; readonly quantity: Number; readonly amount: NumberFromString; #125;#gt;<br/>callee: Schema.Struct<br/>args: #91;#93;"]
   8[/"type: #lt;const Fields extends Struct.Fields#gt;#40;fields: Fields#41; =#gt; Struct#lt;Fields#gt;<br/>node: Schema.Struct"/]
-  9[/"type: #123; finite: Number; integer: Number; importedFinite: Number; importedInteger: Number; pipedFinite: Number; pipedInteger: Number; pipedImported: Number; #125;<br/>node: #123;#92;n  finite: Schema.Number.check#40;Schema.isFinite#40;#41;#41;,#92;n  integer: Schema.Number.check#40;Schema.isInt#40;#41;#41;,#92;n  importedFinite: Schema.Number.check#40;isFinite#40;#41;#41;,#92;n  importedInteger: Schema.Number.check#40;integer#40;#41;#41;,#92;n  pipedFinite: Schema.Number.pipe#40;Schema.check#40;Schema.isFinite#40;#41;#41;#41;,#92;n  pipedInteger: Schema.Number.pipe#40;Schema.check#40;Schema.isInt#40;#41;#41;#41;,#92;n  pipedImported: Schema.Number.pipe#40;refine#40;integer#40;#41;#41;#41;#92;n#125;"/]
+  9[/"type: #123; finite: Number; integer: Number; importedFinite: Number; importedInteger: Number; annotated: Number; annotatedPredicate: Number; pipedFinite: Number; pipedInteger: Number; pipedImported: Number; pipedAnnotated: Number; #125;<br/>node: #123;#92;n  finite: Schema.Number.check#40;Schema.isFinite#40;#41;#41;,#92;n  integer: Schema.Number.check#40;Schema.isInt#40;#41;#41;,#92;n  importedFinite: Schema.Number.check#40;isFinite#40;#41;#41;,#92;n  importedInteger: Schema.Number.check#40;integer#40;#41;#41;,#92;n  annotated: Schema.Number.annotate#40;#123; description: #quot;a#quot; #125;#41;.check#40;Schema.isFinite#40;#41;#41;,#92;n  annotatedPredicate: Schema.Number.check#40;Schema.isFinite#40;#123; description: #quot;a#quot; #125;#41;#41;,#92;n  pipedFinite: Schema.Number.pipe#40;Schema.check#40;Schema.isFinite#40;#41;#41;#41;,#92;n  pipedInteger: Schema.Number.pipe#40;Schema.check#40;Schema.isInt#40;#41;#41;#41;,#92;n  pipedImported: Schema.Number.pipe#40;refine#40;integer#40;#41;#41;#41;,#92;n  pipedAnnotated: Schema.Number.pipe#40;#92;n    Schema.annotate#40;#123; description: #quot;a#quot; #125;#41;,#92;n    Schema.check#40;Schema.isFinite#40;#41;#41;#92;n  #41;#92;n#125;"/]
   10[/"type: Filter#lt;number#gt;<br/>node: Schema.isFinite#40;#41;"/]
   11["type: Number<br/>callee: Schema.Number.check<br/>args: #91;#93;"]
   12[/"type: #40;checks_0: Check#lt;number#gt;, ...checks: Check#lt;number#gt;#91;#93;#41; =#gt; Number<br/>node: Schema.Number.check"/]
@@ -21,21 +21,39 @@ flowchart TB
   19[/"type: Filter#lt;number#gt;<br/>node: integer#40;#41;"/]
   20["type: Number<br/>callee: Schema.Number.check<br/>args: #91;#93;"]
   21[/"type: #40;checks_0: Check#lt;number#gt;, ...checks: Check#lt;number#gt;#91;#93;#41; =#gt; Number<br/>node: Schema.Number.check"/]
-  22[/"type: Number<br/>node: Schema.Number"/]
-  23["type: Number<br/>callee: Schema.check<br/>args: #91;Schema.isFinite#40;#41;#93;"]
-  24[/"type: #lt;S extends Top#gt;#40;checks_0: Check#lt;S#91;#quot;Type#quot;#93;#gt;, ...checks: Check#lt;S#91;#quot;Type#quot;#93;#gt;#91;#93;#41; =#gt; #40;self: S#41; =#gt; S#91;#quot;Rebuild#quot;#93;<br/>node: Schema.check"/]
-  25[/"type: Filter#lt;number#gt;<br/>node: Schema.isFinite#40;#41;"/]
-  26[/"type: Number<br/>node: Schema.Number"/]
-  27["type: Number<br/>callee: Schema.check<br/>args: #91;Schema.isInt#40;#41;#93;"]
-  28[/"type: #lt;S extends Top#gt;#40;checks_0: Check#lt;S#91;#quot;Type#quot;#93;#gt;, ...checks: Check#lt;S#91;#quot;Type#quot;#93;#gt;#91;#93;#41; =#gt; #40;self: S#41; =#gt; S#91;#quot;Rebuild#quot;#93;<br/>node: Schema.check"/]
-  29[/"type: Filter#lt;number#gt;<br/>node: Schema.isInt#40;#41;"/]
-  30[/"type: Number<br/>node: Schema.Number"/]
-  31["type: Number<br/>callee: refine<br/>args: #91;integer#40;#41;#93;"]
-  32[/"type: #lt;S extends Top#gt;#40;checks_0: Check#lt;S#91;#quot;Type#quot;#93;#gt;, ...checks: Check#lt;S#91;#quot;Type#quot;#93;#gt;#91;#93;#41; =#gt; #40;self: S#41; =#gt; S#91;#quot;Rebuild#quot;#93;<br/>node: refine"/]
-  33[/"type: Filter#lt;number#gt;<br/>node: integer#40;#41;"/]
-  34["type: Struct#lt;#123; readonly finite: Number; readonly integer: Number; readonly importedFinite: Number; readonly importedInteger: Number; readonly pipedFinite: Number; readonly pipedInteger: Number; readonly pipedImported: Number; #125;#gt;<br/>callee: Schema.Struct<br/>args: #91;#93;"]
-  35[/"type: #lt;const Fields extends Struct.Fields#gt;#40;fields: Fields#41; =#gt; Struct#lt;Fields#gt;<br/>node: Schema.Struct"/]
-  36[/"type: Number<br/>node: Schema.Number"/]
+  22[/"type: Filter#lt;number#gt;<br/>node: Schema.isFinite#40;#41;"/]
+  23["type: Number<br/>callee: Schema.Number.annotate#40;#123; description: #quot;a#quot; #125;#41;.check<br/>args: #91;#93;"]
+  24[/"type: #40;checks_0: Check#lt;number#gt;, ...checks: Check#lt;number#gt;#91;#93;#41; =#gt; Number<br/>node: Schema.Number.annotate#40;#123; description: #quot;a#quot; #125;#41;.check"/]
+  25[/"type: #123; description: string; #125;<br/>node: #123; description: #quot;a#quot; #125;"/]
+  26["type: Number<br/>callee: Schema.Number.annotate<br/>args: #91;#93;"]
+  27[/"type: #40;annotations: Bottom#lt;number, readonly #91;#93;#gt;#41; =#gt; Number<br/>node: Schema.Number.annotate"/]
+  28[/"type: #123; description: string; #125;<br/>node: #123; description: #quot;a#quot; #125;"/]
+  29["type: Filter#lt;number#gt;<br/>callee: Schema.isFinite<br/>args: #91;#93;"]
+  30[/"type: #40;annotations?: Filter #124; undefined#41; =#gt; Filter#lt;number#gt;<br/>node: Schema.isFinite"/]
+  31["type: Number<br/>callee: Schema.Number.check<br/>args: #91;#93;"]
+  32[/"type: #40;checks_0: Check#lt;number#gt;, ...checks: Check#lt;number#gt;#91;#93;#41; =#gt; Number<br/>node: Schema.Number.check"/]
+  33[/"type: Number<br/>node: Schema.Number"/]
+  34["type: Number<br/>callee: Schema.check<br/>args: #91;Schema.isFinite#40;#41;#93;"]
+  35[/"type: #lt;S extends Top#gt;#40;checks_0: Check#lt;S#91;#quot;Type#quot;#93;#gt;, ...checks: Check#lt;S#91;#quot;Type#quot;#93;#gt;#91;#93;#41; =#gt; #40;self: S#41; =#gt; S#91;#quot;Rebuild#quot;#93;<br/>node: Schema.check"/]
+  36[/"type: Filter#lt;number#gt;<br/>node: Schema.isFinite#40;#41;"/]
+  37[/"type: Number<br/>node: Schema.Number"/]
+  38["type: Number<br/>callee: Schema.check<br/>args: #91;Schema.isInt#40;#41;#93;"]
+  39[/"type: #lt;S extends Top#gt;#40;checks_0: Check#lt;S#91;#quot;Type#quot;#93;#gt;, ...checks: Check#lt;S#91;#quot;Type#quot;#93;#gt;#91;#93;#41; =#gt; #40;self: S#41; =#gt; S#91;#quot;Rebuild#quot;#93;<br/>node: Schema.check"/]
+  40[/"type: Filter#lt;number#gt;<br/>node: Schema.isInt#40;#41;"/]
+  41[/"type: Number<br/>node: Schema.Number"/]
+  42["type: Number<br/>callee: refine<br/>args: #91;integer#40;#41;#93;"]
+  43[/"type: #lt;S extends Top#gt;#40;checks_0: Check#lt;S#91;#quot;Type#quot;#93;#gt;, ...checks: Check#lt;S#91;#quot;Type#quot;#93;#gt;#91;#93;#41; =#gt; #40;self: S#41; =#gt; S#91;#quot;Rebuild#quot;#93;<br/>node: refine"/]
+  44[/"type: Filter#lt;number#gt;<br/>node: integer#40;#41;"/]
+  45[/"type: Number<br/>node: Schema.Number"/]
+  46["type: Number<br/>callee: Schema.annotate<br/>args: #91;#123; description: #quot;a#quot; #125;#93;"]
+  47[/"type: #lt;S extends Top#gt;#40;annotations: Bottom#lt;S#91;#quot;Type#quot;#93;, S#91;#quot;~type.parameters#quot;#93;#gt;#41; =#gt; #40;self: S#41; =#gt; S#91;#quot;Rebuild#quot;#93;<br/>node: Schema.annotate"/]
+  48[/"type: #123; description: string; #125;<br/>node: #123; description: #quot;a#quot; #125;"/]
+  49["type: Number<br/>callee: Schema.check<br/>args: #91;Schema.isFinite#40;#41;#93;"]
+  50[/"type: #lt;S extends Top#gt;#40;checks_0: Check#lt;S#91;#quot;Type#quot;#93;#gt;, ...checks: Check#lt;S#91;#quot;Type#quot;#93;#gt;#91;#93;#41; =#gt; #40;self: S#41; =#gt; S#91;#quot;Rebuild#quot;#93;<br/>node: Schema.check"/]
+  51[/"type: Filter#lt;number#gt;<br/>node: Schema.isFinite#40;#41;"/]
+  52["type: Struct#lt;#123; readonly finite: Number; readonly integer: Number; readonly importedFinite: Number; readonly importedInteger: Number; readonly annotated: Number; readonly annotatedPredicate: Number; readonly pipedFinite: Number; readonly pipedInteger: Number; readonly pipedImported: Number; readonly pipedAnnotated: Number; #125;#gt;<br/>callee: Schema.Struct<br/>args: #91;#93;"]
+  53[/"type: #lt;const Fields extends Struct.Fields#gt;#40;fields: Fields#41; =#gt; Struct#lt;Fields#gt;<br/>node: Schema.Struct"/]
+  54[/"type: Number<br/>node: Schema.Number"/]
   0 -->|"kind: pipe"| 1
   2 -->|"kind: transformCallee"| 1
   3 -->|"kind: pipe"| 4
@@ -54,17 +72,35 @@ flowchart TB
   19 -->|"kind: pipe"| 20
   21 -->|"kind: transformCallee"| 20
   20 -->|"kind: usedBy"| 9
-  24 -->|"kind: transformCallee"| 23
-  25 -->|"kind: transformArg"| 23
   22 -->|"kind: pipe"| 23
+  25 -->|"kind: pipe"| 26
+  27 -->|"kind: transformCallee"| 26
+  26 -->|"kind: usedBy"| 24
+  24 -->|"kind: transformCallee"| 23
   23 -->|"kind: usedBy"| 9
-  28 -->|"kind: transformCallee"| 27
-  29 -->|"kind: transformArg"| 27
-  26 -->|"kind: pipe"| 27
-  27 -->|"kind: usedBy"| 9
+  28 -->|"kind: pipe"| 29
+  30 -->|"kind: transformCallee"| 29
+  29 -->|"kind: pipe"| 31
   32 -->|"kind: transformCallee"| 31
-  33 -->|"kind: transformArg"| 31
-  30 -->|"kind: pipe"| 31
   31 -->|"kind: usedBy"| 9
-  9 -->|"kind: pipe"| 34
   35 -->|"kind: transformCallee"| 34
+  36 -->|"kind: transformArg"| 34
+  33 -->|"kind: pipe"| 34
+  34 -->|"kind: usedBy"| 9
+  39 -->|"kind: transformCallee"| 38
+  40 -->|"kind: transformArg"| 38
+  37 -->|"kind: pipe"| 38
+  38 -->|"kind: usedBy"| 9
+  43 -->|"kind: transformCallee"| 42
+  44 -->|"kind: transformArg"| 42
+  41 -->|"kind: pipe"| 42
+  42 -->|"kind: usedBy"| 9
+  47 -->|"kind: transformCallee"| 46
+  48 -->|"kind: transformArg"| 46
+  45 -->|"kind: pipe"| 46
+  50 -->|"kind: transformCallee"| 49
+  51 -->|"kind: transformArg"| 49
+  46 -->|"kind: pipe"| 49
+  49 -->|"kind: usedBy"| 9
+  9 -->|"kind: pipe"| 52
+  53 -->|"kind: transformCallee"| 52

--- a/testdata/baselines/reference/effect-v4/schemaNumber.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/schemaNumber.pipings.txt
@@ -1,4 +1,4 @@
-==== /.src/schemaNumber.ts (3 flows) ====
+==== /.src/schemaNumber.ts (11 flows) ====
 
 === Piping Flow ===
 Location: 7:20 - 12:3
@@ -41,3 +41,115 @@ Transformations (1):
       callee: Schema.Struct
       args: (constant)
       outType: Struct<{ readonly quantity: Number; readonly amount: NumberFromString; }>
+
+=== Piping Flow ===
+Location: 24:27 - 32:3
+Node: Schema.Struct({\n  finite: Schema.Number.check(Schema.isFinite()),\n  integer: Schema.Number.check(Schema.isInt()),\n  importedFinite: Schema.Number.check(isFinite()),\n  importedInteger: Schema.Number.check(integer()),\n  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),\n  pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),\n  pipedImported: Schema.Number.pipe(refine(integer()))\n})
+Node Kind: KindCallExpression
+
+Subject: {\n  finite: Schema.Number.check(Schema.isFinite()),\n  integer: Schema.Number.check(Schema.isInt()),\n  importedFinite: Schema.Number.check(isFinite()),\n  importedInteger: Schema.Number.check(integer()),\n  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),\n  pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),\n  pipedImported: Schema.Number.pipe(refine(integer()))\n}
+Subject Type: { finite: Number; integer: Number; importedFinite: Number; importedInteger: Number; pipedFinite: Number; pipedInteger: Number; pipedImported: Number; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.Struct
+      args: (constant)
+      outType: Struct<{ readonly finite: Number; readonly integer: Number; readonly importedFinite: Number; readonly importedInteger: Number; readonly pipedFinite: Number; readonly pipedInteger: Number; readonly pipedImported: Number; }>
+
+=== Piping Flow ===
+Location: 25:10 - 25:49
+Node: Schema.Number.check(Schema.isFinite())
+Node Kind: KindCallExpression
+
+Subject: Schema.isFinite()
+Subject Type: Filter<number>
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.Number.check
+      args: (constant)
+      outType: Number
+
+=== Piping Flow ===
+Location: 26:11 - 26:47
+Node: Schema.Number.check(Schema.isInt())
+Node Kind: KindCallExpression
+
+Subject: Schema.isInt()
+Subject Type: Filter<number>
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.Number.check
+      args: (constant)
+      outType: Number
+
+=== Piping Flow ===
+Location: 27:18 - 27:50
+Node: Schema.Number.check(isFinite())
+Node Kind: KindCallExpression
+
+Subject: isFinite()
+Subject Type: Filter<number>
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.Number.check
+      args: (constant)
+      outType: Number
+
+=== Piping Flow ===
+Location: 28:19 - 28:50
+Node: Schema.Number.check(integer())
+Node Kind: KindCallExpression
+
+Subject: integer()
+Subject Type: Filter<number>
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.Number.check
+      args: (constant)
+      outType: Number
+
+=== Piping Flow ===
+Location: 29:15 - 29:67
+Node: Schema.Number.pipe(Schema.check(Schema.isFinite()))
+Node Kind: KindCallExpression
+
+Subject: Schema.Number
+Subject Type: Number
+
+Transformations (1):
+  [0] kind: pipeable
+      callee: Schema.check
+      args: [Schema.isFinite()]
+      outType: Number
+
+=== Piping Flow ===
+Location: 30:16 - 30:65
+Node: Schema.Number.pipe(Schema.check(Schema.isInt()))
+Node Kind: KindCallExpression
+
+Subject: Schema.Number
+Subject Type: Number
+
+Transformations (1):
+  [0] kind: pipeable
+      callee: Schema.check
+      args: [Schema.isInt()]
+      outType: Number
+
+=== Piping Flow ===
+Location: 31:17 - 31:55
+Node: Schema.Number.pipe(refine(integer()))
+Node Kind: KindCallExpression
+
+Subject: Schema.Number
+Subject Type: Number
+
+Transformations (1):
+  [0] kind: pipeable
+      callee: refine
+      args: [integer()]
+      outType: Number

--- a/testdata/baselines/reference/effect-v4/schemaNumber.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/schemaNumber.pipings.txt
@@ -1,4 +1,4 @@
-==== /.src/schemaNumber.ts (11 flows) ====
+==== /.src/schemaNumber.ts (15 flows) ====
 
 === Piping Flow ===
 Location: 7:20 - 12:3
@@ -43,18 +43,18 @@ Transformations (1):
       outType: Struct<{ readonly quantity: Number; readonly amount: NumberFromString; }>
 
 === Piping Flow ===
-Location: 24:27 - 32:3
-Node: Schema.Struct({\n  finite: Schema.Number.check(Schema.isFinite()),\n  integer: Schema.Number.check(Schema.isInt()),\n  importedFinite: Schema.Number.check(isFinite()),\n  importedInteger: Schema.Number.check(integer()),\n  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),\n  pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),\n  pipedImported: Schema.Number.pipe(refine(integer()))\n})
+Location: 24:27 - 38:3
+Node: Schema.Struct({\n  finite: Schema.Number.check(Schema.isFinite()),\n  integer: Schema.Number.check(Schema.isInt()),\n  importedFinite: Schema.Number.check(isFinite()),\n  importedInteger: Schema.Number.check(integer()),\n  annotated: Schema.Number.annotate({ description: "a" }).check(Schema.isFinite()),\n  annotatedPredicate: Schema.Number.check(Schema.isFinite({ description: "a" })),\n  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),\n  pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),\n  pipedImported: Schema.Number.pipe(refine(integer())),\n  pipedAnnotated: Schema.Number.pipe(\n    Schema.annotate({ description: "a" }),\n    Schema.check(Schema.isFinite())\n  )\n})
 Node Kind: KindCallExpression
 
-Subject: {\n  finite: Schema.Number.check(Schema.isFinite()),\n  integer: Schema.Number.check(Schema.isInt()),\n  importedFinite: Schema.Number.check(isFinite()),\n  importedInteger: Schema.Number.check(integer()),\n  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),\n  pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),\n  pipedImported: Schema.Number.pipe(refine(integer()))\n}
-Subject Type: { finite: Number; integer: Number; importedFinite: Number; importedInteger: Number; pipedFinite: Number; pipedInteger: Number; pipedImported: Number; }
+Subject: {\n  finite: Schema.Number.check(Schema.isFinite()),\n  integer: Schema.Number.check(Schema.isInt()),\n  importedFinite: Schema.Number.check(isFinite()),\n  importedInteger: Schema.Number.check(integer()),\n  annotated: Schema.Number.annotate({ description: "a" }).check(Schema.isFinite()),\n  annotatedPredicate: Schema.Number.check(Schema.isFinite({ description: "a" })),\n  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),\n  pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),\n  pipedImported: Schema.Number.pipe(refine(integer())),\n  pipedAnnotated: Schema.Number.pipe(\n    Schema.annotate({ description: "a" }),\n    Schema.check(Schema.isFinite())\n  )\n}
+Subject Type: { finite: Number; integer: Number; importedFinite: Number; importedInteger: Number; annotated: Number; annotatedPredicate: Number; pipedFinite: Number; pipedInteger: Number; pipedImported: Number; pipedAnnotated: Number; }
 
 Transformations (1):
   [0] kind: call
       callee: Schema.Struct
       args: (constant)
-      outType: Struct<{ readonly finite: Number; readonly integer: Number; readonly importedFinite: Number; readonly importedInteger: Number; readonly pipedFinite: Number; readonly pipedInteger: Number; readonly pipedImported: Number; }>
+      outType: Struct<{ readonly finite: Number; readonly integer: Number; readonly importedFinite: Number; readonly importedInteger: Number; readonly annotated: Number; readonly annotatedPredicate: Number; readonly pipedFinite: Number; readonly pipedInteger: Number; readonly pipedImported: Number; readonly pipedAnnotated: Number; }>
 
 === Piping Flow ===
 Location: 25:10 - 25:49
@@ -113,7 +113,53 @@ Transformations (1):
       outType: Number
 
 === Piping Flow ===
-Location: 29:15 - 29:67
+Location: 29:13 - 29:58
+Node: Schema.Number.annotate({ description: "a" })
+Node Kind: KindCallExpression
+
+Subject: { description: "a" }
+Subject Type: { description: string; }
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.Number.annotate
+      args: (constant)
+      outType: Number
+
+=== Piping Flow ===
+Location: 29:13 - 29:83
+Node: Schema.Number.annotate({ description: "a" }).check(Schema.isFinite())
+Node Kind: KindCallExpression
+
+Subject: Schema.isFinite()
+Subject Type: Filter<number>
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.Number.annotate({ description: "a" }).check
+      args: (constant)
+      outType: Number
+
+=== Piping Flow ===
+Location: 30:22 - 30:81
+Node: Schema.Number.check(Schema.isFinite({ description: "a" }))
+Node Kind: KindCallExpression
+
+Subject: { description: "a" }
+Subject Type: { description: string; }
+
+Transformations (2):
+  [0] kind: call
+      callee: Schema.isFinite
+      args: (constant)
+      outType: Filter<number>
+  [1] kind: call
+      callee: Schema.Number.check
+      args: (constant)
+      outType: Number
+
+=== Piping Flow ===
+Location: 31:15 - 31:67
 Node: Schema.Number.pipe(Schema.check(Schema.isFinite()))
 Node Kind: KindCallExpression
 
@@ -127,7 +173,7 @@ Transformations (1):
       outType: Number
 
 === Piping Flow ===
-Location: 30:16 - 30:65
+Location: 32:16 - 32:65
 Node: Schema.Number.pipe(Schema.check(Schema.isInt()))
 Node Kind: KindCallExpression
 
@@ -141,7 +187,7 @@ Transformations (1):
       outType: Number
 
 === Piping Flow ===
-Location: 31:17 - 31:55
+Location: 33:17 - 33:55
 Node: Schema.Number.pipe(refine(integer()))
 Node Kind: KindCallExpression
 
@@ -152,4 +198,22 @@ Transformations (1):
   [0] kind: pipeable
       callee: refine
       args: [integer()]
+      outType: Number
+
+=== Piping Flow ===
+Location: 34:18 - 37:4
+Node: Schema.Number.pipe(\n    Schema.annotate({ description: "a" }),\n    Schema.check(Schema.isFinite())\n  )
+Node Kind: KindCallExpression
+
+Subject: Schema.Number
+Subject Type: Number
+
+Transformations (2):
+  [0] kind: pipeable
+      callee: Schema.annotate
+      args: [{ description: "a" }]
+      outType: Number
+  [1] kind: pipeable
+      callee: Schema.check
+      args: [Schema.isFinite()]
       outType: Number

--- a/testdata/baselines/reference/effect-v4/schemaNumber.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/schemaNumber.quickfixes.txt
@@ -43,7 +43,7 @@ skipped by default
 
 import { Schema } from "effect"
 import * as SchemaModule from "effect/Schema"
-import { Number as NumberSchema, NumberFromString } from "effect/Schema"
+import { check as refine, isFinite, isInt as integer, Number as NumberSchema, NumberFromString } from "effect/Schema"
 
 export const user = Schema.Struct({
   age: Schema.Finite,
@@ -62,6 +62,15 @@ export const direct = Schema.Struct({
   amount: NumberFromString
 })
 
+export const refinements = Schema.Struct({
+  finite: Schema.Number.check(Schema.isFinite()),
+  integer: Schema.Number.check(Schema.isInt()),
+  importedFinite: Schema.Number.check(isFinite()),
+  importedInteger: Schema.Number.check(integer()),
+  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),
+  pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),
+  pipedImported: Schema.Number.pipe(refine(integer()))
+})
 // @effect-diagnostics-next-line schemaNumber:off
 export const intentionallyNonFinite = Schema.Number
 
@@ -79,7 +88,7 @@ skipped by default
 
 import { Schema } from "effect"
 import * as SchemaModule from "effect/Schema"
-import { Number as NumberSchema, NumberFromString } from "effect/Schema"
+import { check as refine, isFinite, isInt as integer, Number as NumberSchema, NumberFromString } from "effect/Schema"
 
 export const user = Schema.Struct({
   age: Schema.Number,
@@ -98,6 +107,15 @@ export const direct = Schema.Struct({
   amount: NumberFromString
 })
 
+export const refinements = Schema.Struct({
+  finite: Schema.Number.check(Schema.isFinite()),
+  integer: Schema.Number.check(Schema.isInt()),
+  importedFinite: Schema.Number.check(isFinite()),
+  importedInteger: Schema.Number.check(integer()),
+  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),
+  pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),
+  pipedImported: Schema.Number.pipe(refine(integer()))
+})
 // @effect-diagnostics-next-line schemaNumber:off
 export const intentionallyNonFinite = Schema.Number
 
@@ -115,7 +133,7 @@ skipped by default
 
 import { Schema } from "effect"
 import * as SchemaModule from "effect/Schema"
-import { Number as NumberSchema, NumberFromString } from "effect/Schema"
+import { check as refine, isFinite, isInt as integer, Number as NumberSchema, NumberFromString } from "effect/Schema"
 
 export const user = Schema.Struct({
   age: Schema.Number,
@@ -134,6 +152,15 @@ export const direct = Schema.Struct({
   amount: NumberFromString
 })
 
+export const refinements = Schema.Struct({
+  finite: Schema.Number.check(Schema.isFinite()),
+  integer: Schema.Number.check(Schema.isInt()),
+  importedFinite: Schema.Number.check(isFinite()),
+  importedInteger: Schema.Number.check(integer()),
+  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),
+  pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),
+  pipedImported: Schema.Number.pipe(refine(integer()))
+})
 // @effect-diagnostics-next-line schemaNumber:off
 export const intentionallyNonFinite = Schema.Number
 
@@ -151,7 +178,7 @@ skipped by default
 
 import { Schema } from "effect"
 import * as SchemaModule from "effect/Schema"
-import { Number as NumberSchema, NumberFromString } from "effect/Schema"
+import { check as refine, isFinite, isInt as integer, Number as NumberSchema, NumberFromString } from "effect/Schema"
 
 export const user = Schema.Struct({
   age: Schema.Number,
@@ -170,6 +197,15 @@ export const direct = Schema.Struct({
   amount: NumberFromString
 })
 
+export const refinements = Schema.Struct({
+  finite: Schema.Number.check(Schema.isFinite()),
+  integer: Schema.Number.check(Schema.isInt()),
+  importedFinite: Schema.Number.check(isFinite()),
+  importedInteger: Schema.Number.check(integer()),
+  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),
+  pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),
+  pipedImported: Schema.Number.pipe(refine(integer()))
+})
 // @effect-diagnostics-next-line schemaNumber:off
 export const intentionallyNonFinite = Schema.Number
 

--- a/testdata/baselines/reference/effect-v4/schemaNumber.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/schemaNumber.quickfixes.txt
@@ -67,9 +67,15 @@ export const refinements = Schema.Struct({
   integer: Schema.Number.check(Schema.isInt()),
   importedFinite: Schema.Number.check(isFinite()),
   importedInteger: Schema.Number.check(integer()),
+  annotated: Schema.Number.annotate({ description: "a" }).check(Schema.isFinite()),
+  annotatedPredicate: Schema.Number.check(Schema.isFinite({ description: "a" })),
   pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),
   pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),
-  pipedImported: Schema.Number.pipe(refine(integer()))
+  pipedImported: Schema.Number.pipe(refine(integer())),
+  pipedAnnotated: Schema.Number.pipe(
+    Schema.annotate({ description: "a" }),
+    Schema.check(Schema.isFinite())
+  )
 })
 // @effect-diagnostics-next-line schemaNumber:off
 export const intentionallyNonFinite = Schema.Number
@@ -112,9 +118,15 @@ export const refinements = Schema.Struct({
   integer: Schema.Number.check(Schema.isInt()),
   importedFinite: Schema.Number.check(isFinite()),
   importedInteger: Schema.Number.check(integer()),
+  annotated: Schema.Number.annotate({ description: "a" }).check(Schema.isFinite()),
+  annotatedPredicate: Schema.Number.check(Schema.isFinite({ description: "a" })),
   pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),
   pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),
-  pipedImported: Schema.Number.pipe(refine(integer()))
+  pipedImported: Schema.Number.pipe(refine(integer())),
+  pipedAnnotated: Schema.Number.pipe(
+    Schema.annotate({ description: "a" }),
+    Schema.check(Schema.isFinite())
+  )
 })
 // @effect-diagnostics-next-line schemaNumber:off
 export const intentionallyNonFinite = Schema.Number
@@ -157,9 +169,15 @@ export const refinements = Schema.Struct({
   integer: Schema.Number.check(Schema.isInt()),
   importedFinite: Schema.Number.check(isFinite()),
   importedInteger: Schema.Number.check(integer()),
+  annotated: Schema.Number.annotate({ description: "a" }).check(Schema.isFinite()),
+  annotatedPredicate: Schema.Number.check(Schema.isFinite({ description: "a" })),
   pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),
   pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),
-  pipedImported: Schema.Number.pipe(refine(integer()))
+  pipedImported: Schema.Number.pipe(refine(integer())),
+  pipedAnnotated: Schema.Number.pipe(
+    Schema.annotate({ description: "a" }),
+    Schema.check(Schema.isFinite())
+  )
 })
 // @effect-diagnostics-next-line schemaNumber:off
 export const intentionallyNonFinite = Schema.Number
@@ -202,9 +220,15 @@ export const refinements = Schema.Struct({
   integer: Schema.Number.check(Schema.isInt()),
   importedFinite: Schema.Number.check(isFinite()),
   importedInteger: Schema.Number.check(integer()),
+  annotated: Schema.Number.annotate({ description: "a" }).check(Schema.isFinite()),
+  annotatedPredicate: Schema.Number.check(Schema.isFinite({ description: "a" })),
   pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),
   pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),
-  pipedImported: Schema.Number.pipe(refine(integer()))
+  pipedImported: Schema.Number.pipe(refine(integer())),
+  pipedAnnotated: Schema.Number.pipe(
+    Schema.annotate({ description: "a" }),
+    Schema.check(Schema.isFinite())
+  )
 })
 // @effect-diagnostics-next-line schemaNumber:off
 export const intentionallyNonFinite = Schema.Number

--- a/testdata/baselines/reference/effect-v4/schemaNumber_preview.errors.txt
+++ b/testdata/baselines/reference/effect-v4/schemaNumber_preview.errors.txt
@@ -15,8 +15,10 @@ Effect version: 4.0.0
       age: Schema.Number,
                   ~~~~~~
 !!! warning TS377098: This Schema number API accepts `NaN`, `Infinity`, and `-Infinity`. Use `Schema.Finite` for finite domain numbers. If non-finite values are intentional, disable this diagnostic for that line. effect(schemaNumber)
-      score: Schema.NumberFromString
+      score: Schema.NumberFromString,
                     ~~~~~~~~~~~~~~~~
 !!! warning TS377098: This Schema number API accepts `NaN`, `Infinity`, and `-Infinity`. Use `Schema.FiniteFromString` for finite domain numbers. If non-finite values are intentional, disable this diagnostic for that line. effect(schemaNumber)
+      integer: Schema.Number.check(Schema.isInt()),
+      pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite()))
     })
     

--- a/testdata/baselines/reference/effect-v4/schemaNumber_preview.flows.schemaNumber_preview.mermaid
+++ b/testdata/baselines/reference/effect-v4/schemaNumber_preview.flows.schemaNumber_preview.mermaid
@@ -1,6 +1,20 @@
 flowchart TB
-  0[/"type: #123; age: Number; score: NumberFromString; #125;<br/>node: #123;#92;n  age: Schema.Number,#92;n  score: Schema.NumberFromString#92;n#125;"/]
-  1["type: Struct#lt;#123; readonly age: Number; readonly score: NumberFromString; #125;#gt;<br/>callee: Schema.Struct<br/>args: #91;#93;"]
-  2[/"type: #lt;const Fields extends Struct.Fields#gt;#40;fields: Fields#41; =#gt; Struct#lt;Fields#gt;<br/>node: Schema.Struct"/]
-  0 -->|"kind: pipe"| 1
-  2 -->|"kind: transformCallee"| 1
+  0[/"type: #123; age: Number; score: NumberFromString; integer: Number; pipedFinite: Number; #125;<br/>node: #123;#92;n  age: Schema.Number,#92;n  score: Schema.NumberFromString,#92;n  integer: Schema.Number.check#40;Schema.isInt#40;#41;#41;,#92;n  pipedFinite: Schema.Number.pipe#40;Schema.check#40;Schema.isFinite#40;#41;#41;#41;#92;n#125;"/]
+  1[/"type: Filter#lt;number#gt;<br/>node: Schema.isInt#40;#41;"/]
+  2["type: Number<br/>callee: Schema.Number.check<br/>args: #91;#93;"]
+  3[/"type: #40;checks_0: Check#lt;number#gt;, ...checks: Check#lt;number#gt;#91;#93;#41; =#gt; Number<br/>node: Schema.Number.check"/]
+  4[/"type: Number<br/>node: Schema.Number"/]
+  5["type: Number<br/>callee: Schema.check<br/>args: #91;Schema.isFinite#40;#41;#93;"]
+  6[/"type: #lt;S extends Top#gt;#40;checks_0: Check#lt;S#91;#quot;Type#quot;#93;#gt;, ...checks: Check#lt;S#91;#quot;Type#quot;#93;#gt;#91;#93;#41; =#gt; #40;self: S#41; =#gt; S#91;#quot;Rebuild#quot;#93;<br/>node: Schema.check"/]
+  7[/"type: Filter#lt;number#gt;<br/>node: Schema.isFinite#40;#41;"/]
+  8["type: Struct#lt;#123; readonly age: Number; readonly score: NumberFromString; readonly integer: Number; readonly pipedFinite: Number; #125;#gt;<br/>callee: Schema.Struct<br/>args: #91;#93;"]
+  9[/"type: #lt;const Fields extends Struct.Fields#gt;#40;fields: Fields#41; =#gt; Struct#lt;Fields#gt;<br/>node: Schema.Struct"/]
+  1 -->|"kind: pipe"| 2
+  3 -->|"kind: transformCallee"| 2
+  2 -->|"kind: usedBy"| 0
+  6 -->|"kind: transformCallee"| 5
+  7 -->|"kind: transformArg"| 5
+  4 -->|"kind: pipe"| 5
+  5 -->|"kind: usedBy"| 0
+  0 -->|"kind: pipe"| 8
+  9 -->|"kind: transformCallee"| 8

--- a/testdata/baselines/reference/effect-v4/schemaNumber_preview.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/schemaNumber_preview.pipings.txt
@@ -1,15 +1,43 @@
-==== /.src/schemaNumber_preview.ts (1 flows) ====
+==== /.src/schemaNumber_preview.ts (3 flows) ====
 
 === Piping Flow ===
-Location: 6:20 - 9:3
-Node: Schema.Struct({\n  age: Schema.Number,\n  score: Schema.NumberFromString\n})
+Location: 6:20 - 11:3
+Node: Schema.Struct({\n  age: Schema.Number,\n  score: Schema.NumberFromString,\n  integer: Schema.Number.check(Schema.isInt()),\n  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite()))\n})
 Node Kind: KindCallExpression
 
-Subject: {\n  age: Schema.Number,\n  score: Schema.NumberFromString\n}
-Subject Type: { age: Number; score: NumberFromString; }
+Subject: {\n  age: Schema.Number,\n  score: Schema.NumberFromString,\n  integer: Schema.Number.check(Schema.isInt()),\n  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite()))\n}
+Subject Type: { age: Number; score: NumberFromString; integer: Number; pipedFinite: Number; }
 
 Transformations (1):
   [0] kind: call
       callee: Schema.Struct
       args: (constant)
-      outType: Struct<{ readonly age: Number; readonly score: NumberFromString; }>
+      outType: Struct<{ readonly age: Number; readonly score: NumberFromString; readonly integer: Number; readonly pipedFinite: Number; }>
+
+=== Piping Flow ===
+Location: 9:11 - 9:47
+Node: Schema.Number.check(Schema.isInt())
+Node Kind: KindCallExpression
+
+Subject: Schema.isInt()
+Subject Type: Filter<number>
+
+Transformations (1):
+  [0] kind: call
+      callee: Schema.Number.check
+      args: (constant)
+      outType: Number
+
+=== Piping Flow ===
+Location: 10:15 - 10:67
+Node: Schema.Number.pipe(Schema.check(Schema.isFinite()))
+Node Kind: KindCallExpression
+
+Subject: Schema.Number
+Subject Type: Number
+
+Transformations (1):
+  [0] kind: pipeable
+      callee: Schema.check
+      args: [Schema.isFinite()]
+      outType: Number

--- a/testdata/baselines/reference/effect-v4/schemaNumber_preview.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/schemaNumber_preview.quickfixes.txt
@@ -28,7 +28,9 @@ import { Schema } from "effect"
 
 export const User = Schema.Struct({
   age: Schema.Finite,
-  score: Schema.NumberFromString
+  score: Schema.NumberFromString,
+  integer: Schema.Number.check(Schema.isInt()),
+  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite()))
 })
 
 
@@ -48,6 +50,8 @@ import { Schema } from "effect"
 
 export const User = Schema.Struct({
   age: Schema.Number,
-  score: Schema.FiniteFromString
+  score: Schema.FiniteFromString,
+  integer: Schema.Number.check(Schema.isInt()),
+  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite()))
 })
 

--- a/testdata/tests/effect-v4/schemaNumber.ts
+++ b/testdata/tests/effect-v4/schemaNumber.ts
@@ -26,9 +26,15 @@ export const refinements = Schema.Struct({
   integer: Schema.Number.check(Schema.isInt()),
   importedFinite: Schema.Number.check(isFinite()),
   importedInteger: Schema.Number.check(integer()),
+  annotated: Schema.Number.annotate({ description: "a" }).check(Schema.isFinite()),
+  annotatedPredicate: Schema.Number.check(Schema.isFinite({ description: "a" })),
   pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),
   pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),
-  pipedImported: Schema.Number.pipe(refine(integer()))
+  pipedImported: Schema.Number.pipe(refine(integer())),
+  pipedAnnotated: Schema.Number.pipe(
+    Schema.annotate({ description: "a" }),
+    Schema.check(Schema.isFinite())
+  )
 })
 // @effect-diagnostics-next-line schemaNumber:off
 export const intentionallyNonFinite = Schema.Number

--- a/testdata/tests/effect-v4/schemaNumber.ts
+++ b/testdata/tests/effect-v4/schemaNumber.ts
@@ -2,7 +2,7 @@
 
 import { Schema } from "effect"
 import * as SchemaModule from "effect/Schema"
-import { Number as NumberSchema, NumberFromString } from "effect/Schema"
+import { check as refine, isFinite, isInt as integer, Number as NumberSchema, NumberFromString } from "effect/Schema"
 
 export const user = Schema.Struct({
   age: Schema.Number,
@@ -21,5 +21,14 @@ export const direct = Schema.Struct({
   amount: NumberFromString
 })
 
+export const refinements = Schema.Struct({
+  finite: Schema.Number.check(Schema.isFinite()),
+  integer: Schema.Number.check(Schema.isInt()),
+  importedFinite: Schema.Number.check(isFinite()),
+  importedInteger: Schema.Number.check(integer()),
+  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite())),
+  pipedInteger: Schema.Number.pipe(Schema.check(Schema.isInt())),
+  pipedImported: Schema.Number.pipe(refine(integer()))
+})
 // @effect-diagnostics-next-line schemaNumber:off
 export const intentionallyNonFinite = Schema.Number

--- a/testdata/tests/effect-v4/schemaNumber_preview.ts
+++ b/testdata/tests/effect-v4/schemaNumber_preview.ts
@@ -5,5 +5,7 @@ import { Schema } from "effect"
 
 export const User = Schema.Struct({
   age: Schema.Number,
-  score: Schema.NumberFromString
+  score: Schema.NumberFromString,
+  integer: Schema.Number.check(Schema.isInt()),
+  pipedFinite: Schema.Number.pipe(Schema.check(Schema.isFinite()))
 })


### PR DESCRIPTION
## Summary

- suppress schemaNumber diagnostics when Schema.Number is refined with Schema.isFinite() or Schema.isInt()
- recognize both Schema.Number.check(...) and Schema.Number.pipe(Schema.check(...)) forms
- tolerate intermediate schema annotations and annotations passed to finite predicates
- resolve namespace and aliased imports and avoid offering redundant quick fixes
- add regression coverage and update generated metadata and rule documentation

## Examples

These no longer report schemaNumber:

```ts
Schema.Number.check(Schema.isFinite())
Schema.Number.check(Schema.isFinite({ description: "a" }))
Schema.Number.annotate({ description: "a" }).check(Schema.isFinite())
Schema.Number.pipe(
  Schema.annotate({ description: "a" }),
  Schema.check(Schema.isFinite())
)
```

The same behavior applies to Schema.isInt().

## Validation

- pnpm setup-repo
- pnpm lint
- pnpm check
- pnpm test

Closes #702