### PR TITLE
Remove location parameters from type parsing

### DIFF
--- a/.changeset/type-parser-without-locations.md
+++ b/.changeset/type-parser-without-locations.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": minor
+---
+
+Remove the AST location parameter from type-only `TypeParser` operations. Effect, Layer, Stream, Schema, service, Context.Tag, Scope, and related type predicates now derive instantiated property types directly from the supplied checker type.

--- a/etsgoapi/type_parser.go
+++ b/etsgoapi/type_parser.go
@@ -55,51 +55,51 @@ func (tp *TypeParser) GetTypeAtLocation(node *ast.Node) *checker.Type {
 }
 
 // EffectType parses an Effect type and extracts A, E, R parameters.
-func (tp *TypeParser) EffectType(t *checker.Type, atLocation *ast.Node) *Effect {
+func (tp *TypeParser) EffectType(t *checker.Type) *Effect {
 	if tp == nil || tp.inner == nil {
 		return nil
 	}
-	return effectFromInternal(tp.inner.EffectType(t, atLocation))
+	return effectFromInternal(tp.inner.EffectType(t))
 }
 
 // LayerType parses a Layer type and extracts ROut, E, RIn parameters.
-func (tp *TypeParser) LayerType(t *checker.Type, atLocation *ast.Node) *Layer {
+func (tp *TypeParser) LayerType(t *checker.Type) *Layer {
 	if tp == nil || tp.inner == nil {
 		return nil
 	}
-	return layerFromInternal(tp.inner.LayerType(t, atLocation))
+	return layerFromInternal(tp.inner.LayerType(t))
 }
 
 // ServiceType parses a v4 service type and extracts Identifier and Shape parameters.
-func (tp *TypeParser) ServiceType(t *checker.Type, atLocation *ast.Node) *Service {
+func (tp *TypeParser) ServiceType(t *checker.Type) *Service {
 	if tp == nil || tp.inner == nil {
 		return nil
 	}
-	return serviceFromInternal(tp.inner.ServiceType(t, atLocation))
+	return serviceFromInternal(tp.inner.ServiceType(t))
 }
 
 // ContextTag parses a v3 Context.Tag type and extracts Identifier and Shape parameters.
-func (tp *TypeParser) ContextTag(t *checker.Type, atLocation *ast.Node) *Service {
+func (tp *TypeParser) ContextTag(t *checker.Type) *Service {
 	if tp == nil || tp.inner == nil {
 		return nil
 	}
-	return serviceFromInternal(tp.inner.ContextTag(t, atLocation))
+	return serviceFromInternal(tp.inner.ContextTag(t))
 }
 
 // EffectSchemaTypes extracts the type and encoded type from a Schema type.
-func (tp *TypeParser) EffectSchemaTypes(t *checker.Type, atLocation *ast.Node) *SchemaTypes {
+func (tp *TypeParser) EffectSchemaTypes(t *checker.Type) *SchemaTypes {
 	if tp == nil || tp.inner == nil {
 		return nil
 	}
-	return schemaTypesFromInternal(tp.inner.EffectSchemaTypes(t, atLocation))
+	return schemaTypesFromInternal(tp.inner.EffectSchemaTypes(t))
 }
 
 // StreamType parses a Stream type and extracts A, E, R parameters.
-func (tp *TypeParser) StreamType(t *checker.Type, atLocation *ast.Node) *Effect {
+func (tp *TypeParser) StreamType(t *checker.Type) *Effect {
 	if tp == nil || tp.inner == nil {
 		return nil
 	}
-	return effectFromInternal(tp.inner.StreamType(t, atLocation))
+	return effectFromInternal(tp.inner.StreamType(t))
 }
 
 // UnrollUnionMembers returns the constituent types of a union type,

--- a/etslshooks/document_symbols.go
+++ b/etslshooks/document_symbols.go
@@ -113,7 +113,7 @@ func collectServiceDocumentSymbols(tp *typeparser.TypeParser, c *checker.Checker
 				return false
 			}
 			t := tp.GetTypeAtLocation(current)
-			if tp.IsLayerType(t, current) {
+			if tp.IsLayerType(t) {
 				return false
 			}
 		}
@@ -342,7 +342,7 @@ func debugFlowTransformationText(sf *ast.SourceFile, transformation *typeparser.
 func layerSymbolDetail(tp *typeparser.TypeParser, c *checker.Checker, node *ast.Node) *string {
 	typeCheckNode, types := classificationTypes(tp, c, node)
 	for _, t := range types {
-		layer := tp.LayerType(t, typeCheckNode)
+		layer := tp.LayerType(t)
 		if layer == nil {
 			continue
 		}
@@ -416,22 +416,17 @@ func classificationTypes(tp *typeparser.TypeParser, c *checker.Checker, node *as
 }
 
 func isLayerDeclaration(tp *typeparser.TypeParser, c *checker.Checker, node *ast.Node) bool {
-	typeCheckNode, types := classificationTypes(tp, c, node)
-	for _, t := range types {
-		if tp.IsLayerType(t, typeCheckNode) {
-			return true
-		}
-	}
-	return false
+	_, types := classificationTypes(tp, c, node)
+	return slices.ContainsFunc(types, tp.IsLayerType)
 }
 
 func isServiceDeclaration(tp *typeparser.TypeParser, c *checker.Checker, node *ast.Node) bool {
 	if node == nil {
 		return false
 	}
-	typeCheckNode, types := classificationTypes(tp, c, node)
+	_, types := classificationTypes(tp, c, node)
 	for _, t := range types {
-		if tp.IsServiceType(t, typeCheckNode) || tp.IsContextTag(t, typeCheckNode) {
+		if tp.IsServiceType(t) || tp.IsContextTag(t) {
 			return true
 		}
 	}
@@ -460,13 +455,8 @@ func isSchemaDeclaration(tp *typeparser.TypeParser, c *checker.Checker, node *as
 	default:
 		return false
 	}
-	typeCheckNode, types := classificationTypes(tp, c, node)
-	for _, t := range types {
-		if tp.IsSchemaType(t, typeCheckNode) {
-			return true
-		}
-	}
-	return false
+	_, types := classificationTypes(tp, c, node)
+	return slices.ContainsFunc(types, tp.IsSchemaType)
 }
 
 func resolveErrorDisplayNode(node *ast.Node) *ast.Node {

--- a/etslshooks/init.go
+++ b/etslshooks/init.go
@@ -202,7 +202,7 @@ func afterQuickInfo(program checker.Program, c *checker.Checker, sf *ast.SourceF
 			if tp.GetEffectContextFlags(yieldNode)&typeparser.EffectContextFlagCanYieldEffect != 0 {
 				t := tp.GetTypeAtLocation(yield.Expression)
 				if t != nil {
-					effect := tp.EffectYieldableType(t, yield.Expression)
+					effect := tp.EffectYieldableType(t)
 					if effect != nil {
 						typeStr := c.TypeToStringEx(t, nil, checker.TypeFormatFlagsNoTruncation, nil)
 						quickInfo = "(yield*) " + typeStr
@@ -224,12 +224,12 @@ func afterQuickInfo(program checker.Program, c *checker.Checker, sf *ast.SourceF
 	// Layer extends Effect in V4, so this check must come before the Effect check.
 	// Only activate layer hover enrichment when the cursor is on the name of the declaration,
 	// not on arbitrary nodes within the initializer expression.
-	if tp.IsLayerType(t, node) && isDeclarationName(node) {
+	if tp.IsLayerType(t) && isDeclarationName(node) {
 		documentation = formatLayerHover(tp, c, sf, node, t, documentation, isMarkdown, effectConfig)
 		return quickInfo, documentation, nil
 	}
 
-	effect := tp.EffectType(t, node)
+	effect := tp.EffectType(t)
 	if effect == nil {
 		return quickInfo, documentation, nil
 	}

--- a/internal/effecttest/baseline.go
+++ b/internal/effecttest/baseline.go
@@ -534,7 +534,7 @@ func generateLayerGraphBaseline(
 					continue
 				}
 				t := tp.GetTypeAtLocation(vd.Initializer)
-				if !tp.IsLayerType(t, vd.Initializer) {
+				if !tp.IsLayerType(t) {
 					continue
 				}
 				exports = append(exports, layerExport{

--- a/internal/fixables/floating_effect_yield.go
+++ b/internal/fixables/floating_effect_yield.go
@@ -31,7 +31,7 @@ func runFloatingEffectYieldFix(ctx *fixable.Context) []ls.CodeAction {
 			return nil
 		}
 		exprType := ctx.TypeParser.GetTypeAtLocation(match.Expression)
-		if ctx.TypeParser.EffectYieldableType(exprType, match.Expression) == nil {
+		if ctx.TypeParser.EffectYieldableType(exprType) == nil {
 			return nil
 		}
 

--- a/internal/layergraph/extract.go
+++ b/internal/layergraph/extract.go
@@ -255,7 +255,7 @@ func extractNodeInfo(tp *typeparser.TypeParser, c *checker.Checker, node *ast.No
 	}
 
 	// Parse as Layer type.
-	layer := tp.LayerType(t, node)
+	layer := tp.LayerType(t)
 	if layer == nil {
 		return info
 	}

--- a/internal/refactors/layer_magic.go
+++ b/internal/refactors/layer_magic.go
@@ -104,7 +104,7 @@ func tryBuildRefactor(ctx *refactor.Context, tp *typeparser.TypeParser, c *check
 	if outerType == nil {
 		return nil
 	}
-	layer := tp.LayerType(outerType, outerAs.Type)
+	layer := tp.LayerType(outerType)
 	if layer == nil {
 		return nil
 	}
@@ -284,7 +284,7 @@ func tryPrepareRefactor(ctx *refactor.Context, tp *typeparser.TypeParser, c *che
 	exprType := tp.GetTypeAtLocation(atLocation)
 	var previouslyProvided *checker.Type
 	if exprType != nil {
-		parsedLayer := tp.LayerType(exprType, atLocation)
+		parsedLayer := tp.LayerType(exprType)
 		if parsedLayer != nil {
 			previouslyProvided = parsedLayer.ROut
 		}

--- a/internal/refactors/make_schema_opaque.go
+++ b/internal/refactors/make_schema_opaque.go
@@ -2,12 +2,12 @@ package refactors
 
 import (
 	"github.com/effect-ts/tsgo/internal/refactor"
+	"github.com/effect-ts/tsgo/internal/rewriter"
 	"github.com/effect-ts/tsgo/internal/typeparser"
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/astnav"
 	"github.com/microsoft/TypeScript/tsc/shim/checker"
 	"github.com/microsoft/TypeScript/tsc/shim/ls"
-	"github.com/effect-ts/tsgo/internal/rewriter"
 )
 
 var MakeSchemaOpaque = refactor.Refactor{
@@ -75,7 +75,7 @@ func findSchemaVariableDeclaration(ctx *refactor.Context, _ *checker.Checker) *s
 			continue
 		}
 
-		schemaTypes := ctx.TypeParser.EffectSchemaTypes(initType, varDecl.Initializer)
+		schemaTypes := ctx.TypeParser.EffectSchemaTypes(initType)
 		if schemaTypes == nil {
 			continue
 		}

--- a/internal/refactors/toggle_pipe_style.go
+++ b/internal/refactors/toggle_pipe_style.go
@@ -4,11 +4,11 @@ import (
 	"strings"
 
 	"github.com/effect-ts/tsgo/internal/refactor"
+	"github.com/effect-ts/tsgo/internal/rewriter"
 	"github.com/effect-ts/tsgo/internal/typeparser"
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/astnav"
 	"github.com/microsoft/TypeScript/tsc/shim/ls"
-	"github.com/effect-ts/tsgo/internal/rewriter"
 	"github.com/microsoft/TypeScript/tsc/shim/lsp/lsproto"
 	"github.com/microsoft/TypeScript/tsc/shim/scanner"
 )
@@ -42,7 +42,7 @@ func runTogglePipeStyle(ctx *refactor.Context) []ls.CodeAction {
 			// pipe(subject, f1, f2) -> subject.pipe(f1, f2)
 			// Check that the subject's type is pipeable
 			subjectType := ctx.TypeParser.GetTypeAtLocation(pipeCall.Subject)
-			if !ctx.TypeParser.IsPipeableType(subjectType, pipeCall.Subject) {
+			if !ctx.TypeParser.IsPipeableType(subjectType) {
 				continue
 			}
 

--- a/internal/refactors/wrap_with_effect_gen.go
+++ b/internal/refactors/wrap_with_effect_gen.go
@@ -2,11 +2,11 @@ package refactors
 
 import (
 	"github.com/effect-ts/tsgo/internal/refactor"
+	"github.com/effect-ts/tsgo/internal/rewriter"
 	"github.com/effect-ts/tsgo/internal/typeparser"
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/astnav"
 	"github.com/microsoft/TypeScript/tsc/shim/ls"
-	"github.com/effect-ts/tsgo/internal/rewriter"
 	"github.com/microsoft/TypeScript/tsc/shim/lsp/lsproto"
 )
 
@@ -45,7 +45,7 @@ func runWrapWithEffectGen(ctx *refactor.Context) []ls.CodeAction {
 		if nodeType == nil {
 			continue
 		}
-		if !ctx.TypeParser.StrictIsEffectType(nodeType, node) {
+		if !ctx.TypeParser.StrictIsEffectType(nodeType) {
 			continue
 		}
 		if ctx.TypeParser.EffectGenCall(node) != nil {

--- a/internal/refactors/write_tag_class_accessors.go
+++ b/internal/refactors/write_tag_class_accessors.go
@@ -4,13 +4,13 @@ import (
 	"strings"
 
 	"github.com/effect-ts/tsgo/internal/refactor"
+	"github.com/effect-ts/tsgo/internal/rewriter"
 	"github.com/effect-ts/tsgo/internal/typeparser"
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/astnav"
 	"github.com/microsoft/TypeScript/tsc/shim/checker"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
 	"github.com/microsoft/TypeScript/tsc/shim/ls"
-	"github.com/effect-ts/tsgo/internal/rewriter"
 	"github.com/microsoft/TypeScript/tsc/shim/scanner"
 )
 
@@ -84,7 +84,7 @@ func runWriteTagClassAccessors(ctx *refactor.Context) []ls.CodeAction {
 		return nil
 	}
 
-	contextTag := ctx.TypeParser.ContextTag(classType, classNode)
+	contextTag := ctx.TypeParser.ContextTag(classType)
 	if contextTag == nil || contextTag.Shape == nil {
 		return nil
 	}
@@ -334,7 +334,7 @@ func buildWrappedReturnTypeText(
 	effectIdentifier string,
 ) string {
 	// Try to parse as Effect type
-	effect := tp.EffectType(returnType, classNode)
+	effect := tp.EffectType(returnType)
 	if effect != nil {
 		aStr := c.TypeToStringEx(effect.A, classNode, checker.TypeFormatFlagsNoTruncation, nil)
 		eStr := c.TypeToStringEx(effect.E, classNode, checker.TypeFormatFlagsNoTruncation, nil)

--- a/internal/rules/acquire_release_disposable.go
+++ b/internal/rules/acquire_release_disposable.go
@@ -119,7 +119,7 @@ func analyzeAcquireReleaseDisposableCall(
 		return AcquireReleaseDisposableMatch{}, false
 	}
 
-	result := tp.StrictEffectType(tp.GetTypeAtLocation(node), node)
+	result := tp.StrictEffectType(tp.GetTypeAtLocation(node))
 	if result == nil || !isDefinitelyDisposable(tp, c, result.A, disposable) {
 		return AcquireReleaseDisposableMatch{}, false
 	}

--- a/internal/rules/all_of_map_to_for_each.go
+++ b/internal/rules/all_of_map_to_for_each.go
@@ -104,7 +104,7 @@ func analyzeAllOfMapToForEachCall(tp *typeparser.TypeParser, c *checker.Checker,
 
 	callback := mapCall.Arguments.Nodes[0]
 	mapResultType := tp.GetTypeAtLocation(mapNode)
-	if mapResultType == nil || tp.EffectType(c.GetNumberIndexType(mapResultType), callback) == nil {
+	if mapResultType == nil || tp.EffectType(c.GetNumberIndexType(mapResultType)) == nil {
 		return AllOfMapToForEachMatch{}, false
 	}
 

--- a/internal/rules/any_unknown_in_error_context.go
+++ b/internal/rules/any_unknown_in_error_context.go
@@ -69,10 +69,10 @@ var AnyUnknownInErrorContext = rule.Rule{
 				if typeNode := node.Type(); typeNode != nil {
 					annotationType := ctx.TypeParser.GetTypeAtLocation(typeNode)
 					if annotationType != nil {
-						if ctx.TypeParser.StrictEffectType(annotationType, typeNode) != nil {
+						if ctx.TypeParser.StrictEffectType(annotationType) != nil {
 							continue
 						}
-						if ctx.TypeParser.LayerType(annotationType, typeNode) != nil {
+						if ctx.TypeParser.LayerType(annotationType) != nil {
 							continue
 						}
 					}
@@ -98,10 +98,10 @@ var AnyUnknownInErrorContext = rule.Rule{
 
 			// Try strict Effect type first, then Layer type
 			var eType, rType *checker.Type
-			if eff := ctx.TypeParser.StrictEffectType(t, node); eff != nil {
+			if eff := ctx.TypeParser.StrictEffectType(t); eff != nil {
 				eType = eff.E
 				rType = eff.R
-			} else if layer := ctx.TypeParser.LayerType(t, node); layer != nil {
+			} else if layer := ctx.TypeParser.LayerType(t); layer != nil {
 				eType = layer.E
 				rType = layer.RIn
 			}

--- a/internal/rules/catch_chain_to_first_success_of.go
+++ b/internal/rules/catch_chain_to_first_success_of.go
@@ -84,7 +84,7 @@ func AnalyzeCatchChainToFirstSuccessOf(tp *typeparser.TypeParser, c *checker.Che
 				if i > 0 {
 					inputType = flow.Transformations[i-1].OutType
 				}
-				inputEffect := tp.StrictEffectType(inputType, transformation.Callee)
+				inputEffect := tp.StrictEffectType(inputType)
 				if inputEffect == nil || inputEffect.E == nil {
 					flush()
 					continue
@@ -92,7 +92,7 @@ func AnalyzeCatchChainToFirstSuccessOf(tp *typeparser.TypeParser, c *checker.Che
 				initialError = inputEffect.E
 			}
 
-			outputEffect := tp.StrictEffectType(transformation.OutType, transformation.Callee)
+			outputEffect := tp.StrictEffectType(transformation.OutType)
 			if outputEffect == nil || outputEffect.E == nil {
 				flush()
 				continue
@@ -127,7 +127,7 @@ func analyzeCatchChainToFirstSuccessOfCandidate(tp *typeparser.TypeParser, c *ch
 		return catchChainToFirstSuccessOfCandidate{}, false
 	}
 
-	fallbackType := tp.StrictEffectType(c.GetReturnTypeOfSignature(signatures[0]), lazy.Expression)
+	fallbackType := tp.StrictEffectType(c.GetReturnTypeOfSignature(signatures[0]))
 	if fallbackType == nil || fallbackType.E == nil {
 		return catchChainToFirstSuccessOfCandidate{}, false
 	}

--- a/internal/rules/catch_conditional_refail_to_catch_if.go
+++ b/internal/rules/catch_conditional_refail_to_catch_if.go
@@ -84,7 +84,7 @@ func AnalyzeCatchConditionalRefailToCatchIf(tp *typeparser.TypeParser, c *checke
 			if index > 0 {
 				inputType = flow.Transformations[index-1].OutType
 			}
-			if tp.StrictEffectType(inputType, transformation.Callee) == nil {
+			if tp.StrictEffectType(inputType) == nil {
 				continue
 			}
 

--- a/internal/rules/catch_die_to_or_die.go
+++ b/internal/rules/catch_die_to_or_die.go
@@ -69,7 +69,7 @@ func AnalyzeCatchDieToOrDie(tp *typeparser.TypeParser, _ *checker.Checker, sf *a
 			if ok && len(args) == 1 {
 				handler, _, _ := tp.UnwrapIdentityForwarder(args[0])
 				if tp.IsNodeReferenceToEffectModuleApi(handler, "die") {
-					inputEffect := tp.StrictEffectType(inputType, callee)
+					inputEffect := tp.StrictEffectType(inputType)
 					if inputEffect != nil && inputEffect.E != nil && inputEffect.E.Flags()&checker.TypeFlagsNever == 0 {
 						if _, duplicate := seen[transformation.Node]; !duplicate {
 							seen[transformation.Node] = struct{}{}

--- a/internal/rules/catch_tag_to_catch_reason.go
+++ b/internal/rules/catch_tag_to_catch_reason.go
@@ -393,7 +393,7 @@ func uniqueCatchReasonParameterName(c *checker.Checker, location *ast.Node) stri
 }
 
 func isEffectExpression(tp *typeparser.TypeParser, expression *ast.Node) bool {
-	return expression != nil && tp.EffectType(tp.GetTypeAtLocation(expression), expression) != nil
+	return expression != nil && tp.EffectType(tp.GetTypeAtLocation(expression)) != nil
 }
 
 func hasCatchReasonApi(tp *typeparser.TypeParser, c *checker.Checker, callee *ast.Node, branchCount int) bool {

--- a/internal/rules/catch_to_ignore.go
+++ b/internal/rules/catch_to_ignore.go
@@ -68,7 +68,7 @@ func AnalyzeCatchToIgnore(tp *typeparser.TypeParser, _ *checker.Checker, sf *ast
 				continue
 			}
 
-			effect := tp.StrictEffectType(transformation.OutType, transformation.Node)
+			effect := tp.StrictEffectType(transformation.OutType)
 			if effect == nil || !isVoidLikeEffectSuccess(effect.A) {
 				continue
 			}

--- a/internal/rules/catch_unfailable_effect.go
+++ b/internal/rules/catch_unfailable_effect.go
@@ -44,7 +44,7 @@ var CatchUnfailableEffect = rule.Rule{
 				}
 
 				// Parse input type as an Effect
-				effect := ctx.TypeParser.EffectType(inputType, transformation.Callee)
+				effect := ctx.TypeParser.EffectType(inputType)
 				if effect == nil {
 					continue
 				}

--- a/internal/rules/effect_in_failure.go
+++ b/internal/rules/effect_in_failure.go
@@ -73,14 +73,14 @@ var EffectInFailure = rule.Rule{
 				continue
 			}
 
-			effect := ctx.TypeParser.StrictEffectType(nodeType, node)
+			effect := ctx.TypeParser.StrictEffectType(nodeType)
 			if effect == nil {
 				continue
 			}
 
 			// Check if any union member of the failure channel (E) is a strict Effect type
 			failureMembers := ctx.TypeParser.UnrollUnionMembers(effect.E)
-			memberWithEffect := findFirstStrictEffect(ctx.TypeParser, ctx.Checker, failureMembers, node)
+			memberWithEffect := findFirstStrictEffect(ctx.TypeParser, ctx.Checker, failureMembers)
 			if memberWithEffect == nil {
 				continue
 			}

--- a/internal/rules/effect_in_void_success.go
+++ b/internal/rules/effect_in_void_success.go
@@ -28,12 +28,12 @@ var EffectInVoidSuccess = rule.Rule{
 				continue
 			}
 
-			realEffect := ctx.TypeParser.EffectType(entry.RealType, entry.ValueNode)
+			realEffect := ctx.TypeParser.EffectType(entry.RealType)
 			if realEffect == nil {
 				continue
 			}
 
-			expectedEffect := ctx.TypeParser.EffectType(entry.ExpectedType, entry.Node)
+			expectedEffect := ctx.TypeParser.EffectType(entry.ExpectedType)
 			if expectedEffect == nil {
 				continue
 			}
@@ -46,7 +46,7 @@ var EffectInVoidSuccess = rule.Rule{
 			// Unroll the real Effect's success type into union members
 			// and check if any member is strictly an Effect type
 			members := ctx.TypeParser.UnrollUnionMembers(realEffect.A)
-			voidedEffect := findFirstStrictEffect(ctx.TypeParser, ctx.Checker, members, entry.Node)
+			voidedEffect := findFirstStrictEffect(ctx.TypeParser, ctx.Checker, members)
 			if voidedEffect != nil {
 				diag := ctx.NewDiagnostic(ctx.SourceFile, ctx.GetErrorRange(entry.Node), tsdiag.There_is_a_nested_0_in_the_void_success_channel_beware_that_this_could_lead_to_nested_Effect_Effect_that_won_t_be_executed_effect_effectInVoidSuccess, nil, ctx.Checker.TypeToString(voidedEffect))
 				diags = append(diags, diag)
@@ -59,9 +59,9 @@ var EffectInVoidSuccess = rule.Rule{
 
 // findFirstStrictEffect returns the first type in the slice that is strictly an Effect type,
 // or nil if none are found. This mirrors the Nano.firstSuccessOf pattern in the TS reference.
-func findFirstStrictEffect(tp *typeparser.TypeParser, _ *checker.Checker, types []*checker.Type, atLocation *ast.Node) *checker.Type {
+func findFirstStrictEffect(tp *typeparser.TypeParser, _ *checker.Checker, types []*checker.Type) *checker.Type {
 	for _, t := range types {
-		if tp.StrictIsEffectType(t, atLocation) {
+		if tp.StrictIsEffectType(t) {
 			return t
 		}
 	}

--- a/internal/rules/floating_effect.go
+++ b/internal/rules/floating_effect.go
@@ -111,27 +111,27 @@ func detectFloatingEffect(tp *typeparser.TypeParser, _ *checker.Checker, node *a
 		return nil
 	}
 
-	if tp.HasEffectTypeId(t, expr) {
+	if tp.HasEffectTypeId(t) {
 		// Full Effect validation.
-		if !tp.IsEffectType(t, expr) {
+		if !tp.IsEffectType(t) {
 			return nil
 		}
 
 		// Exclude Fiber types (considered valid floating operations)
-		if tp.IsFiberType(t, expr) {
+		if tp.IsFiberType(t) {
 			return nil
 		}
 
 		// Exclude Effect subtypes (Exit, Option, Either, Pool, etc.)
-		if tp.IsEffectSubtype(t, expr) {
+		if tp.IsEffectSubtype(t) {
 			return nil
 		}
-	} else if tp.StreamType(t, expr) == nil {
+	} else if tp.StreamType(t) == nil {
 		return nil
 	}
 
 	// Determine if this is strictly an Effect or an Effect-able type
-	isStrict := tp.StrictIsEffectType(t, expr)
+	isStrict := tp.StrictIsEffectType(t)
 	return &floatingEffectResult{
 		isStrict: isStrict,
 		exprType: t,

--- a/internal/rules/floating_effect_in_vitest.go
+++ b/internal/rules/floating_effect_in_vitest.go
@@ -221,7 +221,7 @@ func vitestCallbackReturnsEffect(c *checker.Checker, tp *typeparser.TypeParser, 
 
 func vitestReturnTypeContainsEffect(c *checker.Checker, tp *typeparser.TypeParser, returnType *checker.Type, atLocation *ast.Node, depth int) bool {
 	for _, member := range tp.UnrollUnionMembers(returnType) {
-		if tp.StrictIsEffectType(member, atLocation) {
+		if tp.StrictIsEffectType(member) {
 			return true
 		}
 		if depth == 0 && tp.PromiseType(member) != nil {

--- a/internal/rules/generic_effect_services.go
+++ b/internal/rules/generic_effect_services.go
@@ -44,7 +44,7 @@ var GenericEffectServices = rule.Rule{
 					classSym := ctx.TypeParser.GetSymbolAtLocation(node.Name())
 					if classSym != nil {
 						classType := ctx.Checker.GetTypeOfSymbolAtLocation(classSym, node)
-						if classType != nil && ctx.TypeParser.IsContextTag(classType, node) {
+						if classType != nil && ctx.TypeParser.IsContextTag(classType) {
 							diags = append(diags, ctx.NewDiagnostic(ctx.SourceFile, ctx.GetErrorRange(node.Name()), tsdiag.Effect_Services_with_type_parameters_are_not_supported_because_they_cannot_be_properly_discriminated_at_runtime_which_may_cause_unexpected_behavior_effect_genericEffectServices, nil))
 							continue // skip children
 						}

--- a/internal/rules/global_error_in_effect_failure.go
+++ b/internal/rules/global_error_in_effect_failure.go
@@ -63,7 +63,7 @@ func checkGlobalErrorInEffectFailure(ctx *rule.Context, node *ast.Node) *ast.Dia
 			return ast.FindAncestorFalse
 		}
 
-		effectType := ctx.TypeParser.EffectType(currentType, current)
+		effectType := ctx.TypeParser.EffectType(currentType)
 		if effectType == nil {
 			return ast.FindAncestorFalse
 		}

--- a/internal/rules/instance_of_schema.go
+++ b/internal/rules/instance_of_schema.go
@@ -61,7 +61,7 @@ func AnalyzeInstanceOfSchema(tp *typeparser.TypeParser, _ *checker.Checker, sf *
 			binExpr := node.AsBinaryExpression()
 			rightExpr := binExpr.Right
 			rightType := tp.GetTypeAtLocation(rightExpr)
-			if rightType != nil && tp.IsSchemaType(rightType, rightExpr) {
+			if rightType != nil && tp.IsSchemaType(rightType) {
 				matches = append(matches, InstanceOfSchemaMatch{
 					SourceFile:     sf,
 					Location:       scanner.GetErrorRangeForNode(sf, node),

--- a/internal/rules/layer_merge_all_with_dependencies.go
+++ b/internal/rules/layer_merge_all_with_dependencies.go
@@ -114,7 +114,7 @@ func analyzeLayerMergeAllCall(tp *typeparser.TypeParser, c *checker.Checker, sf 
 			continue
 		}
 
-		layer := tp.LayerType(argType, arg)
+		layer := tp.LayerType(argType)
 		if layer == nil {
 			continue
 		}

--- a/internal/rules/lazy_effect.go
+++ b/internal/rules/lazy_effect.go
@@ -59,7 +59,7 @@ func checkLazyEffectInterface(ctx *rule.Context, stmt *ast.Node) []*ast.Diagnost
 		}
 
 		memberType := ctx.TypeParser.GetTypeAtLocation(member.Name())
-		lazyTypeName, ok := lazyEffectLikeTypeName(ctx.Checker, ctx.TypeParser, memberType, member.Name())
+		lazyTypeName, ok := lazyEffectLikeTypeName(ctx.Checker, ctx.TypeParser, memberType)
 		if !ok {
 			continue
 		}
@@ -111,7 +111,7 @@ func checkLazyEffectExport(ctx *rule.Context, stmt *ast.Node) []*ast.Diagnostic 
 
 func lazyEffectDiagnosticForExportedDeclaration(ctx *rule.Context, name *ast.Node) []*ast.Diagnostic {
 	declType := ctx.TypeParser.GetTypeAtLocation(name)
-	lazyTypeName, ok := lazyEffectLikeTypeName(ctx.Checker, ctx.TypeParser, declType, name)
+	lazyTypeName, ok := lazyEffectLikeTypeName(ctx.Checker, ctx.TypeParser, declType)
 	if !ok {
 		return nil
 	}
@@ -144,7 +144,7 @@ func checkLazyEffectService(ctx *rule.Context, stmt *ast.Node) []*ast.Diagnostic
 		return nil
 	}
 
-	service := ctx.TypeParser.ServiceType(classType, stmt.Name())
+	service := ctx.TypeParser.ServiceType(classType)
 	if service == nil || service.Shape == nil {
 		return nil
 	}
@@ -157,7 +157,7 @@ func checkLazyEffectService(ctx *rule.Context, stmt *ast.Node) []*ast.Diagnostic
 		}
 
 		memberType := ctx.Checker.GetTypeOfSymbolAtLocation(member, stmt.Name())
-		lazyTypeName, ok := lazyEffectLikeTypeName(ctx.Checker, ctx.TypeParser, memberType, stmt.Name())
+		lazyTypeName, ok := lazyEffectLikeTypeName(ctx.Checker, ctx.TypeParser, memberType)
 		if !ok {
 			continue
 		}
@@ -176,7 +176,7 @@ func checkLazyEffectService(ctx *rule.Context, stmt *ast.Node) []*ast.Diagnostic
 	return diags
 }
 
-func lazyEffectLikeTypeName(c *checker.Checker, tp *typeparser.TypeParser, t *checker.Type, atLocation *ast.Node) (string, bool) {
+func lazyEffectLikeTypeName(c *checker.Checker, tp *typeparser.TypeParser, t *checker.Type) (string, bool) {
 	if c == nil || tp == nil || t == nil {
 		return "", false
 	}
@@ -199,13 +199,13 @@ func lazyEffectLikeTypeName(c *checker.Checker, tp *typeparser.TypeParser, t *ch
 		return "", false
 	}
 
-	if tp.StrictIsEffectType(returnType, atLocation) {
+	if tp.StrictIsEffectType(returnType) {
 		return "Effect", true
 	}
-	if tp.LayerType(returnType, atLocation) != nil {
+	if tp.LayerType(returnType) != nil {
 		return "Layer", true
 	}
-	if tp.StreamType(returnType, atLocation) != nil {
+	if tp.StreamType(returnType) != nil {
 		return "Stream", true
 	}
 

--- a/internal/rules/leaking_requirements.go
+++ b/internal/rules/leaking_requirements.go
@@ -86,9 +86,9 @@ var LeakingRequirements = rule.Rule{
 			matched := false
 			for _, ttc := range typesToCheck {
 				// Try ContextTag first, fall back to ServiceType
-				service := ctx.TypeParser.ContextTag(ttc.t, node)
+				service := ctx.TypeParser.ContextTag(ttc.t)
 				if service == nil {
-					service = ctx.TypeParser.ServiceType(ttc.t, node)
+					service = ctx.TypeParser.ServiceType(ttc.t)
 				}
 				if service == nil {
 					continue
@@ -221,7 +221,7 @@ func parseLeakedRequirements(tp *typeparser.TypeParser, c *checker.Checker, serv
 			return true
 		}
 		// Exclude Scope types
-		if tp.IsScopeType(t, atLocation) {
+		if tp.IsScopeType(t) {
 			return true
 		}
 		return false
@@ -241,7 +241,7 @@ func parseLeakedRequirements(tp *typeparser.TypeParser, c *checker.Checker, serv
 		// or from the return type of a single call signature
 		var effectContextType *checker.Type
 
-		effect := tp.EffectType(servicePropertyType, atLocation)
+		effect := tp.EffectType(servicePropertyType)
 		if effect != nil {
 			effectContextType = effect.R
 		} else {
@@ -250,7 +250,7 @@ func parseLeakedRequirements(tp *typeparser.TypeParser, c *checker.Checker, serv
 			if len(sigs) == 1 {
 				retType := c.GetReturnTypeOfSignature(sigs[0])
 				if retType != nil {
-					retEffect := tp.EffectType(retType, atLocation)
+					retEffect := tp.EffectType(retType)
 					if retEffect != nil {
 						effectContextType = retEffect.R
 					}

--- a/internal/rules/missed_pipeable_opportunity.go
+++ b/internal/rules/missed_pipeable_opportunity.go
@@ -152,14 +152,14 @@ func isPipeableAtIndex(tp *typeparser.TypeParser, flow *typeparser.PipingFlow, i
 		if subjectType == nil {
 			return false
 		}
-		return tp.IsPipeableType(subjectType, flow.Subject.Node)
+		return tp.IsPipeableType(subjectType)
 	}
 
 	t := flow.Transformations[index-1]
 	if t.OutType == nil {
 		return false
 	}
-	return tp.IsPipeableType(t.OutType, flow.Node)
+	return tp.IsPipeableType(t.OutType)
 }
 
 // getSubjectText extracts the subject text for the diagnostic message.

--- a/internal/rules/missing_effect_context.go
+++ b/internal/rules/missing_effect_context.go
@@ -31,8 +31,8 @@ var MissingEffectContext = rule.Rule{
 
 		for _, re := range ctx.Checker.GetRelationErrors(ctx.SourceFile) {
 			// Parse both types as Effects
-			srcEffect := ctx.TypeParser.EffectType(re.Source, re.ErrorNode)
-			tgtEffect := ctx.TypeParser.EffectType(re.Target, re.ErrorNode)
+			srcEffect := ctx.TypeParser.EffectType(re.Source)
+			tgtEffect := ctx.TypeParser.EffectType(re.Target)
 
 			// Both must be Effect types
 			if srcEffect == nil || tgtEffect == nil {
@@ -212,7 +212,7 @@ func rootLayerProvidesTypes(tp *typeparser.TypeParser, c *checker.Checker, layer
 	if c == nil || layerNode == nil {
 		return nil
 	}
-	layerType := tp.LayerType(tp.GetTypeAtLocation(layerNode), layerNode)
+	layerType := tp.LayerType(tp.GetTypeAtLocation(layerNode))
 	if layerType == nil {
 		return nil
 	}

--- a/internal/rules/missing_effect_error.go
+++ b/internal/rules/missing_effect_error.go
@@ -52,8 +52,8 @@ func AnalyzeMissingEffectError(tp *typeparser.TypeParser, c *checker.Checker, sf
 
 	for _, re := range c.GetRelationErrors(sf) {
 		// Parse both types as Effects
-		srcEffect := tp.EffectType(re.Source, re.ErrorNode)
-		tgtEffect := tp.EffectType(re.Target, re.ErrorNode)
+		srcEffect := tp.EffectType(re.Source)
+		tgtEffect := tp.EffectType(re.Target)
 
 		// Both must be Effect types
 		if srcEffect == nil || tgtEffect == nil {

--- a/internal/rules/missing_effect_service_dependency.go
+++ b/internal/rules/missing_effect_service_dependency.go
@@ -98,7 +98,7 @@ func checkServiceDependencies(ctx *rule.Context, node *ast.Node) []*ast.Diagnost
 	}
 
 	// Parse as Layer type to get RIn
-	layer := ctx.TypeParser.LayerType(defaultType, node)
+	layer := ctx.TypeParser.LayerType(defaultType)
 	if layer == nil {
 		return nil
 	}
@@ -133,7 +133,7 @@ func checkServiceDependencies(ctx *rule.Context, node *ast.Node) []*ast.Diagnost
 						depTypes := ctx.TypeParser.UnrollUnionMembers(numberIndexType)
 						for _, depType := range depTypes {
 							// Parse each dependency as Layer type
-							depLayer := ctx.TypeParser.LayerType(depType, options)
+							depLayer := ctx.TypeParser.LayerType(depType)
 							if depLayer != nil {
 								// Add the ROut of this dependency to provided services
 								providedResult := ctx.TypeParser.AppendToUniqueTypesMap(servicesMemory, depLayer.ROut, excludeNever)

--- a/internal/rules/missing_layer_context.go
+++ b/internal/rules/missing_layer_context.go
@@ -28,8 +28,8 @@ var MissingLayerContext = rule.Rule{
 
 		for _, re := range ctx.Checker.GetRelationErrors(ctx.SourceFile) {
 			// Parse both types as Layers
-			srcLayer := ctx.TypeParser.LayerType(re.Source, re.ErrorNode)
-			tgtLayer := ctx.TypeParser.LayerType(re.Target, re.ErrorNode)
+			srcLayer := ctx.TypeParser.LayerType(re.Source)
+			tgtLayer := ctx.TypeParser.LayerType(re.Target)
 
 			// Both must be Layer types
 			if srcLayer == nil || tgtLayer == nil {

--- a/internal/rules/missing_return_yield_star.go
+++ b/internal/rules/missing_return_yield_star.go
@@ -90,7 +90,7 @@ func shouldReportMissingReturnYieldStar(tp *typeparser.TypeParser, c *checker.Ch
 	if t == nil {
 		return false
 	}
-	effect := tp.EffectYieldableType(t, expr.AsNode())
+	effect := tp.EffectYieldableType(t)
 	if effect == nil || effect.A == nil {
 		return false
 	}

--- a/internal/rules/multiple_catch_tag.go
+++ b/internal/rules/multiple_catch_tag.go
@@ -131,10 +131,10 @@ func analyzeMultipleCatchTagCandidate(tp *typeparser.TypeParser, c *checker.Chec
 		return multipleCatchTagCandidate{}, false
 	}
 
-		errorChannel := catchTagReturnErrorChannel(tp, returnType, transformation.Args[1])
-		if errorChannel == nil {
-			return multipleCatchTagCandidate{}, false
-		}
+	errorChannel := catchTagReturnErrorChannel(tp, returnType)
+	if errorChannel == nil {
+		return multipleCatchTagCandidate{}, false
+	}
 
 	return multipleCatchTagCandidate{
 		transformation: transformation,
@@ -143,14 +143,14 @@ func analyzeMultipleCatchTagCandidate(tp *typeparser.TypeParser, c *checker.Chec
 	}, true
 }
 
-func catchTagReturnErrorChannel(tp *typeparser.TypeParser, returnType *checker.Type, atLocation *ast.Node) *checker.Type {
+func catchTagReturnErrorChannel(tp *typeparser.TypeParser, returnType *checker.Type) *checker.Type {
 	if tp == nil || returnType == nil {
 		return nil
 	}
-	if effectType := tp.EffectType(returnType, atLocation); effectType != nil {
+	if effectType := tp.EffectType(returnType); effectType != nil {
 		return effectType.E
 	}
-	if streamType := tp.StreamType(returnType, atLocation); streamType != nil {
+	if streamType := tp.StreamType(returnType); streamType != nil {
 		return streamType.E
 	}
 	return nil

--- a/internal/rules/multiple_effect_provide.go
+++ b/internal/rules/multiple_effect_provide.go
@@ -112,7 +112,7 @@ func AnalyzeMultipleEffectProvide(tp *typeparser.TypeParser, _ *checker.Checker,
 				continue
 			}
 
-			if tp.LayerType(argType, arg) == nil {
+			if tp.LayerType(argType) == nil {
 				// provide call but not with a Layer argument — breaks the chain
 				finalizeChunk()
 				continue

--- a/internal/rules/new_schema_class.go
+++ b/internal/rules/new_schema_class.go
@@ -90,7 +90,7 @@ func isV4SchemaClassExpression(tp *typeparser.TypeParser, c *checker.Checker, ex
 	}
 
 	t := tp.GetTypeAtLocation(expr)
-	if t == nil || !tp.IsSchemaType(t, expr) {
+	if t == nil || !tp.IsSchemaType(t) {
 		return false
 	}
 

--- a/internal/rules/non_object_effect_service_type.go
+++ b/internal/rules/non_object_effect_service_type.go
@@ -130,7 +130,7 @@ func checkServicePropertyTypes(ctx *rule.Context, node *ast.Node) []*ast.Diagnos
 			}
 
 			// Try direct EffectType parse first
-			effectResult := ctx.TypeParser.EffectType(valueType, initializer)
+			effectResult := ctx.TypeParser.EffectType(valueType)
 			if effectResult != nil {
 				if isPrimitiveType(ctx.TypeParser, effectResult.A) {
 					diags = append(diags, ctx.NewDiagnostic(
@@ -150,7 +150,7 @@ func checkServicePropertyTypes(ctx *rule.Context, node *ast.Node) []*ast.Diagnos
 				if returnType == nil {
 					continue
 				}
-				effectReturnResult := ctx.TypeParser.EffectType(returnType, initializer)
+				effectReturnResult := ctx.TypeParser.EffectType(returnType)
 				if effectReturnResult != nil && isPrimitiveType(ctx.TypeParser, effectReturnResult.A) {
 					diags = append(diags, ctx.NewDiagnostic(
 						ctx.SourceFile,

--- a/internal/rules/overridden_schema_constructor.go
+++ b/internal/rules/overridden_schema_constructor.go
@@ -78,7 +78,7 @@ func checkOverriddenSchemaConstructor(tp *typeparser.TypeParser, _ *checker.Chec
 		}
 		expr := elem.AsExpressionWithTypeArguments().Expression
 		t := tp.GetTypeAtLocation(expr)
-		if t != nil && tp.IsSchemaType(t, expr) {
+		if t != nil && tp.IsSchemaType(t) {
 			extendsSchema = true
 			break
 		}

--- a/internal/rules/prefer_typed_schema_decoder.go
+++ b/internal/rules/prefer_typed_schema_decoder.go
@@ -134,7 +134,7 @@ func analyzeTypedSchemaDecoderApplication(tp *typeparser.TypeParser, c *checker.
 		return nil
 	}
 
-	schemaType := tp.EffectSchemaTypes(tp.GetTypeAtLocation(schema), schema)
+	schemaType := tp.EffectSchemaTypes(tp.GetTypeAtLocation(schema))
 	if schemaType == nil || schemaType.E == nil {
 		return nil
 	}

--- a/internal/rules/prefer_unsafe_constructor.go
+++ b/internal/rules/prefer_unsafe_constructor.go
@@ -119,7 +119,7 @@ func analyzePreferUnsafeConstructorNode(tp *typeparser.TypeParser, c *checker.Ch
 
 	// The constructor call must produce an `Effect<A, never, never>`: a fallible or
 	// service-requiring effect has no behavior-preserving synchronous replacement.
-	eff := tp.EffectType(tp.GetTypeAtLocation(inner), inner)
+	eff := tp.EffectType(tp.GetTypeAtLocation(inner))
 	if eff == nil || eff.A == nil {
 		return PreferUnsafeConstructorMatch{}, false
 	}

--- a/internal/rules/promise_in_effect_success.go
+++ b/internal/rules/promise_in_effect_success.go
@@ -80,7 +80,7 @@ var PromiseInEffectSuccess = rule.Rule{
 			if t == nil {
 				t = ctx.TypeParser.GetTypeAtLocation(node)
 			}
-			effect := ctx.TypeParser.StrictEffectType(t, node)
+			effect := ctx.TypeParser.StrictEffectType(t)
 			if effect == nil || !typeContainsPromise(ctx.TypeParser, effect.A) {
 				continue
 			}
@@ -114,9 +114,9 @@ func hasExplicitPromiseEffectContext(tp *typeparser.TypeParser, c *checker.Check
 	for current := node; current != nil; current = current.Parent {
 		switch current.Kind {
 		case ast.KindVariableDeclaration, ast.KindPropertyDeclaration, ast.KindParameter:
-			return isExplicitPromiseEffectType(tp, current.Type(), current)
+			return isExplicitPromiseEffectType(tp, current.Type())
 		case ast.KindAsExpression, ast.KindSatisfiesExpression:
-			if isExplicitPromiseEffectType(tp, current.Type(), current) {
+			if isExplicitPromiseEffectType(tp, current.Type()) {
 				return true
 			}
 		case ast.KindArrowFunction, ast.KindFunctionExpression, ast.KindFunctionDeclaration, ast.KindMethodDeclaration:
@@ -132,16 +132,16 @@ func hasExplicitPromiseEffectContext(tp *typeparser.TypeParser, c *checker.Check
 	return false
 }
 
-func isExplicitPromiseEffectType(tp *typeparser.TypeParser, typeNode *ast.Node, atLocation *ast.Node) bool {
+func isExplicitPromiseEffectType(tp *typeparser.TypeParser, typeNode *ast.Node) bool {
 	if typeNode == nil {
 		return false
 	}
-	effect := tp.StrictEffectType(tp.GetTypeAtLocation(typeNode), atLocation)
+	effect := tp.StrictEffectType(tp.GetTypeAtLocation(typeNode))
 	return effect != nil && typeContainsPromise(tp, effect.A)
 }
 
 func hasExplicitPromiseEffectReturn(tp *typeparser.TypeParser, c *checker.Checker, function *ast.Node) bool {
-	if isExplicitPromiseEffectType(tp, function.Type(), function) {
+	if isExplicitPromiseEffectType(tp, function.Type()) {
 		return true
 	}
 	parent := function.Parent
@@ -158,7 +158,7 @@ func hasExplicitPromiseEffectReturn(tp *typeparser.TypeParser, c *checker.Checke
 	t := tp.GetTypeAtLocation(typeNode)
 	for _, member := range tp.UnrollUnionMembers(t) {
 		for _, signature := range c.GetSignaturesOfType(member, checker.SignatureKindCall) {
-			result := tp.StrictEffectType(c.GetReturnTypeOfSignature(signature), function)
+			result := tp.StrictEffectType(c.GetReturnTypeOfSignature(signature))
 			if result != nil && typeContainsPromise(tp, result.A) {
 				return true
 			}

--- a/internal/rules/return_effect_in_gen.go
+++ b/internal/rules/return_effect_in_gen.go
@@ -89,7 +89,7 @@ func checkReturnEffectInGenScope(tp *typeparser.TypeParser, _ *checker.Checker, 
 		return false
 	}
 
-	if !tp.StrictIsEffectType(t, returnStmt.Expression) {
+	if !tp.StrictIsEffectType(t) {
 		return false
 	}
 

--- a/internal/rules/scope_in_layer_effect.go
+++ b/internal/rules/scope_in_layer_effect.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/effect-ts/tsgo/etscore"
@@ -64,7 +65,7 @@ func AnalyzeScopeInLayerEffect(tp *typeparser.TypeParser, c *checker.Checker, sf
 
 		// Pattern 1: Layer.effect*() calls
 		if node.Kind == ast.KindCallExpression {
-			if m := matchLayerEffectCall(tp, c, sf, node); m != nil {
+			if m := matchLayerEffectCall(tp, sf, node); m != nil {
 				matches = append(matches, *m)
 				continue // skip children
 			}
@@ -86,7 +87,7 @@ func AnalyzeScopeInLayerEffect(tp *typeparser.TypeParser, c *checker.Checker, sf
 }
 
 // matchLayerEffectCall checks if a call expression is Layer.effect*() with Scope in RIn.
-func matchLayerEffectCall(tp *typeparser.TypeParser, c *checker.Checker, sf *ast.SourceFile, node *ast.Node) *ScopeInLayerEffectMatch {
+func matchLayerEffectCall(tp *typeparser.TypeParser, sf *ast.SourceFile, node *ast.Node) *ScopeInLayerEffectMatch {
 	if node.Kind != ast.KindCallExpression {
 		return nil
 	}
@@ -118,13 +119,13 @@ func matchLayerEffectCall(tp *typeparser.TypeParser, c *checker.Checker, sf *ast
 	}
 
 	// Parse as Layer type
-	layer := tp.LayerType(t, node)
+	layer := tp.LayerType(t)
 	if layer == nil {
 		return nil
 	}
 
 	// Check if RIn contains a Scope type
-	if !hasScope(tp, c, layer.RIn, node) {
+	if !hasScope(tp, layer.RIn) {
 		return nil
 	}
 
@@ -172,13 +173,13 @@ func matchClassWithDefaultLayer(tp *typeparser.TypeParser, c *checker.Checker, s
 	}
 
 	// Parse as Layer type
-	layer := tp.LayerType(defaultType, node)
+	layer := tp.LayerType(defaultType)
 	if layer == nil {
 		return nil
 	}
 
 	// Check if RIn contains a Scope type
-	if !hasScope(tp, c, layer.RIn, node) {
+	if !hasScope(tp, layer.RIn) {
 		return nil
 	}
 
@@ -190,12 +191,7 @@ func matchClassWithDefaultLayer(tp *typeparser.TypeParser, c *checker.Checker, s
 }
 
 // hasScope checks if any union member of the given type is a Scope type.
-func hasScope(tp *typeparser.TypeParser, _ *checker.Checker, t *checker.Type, atLocation *ast.Node) bool {
+func hasScope(tp *typeparser.TypeParser, t *checker.Type) bool {
 	members := tp.UnrollUnionMembers(t)
-	for _, member := range members {
-		if tp.IsScopeType(member, atLocation) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(members, tp.IsScopeType)
 }

--- a/internal/rules/strict_effect_provide.go
+++ b/internal/rules/strict_effect_provide.go
@@ -67,7 +67,7 @@ func checkEffectProvideWithLayer(ctx *rule.Context, node *ast.Node) *ast.Diagnos
 		if argType == nil {
 			continue
 		}
-		if ctx.TypeParser.LayerType(argType, arg) != nil {
+		if ctx.TypeParser.LayerType(argType) != nil {
 			// Found a Layer argument — emit diagnostic on the call expression
 			return ctx.NewDiagnostic(ctx.SourceFile, ctx.GetErrorRange(node), tsdiag.Effect_provide_with_a_Layer_should_only_be_used_at_application_entry_points_If_this_is_an_entry_point_you_can_safely_disable_this_diagnostic_Otherwise_using_Effect_provide_may_break_scope_lifetimes_Compose_all_layers_at_your_entry_point_and_provide_them_at_once_effect_strictEffectProvide, nil)
 		}

--- a/internal/rules/unnecessary_effect_gen.go
+++ b/internal/rules/unnecessary_effect_gen.go
@@ -124,7 +124,7 @@ func analyzeUnnecessaryEffectGenNode(tp *typeparser.TypeParser, _ *checker.Check
 	successIsVoid := false
 	t := tp.GetTypeAtLocation(yieldedExpr)
 	if t != nil {
-		effect := tp.EffectType(t, yieldedExpr)
+		effect := tp.EffectType(t)
 		if effect != nil && effect.A != nil {
 			successIsVoid = effect.A.Flags()&checker.TypeFlagsVoidLike != 0
 		}

--- a/internal/rules/unsafe_effect_type_assertion.go
+++ b/internal/rules/unsafe_effect_type_assertion.go
@@ -54,14 +54,14 @@ func AnalyzeUnsafeEffectTypeAssertion(tp *typeparser.TypeParser, c *checker.Chec
 	}
 
 	var matches []UnsafeEffectTypeAssertionMatch
-	parseEffectStreamOrLayer := func(t *checker.Type, atLocation *ast.Node) (e *checker.Type, r *checker.Type, ok bool) {
-		if effect := tp.EffectType(t, atLocation); effect != nil {
+	parseEffectStreamOrLayer := func(t *checker.Type) (e *checker.Type, r *checker.Type, ok bool) {
+		if effect := tp.EffectType(t); effect != nil {
 			return effect.E, effect.R, true
 		}
-		if stream := tp.StreamType(t, atLocation); stream != nil {
+		if stream := tp.StreamType(t); stream != nil {
 			return stream.E, stream.R, true
 		}
-		if layer := tp.LayerType(t, atLocation); layer != nil {
+		if layer := tp.LayerType(t); layer != nil {
 			return layer.E, layer.RIn, true
 		}
 		return nil, nil, false
@@ -93,12 +93,12 @@ func AnalyzeUnsafeEffectTypeAssertion(tp *typeparser.TypeParser, c *checker.Chec
 			continue
 		}
 
-		originalE, originalR, ok := parseEffectStreamOrLayer(originalType, expr)
+		originalE, originalR, ok := parseEffectStreamOrLayer(originalType)
 		if !ok {
 			continue
 		}
 
-		assertedE, assertedR, ok := parseEffectStreamOrLayer(assertedType, node)
+		assertedE, assertedR, ok := parseEffectStreamOrLayer(assertedType)
 		if !ok {
 			continue
 		}

--- a/internal/schemagen/structural.go
+++ b/internal/schemagen/structural.go
@@ -576,7 +576,7 @@ func (g *StructuralSchemaGen) ScanExistingSchemas(scope *ast.Node) {
 		if t == nil {
 			continue
 		}
-		schemaTypes := g.TypeParser.EffectSchemaTypes(t, scope)
+		schemaTypes := g.TypeParser.EffectSchemaTypes(t)
 		if schemaTypes == nil {
 			continue
 		}

--- a/internal/typeparser/context_tag.go
+++ b/internal/typeparser/context_tag.go
@@ -10,7 +10,7 @@ import (
 
 // ContextTag parses a v3 Context.Tag type and extracts Identifier, Shape parameters.
 // Returns nil if the type is not a v3 Context.Tag.
-func (tp *TypeParser) ContextTag(t *checker.Type, atLocation *ast.Node) *Service {
+func (tp *TypeParser) ContextTag(t *checker.Type) *Service {
 	if tp == nil || tp.checker == nil || t == nil {
 		return nil
 	}
@@ -18,7 +18,7 @@ func (tp *TypeParser) ContextTag(t *checker.Type, atLocation *ast.Node) *Service
 		if tp.DetectEffectVersion() != EffectMajorV3 {
 			return nil
 		}
-		if !tp.IsPipeableType(t, atLocation) {
+		if !tp.IsPipeableType(t) {
 			return nil
 		}
 
@@ -56,7 +56,7 @@ func (tp *TypeParser) ContextTag(t *checker.Type, atLocation *ast.Node) *Service
 		})
 
 		for _, prop := range candidates {
-			propType := tp.checker.GetTypeOfSymbolAtLocation(prop, atLocation)
+			propType := tp.checker.GetTypeOfSymbolAtLocation(prop, nil)
 			if result := tp.parseServiceVarianceStruct(propType); result != nil {
 				return result
 			}
@@ -67,6 +67,6 @@ func (tp *TypeParser) ContextTag(t *checker.Type, atLocation *ast.Node) *Service
 }
 
 // IsContextTag returns true if the type has the Context.Tag variance struct.
-func (tp *TypeParser) IsContextTag(t *checker.Type, atLocation *ast.Node) bool {
-	return tp.ContextTag(t, atLocation) != nil
+func (tp *TypeParser) IsContextTag(t *checker.Type) bool {
+	return tp.ContextTag(t) != nil
 }

--- a/internal/typeparser/effect_fn_opportunity.go
+++ b/internal/typeparser/effect_fn_opportunity.go
@@ -125,7 +125,7 @@ func (tp *TypeParser) parseEffectFnOpportunityInner(node *ast.Node) *EffectFnOpp
 		return nil
 	}
 	for _, member := range unionMembers {
-		if tp.StrictEffectType(member, node) == nil {
+		if tp.StrictEffectType(member) == nil {
 			return nil
 		}
 	}
@@ -723,7 +723,7 @@ func (tp *TypeParser) tryMatchOfInference(objectLiteral *ast.Node) string {
 	if serviceTagType == nil {
 		return ""
 	}
-	if !tp.IsContextTag(serviceTagType, serviceTagExpression) && !tp.IsServiceType(serviceTagType, serviceTagExpression) {
+	if !tp.IsContextTag(serviceTagType) && !tp.IsServiceType(serviceTagType) {
 		return ""
 	}
 	return layerServiceNameFromExpression(serviceTagExpression)

--- a/internal/typeparser/effect_type.go
+++ b/internal/typeparser/effect_type.go
@@ -27,7 +27,7 @@ type Effect struct {
 // Returns nil if the type is not an Effect.
 // The detection strategy is chosen based on the detected Effect version:
 // v4 uses direct symbol lookup, v3/unknown uses property iteration.
-func (tp *TypeParser) EffectType(t *checker.Type, atLocation *ast.Node) *Effect {
+func (tp *TypeParser) EffectType(t *checker.Type) *Effect {
 	if tp == nil || tp.checker == nil || t == nil {
 		return nil
 	}
@@ -80,7 +80,7 @@ func (tp *TypeParser) EffectType(t *checker.Type, atLocation *ast.Node) *Effect 
 
 		// Try each candidate as a variance struct
 		for _, prop := range candidates {
-			propType := tp.checker.GetTypeOfSymbolAtLocation(prop, atLocation)
+			propType := tp.checker.GetTypeOfSymbolAtLocation(prop, nil)
 			if result := tp.parseVarianceStruct(propType); result != nil {
 				return result
 			}
@@ -111,14 +111,14 @@ func (tp *TypeParser) parseVarianceStruct(t *checker.Type) *Effect {
 }
 
 // IsEffectType returns true if the type has the Effect variance struct.
-func (tp *TypeParser) IsEffectType(t *checker.Type, atLocation *ast.Node) bool {
-	return tp.EffectType(t, atLocation) != nil
+func (tp *TypeParser) IsEffectType(t *checker.Type) bool {
+	return tp.EffectType(t) != nil
 }
 
 // StrictEffectType returns the parsed Effect type only if the type's symbol name
 // is "Effect". This filters out types like Stream, Layer, HttpApp.Default that
 // carry the variance struct but are not Effect itself.
-func (tp *TypeParser) StrictEffectType(t *checker.Type, atLocation *ast.Node) *Effect {
+func (tp *TypeParser) StrictEffectType(t *checker.Type) *Effect {
 	if tp == nil || tp.checker == nil || t == nil {
 		return nil
 	}
@@ -127,20 +127,20 @@ func (tp *TypeParser) StrictEffectType(t *checker.Type, atLocation *ast.Node) *E
 		if sym == nil || sym.Name != "Effect" {
 			return nil
 		}
-		return tp.EffectType(t, atLocation)
+		return tp.EffectType(t)
 	})
 }
 
 // StrictIsEffectType returns true if the type has the Effect variance struct
 // AND the type's symbol name is "Effect". This filters out types like Stream,
 // Layer, HttpApp.Default that carry the variance struct but are not Effect itself.
-func (tp *TypeParser) StrictIsEffectType(t *checker.Type, atLocation *ast.Node) bool {
-	return tp.StrictEffectType(t, atLocation) != nil
+func (tp *TypeParser) StrictIsEffectType(t *checker.Type) bool {
+	return tp.StrictEffectType(t) != nil
 }
 
 // EffectSubtype detects types that have the Effect variance struct AND a "_tag" or "get"
 // marker property (e.g., Exit, Option, Either, Pool). Returns nil if not an Effect subtype.
-func (tp *TypeParser) EffectSubtype(t *checker.Type, atLocation *ast.Node) *Effect {
+func (tp *TypeParser) EffectSubtype(t *checker.Type) *Effect {
 	if tp == nil || tp.checker == nil || t == nil {
 		return nil
 	}
@@ -152,18 +152,18 @@ func (tp *TypeParser) EffectSubtype(t *checker.Type, atLocation *ast.Node) *Effe
 			return nil
 		}
 		// Must also be an Effect type
-		return tp.EffectType(t, atLocation)
+		return tp.EffectType(t)
 	})
 }
 
 // IsEffectSubtype returns true if the type is an Effect subtype (has variance struct + "_tag" or "get").
-func (tp *TypeParser) IsEffectSubtype(t *checker.Type, atLocation *ast.Node) bool {
-	return tp.EffectSubtype(t, atLocation) != nil
+func (tp *TypeParser) IsEffectSubtype(t *checker.Type) bool {
+	return tp.EffectSubtype(t) != nil
 }
 
 // FiberType detects types that have the Effect variance struct AND both "await" and "poll"
 // properties. Returns nil if the type is not a Fiber.
-func (tp *TypeParser) FiberType(t *checker.Type, atLocation *ast.Node) *Effect {
+func (tp *TypeParser) FiberType(t *checker.Type) *Effect {
 	if tp == nil || tp.checker == nil || t == nil {
 		return nil
 	}
@@ -175,19 +175,19 @@ func (tp *TypeParser) FiberType(t *checker.Type, atLocation *ast.Node) *Effect {
 			return nil
 		}
 		// Must also be an Effect type
-		return tp.EffectType(t, atLocation)
+		return tp.EffectType(t)
 	})
 }
 
 // IsFiberType returns true if the type is a Fiber type (has variance struct + "await" and "poll").
-func (tp *TypeParser) IsFiberType(t *checker.Type, atLocation *ast.Node) bool {
-	return tp.FiberType(t, atLocation) != nil
+func (tp *TypeParser) IsFiberType(t *checker.Type) bool {
+	return tp.FiberType(t) != nil
 }
 
 // HasEffectTypeId returns true if the type has the Effect type identifier.
 // For v4, this is a quick check for the "~effect/Effect" property.
 // For v3/unknown, this defers to IsEffectType since there is no single property shortcut.
-func (tp *TypeParser) HasEffectTypeId(t *checker.Type, atLocation *ast.Node) bool {
+func (tp *TypeParser) HasEffectTypeId(t *checker.Type) bool {
 	if tp == nil || tp.checker == nil || t == nil {
 		return false
 	}
@@ -197,7 +197,7 @@ func (tp *TypeParser) HasEffectTypeId(t *checker.Type, atLocation *ast.Node) boo
 			return tp.GetTypeOfPropertyByName(t, EffectTypeId) != nil
 		}
 		// For v3/unknown, the quick check is not available; defer to full detection.
-		return tp.IsEffectType(t, atLocation)
+		return tp.IsEffectType(t)
 	})
 }
 
@@ -221,7 +221,7 @@ func isEffectTypeSourceFile(tp *TypeParser, c *checker.Checker, sf *ast.SourceFi
 		return false
 	}
 
-	return tp.EffectType(effectType, sf.AsNode()) != nil
+	return tp.EffectType(effectType) != nil
 }
 
 // IsExpressionEffectModule reports whether node resolves to the Effect module namespace

--- a/internal/typeparser/effect_yieldable_type.go
+++ b/internal/typeparser/effect_yieldable_type.go
@@ -1,9 +1,6 @@
 package typeparser
 
-import (
-	"github.com/microsoft/TypeScript/tsc/shim/ast"
-	"github.com/microsoft/TypeScript/tsc/shim/checker"
-)
+import "github.com/microsoft/TypeScript/tsc/shim/checker"
 
 // EffectYieldableType resolves both plain Effect types and yieldable wrappers
 // that implement the asEffect() protocol.
@@ -11,7 +8,7 @@ import (
 // For v4: tries EffectType first; if that fails, looks for an asEffect property,
 // checks if it's callable, and tries EffectType on the return type of each call signature.
 // Returns nil if the type is not an Effect and not yieldable.
-func (tp *TypeParser) EffectYieldableType(t *checker.Type, atLocation *ast.Node) *Effect {
+func (tp *TypeParser) EffectYieldableType(t *checker.Type) *Effect {
 	if tp == nil || tp.checker == nil || t == nil {
 		return nil
 	}
@@ -21,11 +18,11 @@ func (tp *TypeParser) EffectYieldableType(t *checker.Type, atLocation *ast.Node)
 		// For v3, yieldable types are modeled through Effect subtyping,
 		// so EffectType alone is sufficient.
 		if version != EffectMajorV4 {
-			return tp.EffectType(t, atLocation)
+			return tp.EffectType(t)
 		}
 
 		// v4: first try plain Effect type
-		if result := tp.EffectType(t, atLocation); result != nil {
+		if result := tp.EffectType(t); result != nil {
 			return result
 		}
 
@@ -41,7 +38,7 @@ func (tp *TypeParser) EffectYieldableType(t *checker.Type, atLocation *ast.Node)
 			if returnType == nil {
 				continue
 			}
-			if result := tp.EffectType(returnType, atLocation); result != nil {
+			if result := tp.EffectType(returnType); result != nil {
 				return result
 			}
 		}

--- a/internal/typeparser/expected_and_real_type_test.go
+++ b/internal/typeparser/expected_and_real_type_test.go
@@ -291,19 +291,19 @@ func TestEffectType_NilInputs(t *testing.T) {
 	t.Parallel()
 
 	source := `const x: number = 42`
-	_, tp, sf, done := compileAndGetCheckerAndSourceFile(t, source)
+	_, tp, _, done := compileAndGetCheckerAndSourceFile(t, source)
 	defer done()
 
 	// nil type must not panic
-	if result := tp.EffectType(nil, sf.AsNode()); result != nil {
+	if result := tp.EffectType(nil); result != nil {
 		t.Error("expected nil for nil type")
 	}
 	// nil checker must not panic
-	if result := (*typeparser.TypeParser)(nil).EffectType(nil, sf.AsNode()); result != nil {
+	if result := (*typeparser.TypeParser)(nil).EffectType(nil); result != nil {
 		t.Error("expected nil for nil checker")
 	}
 	// HasEffectTypeId with nil type must not panic
-	if tp.HasEffectTypeId(nil, sf.AsNode()) {
+	if tp.HasEffectTypeId(nil) {
 		t.Error("expected false for nil type")
 	}
 }
@@ -312,13 +312,13 @@ func TestLayerType_NilInputs(t *testing.T) {
 	t.Parallel()
 
 	source := `const x: number = 42`
-	_, tp, sf, done := compileAndGetCheckerAndSourceFile(t, source)
+	_, tp, _, done := compileAndGetCheckerAndSourceFile(t, source)
 	defer done()
 
-	if result := tp.LayerType(nil, sf.AsNode()); result != nil {
+	if result := tp.LayerType(nil); result != nil {
 		t.Error("expected nil for nil type")
 	}
-	if result := (*typeparser.TypeParser)(nil).LayerType(nil, sf.AsNode()); result != nil {
+	if result := (*typeparser.TypeParser)(nil).LayerType(nil); result != nil {
 		t.Error("expected nil for nil checker")
 	}
 }
@@ -327,13 +327,13 @@ func TestContextTag_NilInputs(t *testing.T) {
 	t.Parallel()
 
 	source := `const x: number = 42`
-	_, tp, sf, done := compileAndGetCheckerAndSourceFile(t, source)
+	_, tp, _, done := compileAndGetCheckerAndSourceFile(t, source)
 	defer done()
 
-	if result := tp.ContextTag(nil, sf.AsNode()); result != nil {
+	if result := tp.ContextTag(nil); result != nil {
 		t.Error("expected nil for nil type")
 	}
-	if result := (*typeparser.TypeParser)(nil).ContextTag(nil, sf.AsNode()); result != nil {
+	if result := (*typeparser.TypeParser)(nil).ContextTag(nil); result != nil {
 		t.Error("expected nil for nil checker")
 	}
 }

--- a/internal/typeparser/layer_type.go
+++ b/internal/typeparser/layer_type.go
@@ -44,7 +44,7 @@ func (tp *TypeParser) parseLayerVarianceStruct(t *checker.Type) *Layer {
 // Returns nil if the type is not a Layer.
 // The detection strategy is chosen based on the detected Effect version:
 // v4 uses direct symbol lookup, v3/unknown uses property iteration.
-func (tp *TypeParser) LayerType(t *checker.Type, atLocation *ast.Node) *Layer {
+func (tp *TypeParser) LayerType(t *checker.Type) *Layer {
 	if tp == nil || tp.checker == nil || t == nil {
 		return nil
 	}
@@ -97,7 +97,7 @@ func (tp *TypeParser) LayerType(t *checker.Type, atLocation *ast.Node) *Layer {
 
 		// Try each candidate as a layer variance struct
 		for _, prop := range candidates {
-			propType := c.GetTypeOfSymbolAtLocation(prop, atLocation)
+			propType := c.GetTypeOfSymbolAtLocation(prop, nil)
 			if result := tp.parseLayerVarianceStruct(propType); result != nil {
 				return result
 			}
@@ -108,8 +108,8 @@ func (tp *TypeParser) LayerType(t *checker.Type, atLocation *ast.Node) *Layer {
 }
 
 // IsLayerType returns true if the type has the Layer variance struct.
-func (tp *TypeParser) IsLayerType(t *checker.Type, atLocation *ast.Node) bool {
-	return tp.LayerType(t, atLocation) != nil
+func (tp *TypeParser) IsLayerType(t *checker.Type) bool {
+	return tp.LayerType(t) != nil
 }
 
 func isLayerTypeSourceFile(tp *TypeParser, c *checker.Checker, sf *ast.SourceFile) bool {
@@ -132,7 +132,7 @@ func isLayerTypeSourceFile(tp *TypeParser, c *checker.Checker, sf *ast.SourceFil
 		return false
 	}
 
-	return tp.LayerType(layerType, sf.AsNode()) != nil
+	return tp.LayerType(layerType) != nil
 }
 
 // IsNodeReferenceToEffectLayerModuleApi reports whether node resolves to a member

--- a/internal/typeparser/location_independent_type_parser_test.go
+++ b/internal/typeparser/location_independent_type_parser_test.go
@@ -1,0 +1,124 @@
+package typeparser
+
+import (
+	"testing"
+
+	"github.com/effect-ts/tsgo/internal/bundledeffect"
+)
+
+func TestEffectTypeParsesInstantiatedV3TypeWithoutLocation(t *testing.T) {
+	t.Parallel()
+	if err := bundledeffect.EnsurePackageInstalled(bundledeffect.EffectV3, "effect"); err != nil {
+		t.Skip("Effect v3 not installed:", err)
+	}
+
+	c, tp, sf, done := compileAndGetCheckerAndSourceFileWithEffectV3Internal(t, `
+import * as Effect from "effect/Effect"
+
+declare const effect: Effect.Effect<string, Error, number>
+effect
+`)
+	defer done()
+
+	effectType := tp.GetTypeAtLocation(findIdentifierByText(t, sf, "effect", 1))
+	parsed := tp.EffectType(effectType)
+	if parsed == nil {
+		t.Fatal("expected instantiated v3 Effect type to parse without a location")
+	}
+	if got := c.TypeToString(parsed.A); got != "string" {
+		t.Fatalf("expected success type string, got %s", got)
+	}
+	if got := c.TypeToString(parsed.E); got != "Error" {
+		t.Fatalf("expected error type Error, got %s", got)
+	}
+	if got := c.TypeToString(parsed.R); got != "number" {
+		t.Fatalf("expected requirements type number, got %s", got)
+	}
+}
+
+func TestLayerTypeParsesInstantiatedV3TypeWithoutLocation(t *testing.T) {
+	t.Parallel()
+	if err := bundledeffect.EnsurePackageInstalled(bundledeffect.EffectV3, "effect"); err != nil {
+		t.Skip("Effect v3 not installed:", err)
+	}
+
+	c, tp, sf, done := compileAndGetCheckerAndSourceFileWithEffectV3Internal(t, `
+import * as Layer from "effect/Layer"
+
+declare const layer: Layer.Layer<string, Error, number>
+layer
+`)
+	defer done()
+
+	layerType := tp.GetTypeAtLocation(findIdentifierByText(t, sf, "layer", 1))
+	parsed := tp.LayerType(layerType)
+	if parsed == nil {
+		t.Fatal("expected instantiated v3 Layer type to parse without a location")
+	}
+	if got := c.TypeToString(parsed.ROut); got != "string" {
+		t.Fatalf("expected output requirements type string, got %s", got)
+	}
+	if got := c.TypeToString(parsed.E); got != "Error" {
+		t.Fatalf("expected error type Error, got %s", got)
+	}
+	if got := c.TypeToString(parsed.RIn); got != "number" {
+		t.Fatalf("expected input requirements type number, got %s", got)
+	}
+}
+
+func TestEffectSchemaTypesParsesInstantiatedV3TypeWithoutLocation(t *testing.T) {
+	t.Parallel()
+	if err := bundledeffect.EnsurePackageInstalled(bundledeffect.EffectV3, "effect"); err != nil {
+		t.Skip("Effect v3 not installed:", err)
+	}
+
+	c, tp, sf, done := compileAndGetCheckerAndSourceFileWithEffectV3Internal(t, `
+import * as Schema from "effect/Schema"
+
+declare const schema: Schema.Schema<string, number>
+schema
+`)
+	defer done()
+
+	schemaType := tp.GetTypeAtLocation(findIdentifierByText(t, sf, "schema", 1))
+	parsed := tp.EffectSchemaTypes(schemaType)
+	if parsed == nil {
+		t.Fatal("expected instantiated v3 Schema type to parse without a location")
+	}
+	if got := c.TypeToString(parsed.A); got != "string" {
+		t.Fatalf("expected decoded type string, got %s", got)
+	}
+	if got := c.TypeToString(parsed.E); got != "number" {
+		t.Fatalf("expected encoded type number, got %s", got)
+	}
+}
+
+func TestStreamTypeParsesInstantiatedV3TypeWithoutLocation(t *testing.T) {
+	t.Parallel()
+	if err := bundledeffect.EnsurePackageInstalled(bundledeffect.EffectV3, "effect"); err != nil {
+		t.Skip("Effect v3 not installed:", err)
+	}
+
+	c, tp, sf, done := compileAndGetCheckerAndSourceFileWithEffectV3Internal(t, `
+import * as Stream from "effect/Stream"
+
+declare const stream: Stream.Stream<string, Error, number>
+stream
+`)
+	defer done()
+
+	streamType := tp.GetTypeAtLocation(findIdentifierByText(t, sf, "stream", 1))
+	parsed := tp.StreamType(streamType)
+	if parsed == nil {
+		t.Fatal("expected instantiated v3 Stream type to parse without a location")
+	}
+	if got := c.TypeToString(parsed.A); got != "string" {
+		t.Fatalf("expected element type string, got %s", got)
+	}
+	if got := c.TypeToString(parsed.E); got != "Error" {
+		t.Fatalf("expected error type Error, got %s", got)
+	}
+	if got := c.TypeToString(parsed.R); got != "number" {
+		t.Fatalf("expected requirements type number, got %s", got)
+	}
+}

--- a/internal/typeparser/pipeable.go
+++ b/internal/typeparser/pipeable.go
@@ -7,18 +7,16 @@ import (
 
 // IsPipeableType returns true if the type has a callable "pipe" property,
 // indicating it supports the pipeable pattern (e.g., value.pipe(f1, f2, ...)).
-func (tp *TypeParser) IsPipeableType(t *checker.Type, atLocation *ast.Node) bool {
+func (tp *TypeParser) IsPipeableType(t *checker.Type) bool {
 	if tp == nil || tp.checker == nil || t == nil {
 		return false
 	}
 	c := tp.checker
 	return Cached(&tp.links.IsPipeableType, t, func() bool {
-		pipeSymbol := c.GetPropertyOfType(t, "pipe")
-		if pipeSymbol == nil {
+		pipeType := tp.GetTypeOfPropertyByName(t, "pipe")
+		if pipeType == nil {
 			return false
 		}
-
-		pipeType := c.GetTypeOfSymbolAtLocation(pipeSymbol, atLocation)
 		signatures := c.GetSignaturesOfType(pipeType, checker.SignatureKindCall)
 		return len(signatures) > 0
 	})

--- a/internal/typeparser/schema_type.go
+++ b/internal/typeparser/schema_type.go
@@ -15,11 +15,11 @@ var effectSchemaParserModuleDescriptor = newPackageSourceFileDescriptor("effect"
 const SchemaTypeId = "~effect/Schema/Schema"
 
 // IsSchemaType returns true if the type is a Schema type (v4 or v3).
-func (tp *TypeParser) IsSchemaType(t *checker.Type, atLocation *ast.Node) bool {
+func (tp *TypeParser) IsSchemaType(t *checker.Type) bool {
 	if tp == nil {
 		return false
 	}
-	return tp.EffectSchemaTypes(t, atLocation) != nil
+	return tp.EffectSchemaTypes(t) != nil
 }
 
 // SchemaTypes holds the A (Type) and E (Encoded) types extracted from a Schema type.
@@ -30,7 +30,7 @@ type SchemaTypes struct {
 
 // EffectSchemaTypes extracts the A (Type) and E (Encoded) types from a Schema type.
 // Returns nil if the type is not a recognized Schema type or types cannot be extracted.
-func (tp *TypeParser) EffectSchemaTypes(t *checker.Type, atLocation *ast.Node) *SchemaTypes {
+func (tp *TypeParser) EffectSchemaTypes(t *checker.Type) *SchemaTypes {
 	if tp == nil || tp.checker == nil || t == nil {
 		return nil
 	}
@@ -42,8 +42,8 @@ func (tp *TypeParser) EffectSchemaTypes(t *checker.Type, atLocation *ast.Node) *
 				return nil
 			}
 			// V4: get Type and Encoded properties directly
-			aType := tp.getPropertyType(t, atLocation, "Type")
-			eType := tp.getPropertyType(t, atLocation, "Encoded")
+			aType := tp.GetTypeOfPropertyByName(t, "Type")
+			eType := tp.GetTypeOfPropertyByName(t, "Encoded")
 			if aType == nil || eType == nil {
 				return nil
 			}
@@ -61,7 +61,7 @@ func (tp *TypeParser) EffectSchemaTypes(t *checker.Type, atLocation *ast.Node) *
 			if prop == nil || prop.Flags&ast.SymbolFlagsProperty == 0 || prop.Flags&ast.SymbolFlagsOptional != 0 || prop.ValueDeclaration == nil {
 				continue
 			}
-			propType := c.GetTypeOfSymbolAtLocation(prop, atLocation)
+			propType := c.GetTypeOfSymbolAtLocation(prop, nil)
 			a := tp.extractInvariantType(propType, "_A")
 			if a == nil {
 				continue
@@ -79,16 +79,6 @@ func (tp *TypeParser) EffectSchemaTypes(t *checker.Type, atLocation *ast.Node) *
 
 		return nil
 	})
-}
-
-// getPropertyType extracts the type of a named property from a type.
-func (tp *TypeParser) getPropertyType(t *checker.Type, atLocation *ast.Node, propName string) *checker.Type {
-	c := tp.checker
-	sym := c.GetPropertyOfType(t, propName)
-	if sym == nil {
-		return nil
-	}
-	return c.GetTypeOfSymbolAtLocation(sym, atLocation)
 }
 
 func isSchemaTypeSourceFile(tp *TypeParser, c *checker.Checker, sf *ast.SourceFile) bool {
@@ -111,7 +101,7 @@ func isSchemaTypeSourceFile(tp *TypeParser, c *checker.Checker, sf *ast.SourceFi
 		return false
 	}
 
-	return tp.IsSchemaType(schemaType, sf.AsNode())
+	return tp.IsSchemaType(schemaType)
 }
 
 // IsNodeReferenceToEffectSchemaModuleApi reports whether node resolves to a member

--- a/internal/typeparser/scope_type.go
+++ b/internal/typeparser/scope_type.go
@@ -14,7 +14,7 @@ const ScopeTypeId = "~effect/Scope"
 // For v4, this checks for the "~effect/Scope" computed property.
 // For v3/unknown, this checks that the type is "pipeable" (has a callable pipe property)
 // and that any required non-optional property's symbol name contains "ScopeTypeId".
-func (tp *TypeParser) IsScopeType(t *checker.Type, atLocation *ast.Node) bool {
+func (tp *TypeParser) IsScopeType(t *checker.Type) bool {
 	if tp == nil || tp.checker == nil || t == nil {
 		return false
 	}
@@ -25,11 +25,10 @@ func (tp *TypeParser) IsScopeType(t *checker.Type, atLocation *ast.Node) bool {
 		}
 
 		// v3 / unknown: check that the type is "pipeable"
-		pipeSymbol := tp.checker.GetPropertyOfType(t, "pipe")
-		if pipeSymbol == nil {
+		pipeType := tp.GetTypeOfPropertyByName(t, "pipe")
+		if pipeType == nil {
 			return false
 		}
-		pipeType := tp.checker.GetTypeOfSymbolAtLocation(pipeSymbol, atLocation)
 		signatures := tp.checker.GetSignaturesOfType(pipeType, checker.SignatureKindCall)
 		if len(signatures) == 0 {
 			return false

--- a/internal/typeparser/service_type.go
+++ b/internal/typeparser/service_type.go
@@ -1,9 +1,6 @@
 package typeparser
 
-import (
-	"github.com/microsoft/TypeScript/tsc/shim/ast"
-	"github.com/microsoft/TypeScript/tsc/shim/checker"
-)
+import "github.com/microsoft/TypeScript/tsc/shim/checker"
 
 // ServiceTypeId is the property key for the newer Context.Service variance struct.
 const ServiceTypeId = "~effect/Context/Service"
@@ -31,7 +28,7 @@ func (tp *TypeParser) parseServiceVarianceStruct(t *checker.Type) *Service {
 
 // ServiceType parses a v4 service type and extracts Identifier, Shape parameters.
 // Returns nil if the type is not a v4 service.
-func (tp *TypeParser) ServiceType(t *checker.Type, atLocation *ast.Node) *Service {
+func (tp *TypeParser) ServiceType(t *checker.Type) *Service {
 	if tp == nil || tp.checker == nil || t == nil {
 		return nil
 	}
@@ -39,7 +36,7 @@ func (tp *TypeParser) ServiceType(t *checker.Type, atLocation *ast.Node) *Servic
 		if tp.DetectEffectVersion() != EffectMajorV4 {
 			return nil
 		}
-		if !tp.IsPipeableType(t, atLocation) {
+		if !tp.IsPipeableType(t) {
 			return nil
 		}
 
@@ -61,6 +58,6 @@ func (tp *TypeParser) ServiceType(t *checker.Type, atLocation *ast.Node) *Servic
 }
 
 // IsServiceType returns true if the type has the Service variance struct.
-func (tp *TypeParser) IsServiceType(t *checker.Type, atLocation *ast.Node) bool {
-	return tp.ServiceType(t, atLocation) != nil
+func (tp *TypeParser) IsServiceType(t *checker.Type) bool {
+	return tp.ServiceType(t) != nil
 }

--- a/internal/typeparser/service_type_test.go
+++ b/internal/typeparser/service_type_test.go
@@ -21,12 +21,12 @@ export class UserRepo extends Context.Service<UserRepo, { readonly find: () => s
 `)
 	defer done()
 
-	className, classType := findClassTypeByName(t, c, sf, "UserRepo")
+	_, classType := findClassTypeByName(t, c, sf, "UserRepo")
 	if classType == nil {
 		t.Fatal("expected class type")
 	}
 
-	service := tp.ServiceType(classType, className)
+	service := tp.ServiceType(classType)
 	if service == nil {
 		t.Fatal("expected v4 service type to parse")
 		return
@@ -37,7 +37,7 @@ export class UserRepo extends Context.Service<UserRepo, { readonly find: () => s
 	if service.Shape == nil {
 		t.Fatal("expected service shape type")
 	}
-	if tp.ContextTag(classType, className) != nil {
+	if tp.ContextTag(classType) != nil {
 		t.Fatal("expected v4 service not to parse as Context.Tag")
 	}
 }
@@ -55,12 +55,12 @@ export class Config extends Context.Tag("Config")<Config, { readonly port: numbe
 `)
 	defer done()
 
-	className, classType := findClassTypeByName(t, c, sf, "Config")
+	_, classType := findClassTypeByName(t, c, sf, "Config")
 	if classType == nil {
 		t.Fatal("expected class type")
 	}
 
-	contextTag := tp.ContextTag(classType, className)
+	contextTag := tp.ContextTag(classType)
 	if contextTag == nil {
 		t.Fatal("expected v3 Context.Tag type to parse")
 		return
@@ -71,7 +71,7 @@ export class Config extends Context.Tag("Config")<Config, { readonly port: numbe
 	if contextTag.Shape == nil {
 		t.Fatal("expected context tag shape type")
 	}
-	if tp.ServiceType(classType, className) != nil {
+	if tp.ServiceType(classType) != nil {
 		t.Fatal("expected v3 Context.Tag not to parse as a v4 service type")
 	}
 }

--- a/internal/typeparser/stream_type.go
+++ b/internal/typeparser/stream_type.go
@@ -1,22 +1,19 @@
 package typeparser
 
-import (
-	"github.com/microsoft/TypeScript/tsc/shim/ast"
-	"github.com/microsoft/TypeScript/tsc/shim/checker"
-)
+import "github.com/microsoft/TypeScript/tsc/shim/checker"
 
 // StreamTypeId is the property key for Stream's variance struct.
 const StreamTypeId = "~effect/Stream"
 
 // StreamType parses a Stream type and extracts A, E, R parameters.
 // For v3, Stream carries the Effect variance struct, so this delegates to EffectType.
-func (tp *TypeParser) StreamType(t *checker.Type, atLocation *ast.Node) *Effect {
+func (tp *TypeParser) StreamType(t *checker.Type) *Effect {
 	if tp == nil || tp.checker == nil || t == nil {
 		return nil
 	}
 	return Cached(&tp.links.StreamType, t, func() *Effect {
 		if tp.DetectEffectVersion() != EffectMajorV4 {
-			return tp.EffectType(t, atLocation)
+			return tp.EffectType(t)
 		}
 
 		varianceStructType := tp.GetTypeOfPropertyByName(t, StreamTypeId)


### PR DESCRIPTION
## Summary

- remove AST location parameters from type-only `TypeParser` operations and their public `etsgoapi` wrappers
- resolve V3 variance properties without source context while preserving the checker's instantiated-symbol normalization
- simplify downstream rule, refactor, schema-generation, and language-service call sites
- add regression coverage for instantiated V3 Effect, Layer, Schema, and Stream types; existing Context.Tag coverage now exercises the location-free interface

Type acquisition remains location-sensitive through `GetTypeAtLocation`. Once callers hold a materialized checker type, parsing is now explicitly a function of that type, matching the parser's existing type-keyed caches.

For V3 computed variance properties, parsing uses `GetTypeOfSymbolAtLocation(prop, nil)`. This preserves export/missing-symbol normalization and mapper application without performing flow-sensitive lookup at an unrelated AST node.

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `git diff --check`
