### PR TITLE
Normalize piping flow transformations and rewrites

### DIFF
--- a/.changeset/piping-flow-type-arguments.md
+++ b/.changeset/piping-flow-type-arguments.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": minor
+---
+
+Expose explicit type arguments on piping-flow transformations. Rules can now inspect `PipingFlowTransformation.TypeArguments` directly without recovering them from the transformation's syntax node.

--- a/.changeset/piping-flow-type-arguments.md
+++ b/.changeset/piping-flow-type-arguments.md
@@ -2,4 +2,4 @@
 "@effect/tsgo": minor
 ---
 
-Expose explicit type arguments on piping-flow transformations. Rules can now inspect `PipingFlowTransformation.TypeArguments` directly without recovering them from the transformation's syntax node.
+Normalize piping-flow transformations around their callee, arguments, and explicit type arguments without exposing a representation-dependent transformation node. Add shared rewriter operations for replacing transformations and flow prefixes while preserving data-first, data-last, `pipe(...)`, and `.pipe(...)` source forms.

--- a/_packages/tsgo/src/metadata.json
+++ b/_packages/tsgo/src/metadata.json
@@ -1664,7 +1664,7 @@
         "diagnostics": [
           {
             "start": 348,
-            "end": 499,
+            "end": 363,
             "text": "Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)"
           }
         ]

--- a/docs/rules/catch-tag-to-catch-reason.md
+++ b/docs/rules/catch-tag-to-catch-reason.md
@@ -37,20 +37,11 @@ declare const program: Effect.Effect<string, AppError>
 export const fixable = program.pipe(
   Effect.catchTag("AppError", (error) => {
 /**
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ effecttsgo(catch-tag-to-catch-reason): Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically.
+  ^^^^^^^^^^^^^^^ effecttsgo(catch-tag-to-catch-reason): Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically.
 */
     if (error.reason._tag === "RetryReason") return Effect.succeed("retry")
-/**
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-*/
     return Effect.fail(error)
-/**
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-*/
   })
-/**
-^^^^
-*/
 )
 ```
 

--- a/etsgoapi/piping_flow.go
+++ b/etsgoapi/piping_flow.go
@@ -43,6 +43,7 @@ type PipingFlow struct {
 }
 
 // PipingFlows returns all piping flows found in a source file, sorted by source position.
+// Each source transformation occurrence belongs to at most one returned flow.
 // When includeEffectFn is true, Effect.fn / Effect.fnUntraced calls carrying trailing
 // transformation arguments are surfaced as flows as well.
 func (tp *TypeParser) PipingFlows(sf *ast.SourceFile, includeEffectFn bool) []*PipingFlow {

--- a/etsgoapi/piping_flow.go
+++ b/etsgoapi/piping_flow.go
@@ -21,11 +21,12 @@ const (
 
 // PipingFlowTransformation represents a single transformation step in a piping flow.
 type PipingFlowTransformation struct {
-	Kind    TransformationKind // How the transformation was expressed
-	Node    *ast.Node          // The full transformation node (call expression or bare callee)
-	Callee  *ast.Node          // The function being applied (e.g., Effect.map)
-	Args    []*ast.Node        // Arguments to the transformation, or nil for constants/single-arg calls
-	OutType *checker.Type      // The resulting type after this transformation (may be nil)
+	Kind          TransformationKind // How the transformation was expressed
+	Node          *ast.Node          // The full transformation node (call expression or bare callee)
+	Callee        *ast.Node          // The function being applied (e.g., Effect.map)
+	TypeArguments *ast.NodeList      // Explicit type arguments to the transformation call, if any
+	Args          []*ast.Node        // Arguments to the transformation, or nil for constants/single-arg calls
+	OutType       *checker.Type      // The resulting type after this transformation (may be nil)
 }
 
 // PipingFlowSubject is the starting expression of a piping flow.
@@ -81,11 +82,12 @@ func pipingFlowFromInternal(flow *typeparser.PipingFlow) *PipingFlow {
 	transformations := make([]PipingFlowTransformation, 0, len(flow.Transformations))
 	for _, transformation := range flow.Transformations {
 		transformations = append(transformations, PipingFlowTransformation{
-			Kind:    TransformationKind(transformation.Kind),
-			Node:    transformation.Node,
-			Callee:  transformation.Callee,
-			Args:    transformation.Args,
-			OutType: transformation.OutType,
+			Kind:          TransformationKind(transformation.Kind),
+			Node:          transformation.Node,
+			Callee:        transformation.Callee,
+			TypeArguments: transformation.TypeArguments,
+			Args:          transformation.Args,
+			OutType:       transformation.OutType,
 		})
 	}
 

--- a/etsgoapi/piping_flow.go
+++ b/etsgoapi/piping_flow.go
@@ -22,7 +22,6 @@ const (
 // PipingFlowTransformation represents a single transformation step in a piping flow.
 type PipingFlowTransformation struct {
 	Kind          TransformationKind // How the transformation was expressed
-	Node          *ast.Node          // The full transformation node (call expression or bare callee)
 	Callee        *ast.Node          // The function being applied (e.g., Effect.map)
 	TypeArguments *ast.NodeList      // Explicit type arguments to the transformation call, if any
 	Args          []*ast.Node        // Arguments to the transformation, or nil for constants/single-arg calls
@@ -84,7 +83,6 @@ func pipingFlowFromInternal(flow *typeparser.PipingFlow) *PipingFlow {
 	for _, transformation := range flow.Transformations {
 		transformations = append(transformations, PipingFlowTransformation{
 			Kind:          TransformationKind(transformation.Kind),
-			Node:          transformation.Node,
 			Callee:        transformation.Callee,
 			TypeArguments: transformation.TypeArguments,
 			Args:          transformation.Args,

--- a/etslshooks/document_symbols.go
+++ b/etslshooks/document_symbols.go
@@ -198,15 +198,15 @@ func collectFlowDocumentSymbols(tp *typeparser.TypeParser, c *checker.Checker, s
 			))
 		}
 		for j, transformation := range flow.Transformations {
-			if transformation.Node == nil {
+			if transformation.Callee == nil {
 				continue
 			}
 			children = append(children, newNamedDocumentSymbol(
 				sf,
 				langService,
-				transformation.Node,
+				transformation.Callee,
 				strconv.Itoa(j)+": "+debugFlowTransformationText(sf, &transformation),
-				typeToDetail(c, transformation.OutType, transformation.Node),
+				typeToDetail(c, transformation.OutType, transformation.Callee),
 				lsproto.SymbolKindFunction,
 			))
 		}
@@ -330,13 +330,10 @@ func debugFlowNodeText(sf *ast.SourceFile, node *ast.Node) string {
 }
 
 func debugFlowTransformationText(sf *ast.SourceFile, transformation *typeparser.PipingFlowTransformation) string {
-	if transformation == nil {
+	if transformation == nil || transformation.Callee == nil {
 		return "<unknown>"
 	}
-	if transformation.Callee != nil {
-		return debugFlowNodeText(sf, transformation.Callee)
-	}
-	return debugFlowNodeText(sf, transformation.Node)
+	return debugFlowNodeText(sf, transformation.Callee)
 }
 
 func layerSymbolDetail(tp *typeparser.TypeParser, c *checker.Checker, node *ast.Node) *string {

--- a/internal/fixables/catch_die_to_or_die.go
+++ b/internal/fixables/catch_die_to_or_die.go
@@ -24,8 +24,7 @@ func runCatchDieToOrDieFix(ctx *fixable.Context) []ls.CodeAction {
 		if !match.Location.Intersects(ctx.Span) && !ctx.Span.ContainedBy(match.Location) {
 			continue
 		}
-		if match.EffectModule == nil || match.Transformation == nil || match.HasTypeArguments ||
-			(match.IsDataApplication && match.Input == nil) {
+		if match.Transformation == nil || match.EffectModule == nil || match.HasTypeArguments {
 			return nil
 		}
 
@@ -38,18 +37,9 @@ func runCatchDieToOrDieFix(ctx *fixable.Context) []ls.CodeAction {
 					tracker.NewIdentifier("orDie"),
 					ast.NodeFlagsNone,
 				)
-				replacement := orDie
-				if match.IsDataApplication {
-					replacement = tracker.NewCallExpression(
-						orDie,
-						nil,
-						nil,
-						tracker.NewNodeList([]*ast.Node{tracker.DeepCloneNode(match.Input)}),
-						ast.NodeFlagsNone,
-					)
-				}
-				ast.SetParentInChildren(replacement)
-				tracker.ReplaceNode(ctx.SourceFile, match.Transformation, replacement, nil)
+				tracker.ReplacePipingFlowTransformation(ctx.SourceFile, match.Transformation, rewriter.PipingFlowTransformationReplacement{
+					Callee: orDie,
+				})
 			},
 		}); action != nil {
 			return []ls.CodeAction{*action}

--- a/internal/fixables/catch_tag_to_catch_reason.go
+++ b/internal/fixables/catch_tag_to_catch_reason.go
@@ -25,16 +25,21 @@ func runCatchTagToCatchReasonFix(ctx *fixable.Context) []ls.CodeAction {
 		if !match.CanFix || (!match.Location.Intersects(ctx.Span) && !ctx.Span.ContainedBy(match.Location)) {
 			continue
 		}
+		if match.Transformation == nil {
+			return nil
+		}
 
 		if action := ctx.NewFixAction(fixable.FixAction{
 			Description: "Replace with Effect.catchReason or Effect.catchReasons",
 			Run: func(tracker *rewriter.Tracker) {
-				replacement := buildCatchTagToCatchReasonReplacement(tracker, match)
-				if replacement == nil {
+				callee, arguments := buildCatchTagToCatchReasonReplacement(tracker, match)
+				if callee == nil || arguments == nil {
 					return
 				}
-				ast.SetParentInChildren(replacement)
-				tracker.ReplaceNode(ctx.SourceFile, match.CallNode, replacement, nil)
+				tracker.ReplacePipingFlowTransformation(ctx.SourceFile, match.Transformation, rewriter.PipingFlowTransformationReplacement{
+					Callee:    callee,
+					Arguments: arguments,
+				})
 			},
 		}); action != nil {
 			return []ls.CodeAction{*action}
@@ -44,13 +49,13 @@ func runCatchTagToCatchReasonFix(ctx *fixable.Context) []ls.CodeAction {
 	return nil
 }
 
-func buildCatchTagToCatchReasonReplacement(tracker *rewriter.Tracker, match rules.CatchTagToCatchReasonMatch) *ast.Node {
+func buildCatchTagToCatchReasonReplacement(tracker *rewriter.Tracker, match rules.CatchTagToCatchReasonMatch) (*ast.Node, *ast.NodeList) {
 	if tracker == nil || match.Callee == nil || match.Callee.Kind != ast.KindPropertyAccessExpression || match.OuterTag == nil || len(match.Branches) == 0 {
-		return nil
+		return nil, nil
 	}
 	callee := match.Callee.AsPropertyAccessExpression()
 	if callee == nil || callee.Expression == nil {
-		return nil
+		return nil, nil
 	}
 
 	methodName := "catchReason"
@@ -81,7 +86,7 @@ func buildCatchTagToCatchReasonReplacement(tracker *rewriter.Tracker, match rule
 		arguments = append(arguments, tracker.NewObjectLiteralExpression(tracker.NewNodeList(properties), false))
 	}
 
-	return tracker.NewCallExpression(method, nil, nil, tracker.NewNodeList(arguments), ast.NodeFlagsNone)
+	return method, tracker.NewNodeList(arguments)
 }
 
 func newCatchReasonHandler(tracker *rewriter.Tracker, parameterName string, branch rules.CatchTagToCatchReasonBranch) *ast.Node {

--- a/internal/fixables/catch_to_ignore.go
+++ b/internal/fixables/catch_to_ignore.go
@@ -26,19 +26,17 @@ func runCatchToIgnoreFix(ctx *fixable.Context) []ls.CodeAction {
 		if !diagRange.Intersects(ctx.Span) && !ctx.Span.ContainedBy(diagRange) {
 			continue
 		}
+		if match.Transformation == nil {
+			return nil
+		}
 
 		if action := ctx.NewFixAction(fixable.FixAction{
 			Description: "Replace with Effect." + match.IgnoreMethodName,
 			Run: func(tracker *rewriter.Tracker) {
 				ignoreAccess := catchToIgnoreReplacementAccess(tracker, match)
-				if match.DataCallSubject != nil {
-					ignoreCall := tracker.NewCallExpression(ignoreAccess, nil, nil, tracker.NewNodeList([]*ast.Node{tracker.DeepCloneNode(match.DataCallSubject)}), ast.NodeFlagsNone)
-					ast.SetParentInChildren(ignoreCall)
-					tracker.ReplaceNode(sf, match.TransformationNode, ignoreCall, nil)
-					return
-				}
-
-				tracker.ReplaceNode(sf, match.TransformationNode, ignoreAccess, nil)
+				tracker.ReplacePipingFlowTransformation(sf, match.Transformation, rewriter.PipingFlowTransformationReplacement{
+					Callee: ignoreAccess,
+				})
 			},
 		}); action != nil {
 			return []ls.CodeAction{*action}

--- a/internal/fixables/effect_map_void.go
+++ b/internal/fixables/effect_map_void.go
@@ -26,6 +26,9 @@ func runEffectMapVoidFix(ctx *fixable.Context) []ls.CodeAction {
 		if !diagRange.Intersects(ctx.Span) && !ctx.Span.ContainedBy(diagRange) {
 			continue
 		}
+		if match.Transformation == nil || match.EffectModuleNode == nil {
+			return nil
+		}
 
 		if action := ctx.NewFixAction(fixable.FixAction{
 			Description: "Replace with Effect.asVoid",
@@ -37,19 +40,9 @@ func runEffectMapVoidFix(ctx *fixable.Context) []ls.CodeAction {
 					tracker.NewIdentifier("asVoid"),
 					ast.NodeFlagsNone,
 				)
-				// Data-last/pipeable forms drop to a bare Effect.asVoid reference; the
-				// data-first form must keep its subject as Effect.asVoid(self).
-				var replacement = asVoid
-				if match.SubjectNode != nil {
-					replacement = tracker.NewCallExpression(
-						asVoid,
-						nil,
-						nil,
-						tracker.NewNodeList([]*ast.Node{tracker.DeepCloneNode(match.SubjectNode)}),
-						ast.NodeFlagsNone,
-					)
-				}
-				tracker.ReplaceNode(sf, match.CallNode, replacement, nil)
+				tracker.ReplacePipingFlowTransformation(sf, match.Transformation, rewriter.PipingFlowTransformationReplacement{
+					Callee: asVoid,
+				})
 			},
 		}); action != nil {
 			return []ls.CodeAction{*action}

--- a/internal/fixables/flat_map_conditional_to_filter_or_fail.go
+++ b/internal/fixables/flat_map_conditional_to_filter_or_fail.go
@@ -24,7 +24,7 @@ func runFlatMapConditionalToFilterOrFailFix(ctx *fixable.Context) []ls.CodeActio
 		if !match.Location.Intersects(ctx.Span) && !ctx.Span.ContainedBy(match.Location) {
 			continue
 		}
-		if !match.CanFix || match.ReplacementNode == nil || match.EffectModuleNode == nil ||
+		if !match.CanFix || match.Transformation == nil || match.EffectModuleNode == nil ||
 			match.ParameterNode == nil || match.PredicateNode == nil || match.FallbackNode == nil {
 			return nil
 		}
@@ -32,12 +32,18 @@ func runFlatMapConditionalToFilterOrFailFix(ctx *fixable.Context) []ls.CodeActio
 		if action := ctx.NewFixAction(fixable.FixAction{
 			Description: "Replace with Effect." + match.PreferredMethodName,
 			Run: func(tracker *rewriter.Tracker) {
-				replacement := buildFlatMapConditionalFilterReplacement(tracker, match)
-				if replacement == nil {
+				callee, arguments := buildFlatMapConditionalFilterReplacement(tracker, match)
+				if callee == nil || arguments == nil {
 					return
 				}
-				ast.SetParentInChildren(replacement)
-				tracker.ReplaceNode(ctx.SourceFile, match.ReplacementNode, replacement, nil)
+				tracker.ReplacePipingFlowTransformation(
+					ctx.SourceFile,
+					match.Transformation,
+					rewriter.PipingFlowTransformationReplacement{
+						Callee:    callee,
+						Arguments: arguments,
+					},
+				)
 			},
 		}); action != nil {
 			return []ls.CodeAction{*action}
@@ -46,8 +52,8 @@ func runFlatMapConditionalToFilterOrFailFix(ctx *fixable.Context) []ls.CodeActio
 	return nil
 }
 
-func buildFlatMapConditionalFilterReplacement(tracker *rewriter.Tracker, match rules.FlatMapConditionalToFilterOrFailMatch) *ast.Node {
-	method := tracker.NewPropertyAccessExpression(
+func buildFlatMapConditionalFilterReplacement(tracker *rewriter.Tracker, match rules.FlatMapConditionalToFilterOrFailMatch) (*ast.Node, *ast.NodeList) {
+	callee := tracker.NewPropertyAccessExpression(
 		tracker.DeepCloneNode(match.EffectModuleNode),
 		nil,
 		tracker.NewIdentifier(match.PreferredMethodName),
@@ -76,9 +82,5 @@ func buildFlatMapConditionalFilterReplacement(tracker *rewriter.Tracker, match r
 		tracker.NewToken(ast.KindEqualsGreaterThanToken),
 		tracker.DeepCloneNode(match.FallbackNode),
 	)
-	arguments := []*ast.Node{predicate, fallback}
-	if match.SubjectNode != nil {
-		arguments = append([]*ast.Node{tracker.DeepCloneNode(match.SubjectNode)}, arguments...)
-	}
-	return tracker.NewCallExpression(method, nil, nil, tracker.NewNodeList(arguments), ast.NodeFlagsNone)
+	return callee, tracker.NewNodeList([]*ast.Node{predicate, fallback})
 }

--- a/internal/fixables/map_some_to_as_some.go
+++ b/internal/fixables/map_some_to_as_some.go
@@ -24,6 +24,9 @@ func runMapSomeToAsSomeFix(ctx *fixable.Context) []ls.CodeAction {
 		if !match.Location.Intersects(ctx.Span) && !ctx.Span.ContainedBy(match.Location) {
 			continue
 		}
+		if match.Transformation == nil || match.EffectModuleNode == nil {
+			return nil
+		}
 
 		if action := ctx.NewFixAction(fixable.FixAction{
 			Description: "Replace with Effect.asSome",
@@ -34,17 +37,9 @@ func runMapSomeToAsSomeFix(ctx *fixable.Context) []ls.CodeAction {
 					tracker.NewIdentifier("asSome"),
 					ast.NodeFlagsNone,
 				)
-				var replacement = asSome
-				if match.SubjectNode != nil {
-					replacement = tracker.NewCallExpression(
-						asSome,
-						nil,
-						nil,
-						tracker.NewNodeList([]*ast.Node{tracker.DeepCloneNode(match.SubjectNode)}),
-						ast.NodeFlagsNone,
-					)
-				}
-				tracker.ReplaceNode(ctx.SourceFile, match.CallNode, replacement, nil)
+				tracker.ReplacePipingFlowTransformation(ctx.SourceFile, match.Transformation, rewriter.PipingFlowTransformationReplacement{
+					Callee: asSome,
+				})
 			},
 		}); action != nil {
 			return []ls.CodeAction{*action}

--- a/internal/fixables/option_match_to_from_option.go
+++ b/internal/fixables/option_match_to_from_option.go
@@ -24,17 +24,31 @@ func runOptionMatchToFromOptionFix(ctx *fixable.Context) []ls.CodeAction {
 		if !match.Location.Intersects(ctx.Span) && !ctx.Span.ContainedBy(match.Location) {
 			continue
 		}
-		if !match.CanFix || match.EffectModuleNode == nil || match.ReplacementNode == nil || !match.Pipeable && match.OptionNode == nil {
+		if !match.CanFix || match.EffectModuleNode == nil ||
+			match.Transformation == nil && (match.ReplacementNode == nil || match.OptionNode == nil) {
 			return nil
 		}
 
 		if action := ctx.NewFixAction(fixable.FixAction{
 			Description: "Replace with Effect.fromOption",
 			Run: func(tracker *rewriter.Tracker) {
-				replacement := buildFromOptionReplacement(tracker, match)
-				if replacement == nil {
+				callee, arguments := buildFromOptionReplacement(tracker, match)
+				if callee == nil {
 					return
 				}
+				if match.Transformation != nil {
+					tracker.ReplacePipingFlowTransformation(ctx.SourceFile, match.Transformation, rewriter.PipingFlowTransformationReplacement{
+						Callee:    callee,
+						Arguments: arguments,
+					})
+					return
+				}
+
+				directArguments := []*ast.Node{tracker.DeepCloneNode(match.OptionNode)}
+				if arguments != nil {
+					directArguments = append(directArguments, arguments.Nodes...)
+				}
+				replacement := tracker.NewCallExpression(callee, nil, nil, tracker.NewNodeList(directArguments), ast.NodeFlagsNone)
 				ast.SetParentInChildren(replacement)
 				tracker.ReplaceNode(ctx.SourceFile, match.ReplacementNode, replacement, nil)
 			},
@@ -45,7 +59,7 @@ func runOptionMatchToFromOptionFix(ctx *fixable.Context) []ls.CodeAction {
 	return nil
 }
 
-func buildFromOptionReplacement(tracker *rewriter.Tracker, match rules.OptionMatchToFromOptionMatch) *ast.Node {
+func buildFromOptionReplacement(tracker *rewriter.Tracker, match rules.OptionMatchToFromOptionMatch) (*ast.Node, *ast.NodeList) {
 	fromOption := tracker.NewPropertyAccessExpression(
 		tracker.DeepCloneNode(match.EffectModuleNode),
 		nil,
@@ -53,16 +67,12 @@ func buildFromOptionReplacement(tracker *rewriter.Tracker, match rules.OptionMat
 		ast.NodeFlagsNone,
 	)
 
-	if match.Pipeable && match.DefaultFailure {
-		return fromOption
+	if match.DefaultFailure {
+		return fromOption, nil
 	}
 
-	var arguments []*ast.Node
-	if !match.Pipeable {
-		arguments = append(arguments, tracker.DeepCloneNode(match.OptionNode))
-	}
-	if !match.DefaultFailure {
-		arguments = append(arguments, tracker.NewArrowFunction(
+	return fromOption, tracker.NewNodeList([]*ast.Node{
+		tracker.NewArrowFunction(
 			nil,
 			nil,
 			tracker.NewNodeList(nil),
@@ -70,8 +80,6 @@ func buildFromOptionReplacement(tracker *rewriter.Tracker, match rules.OptionMat
 			nil,
 			tracker.NewToken(ast.KindEqualsGreaterThanToken),
 			tracker.DeepCloneNode(match.FailureNode),
-		))
-	}
-
-	return tracker.NewCallExpression(fromOption, nil, nil, tracker.NewNodeList(arguments), ast.NodeFlagsNone)
+		),
+	})
 }

--- a/internal/fixables/prefer_succeed_some_or_none.go
+++ b/internal/fixables/prefer_succeed_some_or_none.go
@@ -24,7 +24,7 @@ func runPreferSucceedSomeOrNoneFix(ctx *fixable.Context) []ls.CodeAction {
 		if !match.Location.Intersects(ctx.Span) && !ctx.Span.ContainedBy(match.Location) {
 			continue
 		}
-		if match.ReplacementTarget == nil || match.ReplacementName == "succeedSome" && match.ValueNode == nil {
+		if match.Flow == nil || match.TransformationCount <= 0 || match.ReplacementName == "succeedSome" && match.ValueNode == nil {
 			return nil
 		}
 
@@ -56,7 +56,7 @@ func runPreferSucceedSomeOrNoneFix(ctx *fixable.Context) []ls.CodeAction {
 						ast.NodeFlagsNone,
 					)
 				}
-				tracker.ReplaceNode(ctx.SourceFile, match.ReplacementTarget, replacement, nil)
+				tracker.ReplacePipingFlowPrefix(ctx.SourceFile, match.Flow, match.TransformationCount, replacement)
 			},
 		}); action != nil {
 			return []ls.CodeAction{*action}

--- a/internal/rewriter/piping_flow.go
+++ b/internal/rewriter/piping_flow.go
@@ -1,0 +1,264 @@
+package rewriter
+
+import (
+	"github.com/effect-ts/tsgo/internal/typeparser"
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+)
+
+// PipingFlowTransformationReplacement describes a replacement operator in its
+// normalized, pipeable form. A nil Arguments list represents a bare operator;
+// a non-nil list represents a call, including an explicit zero-argument call.
+type PipingFlowTransformationReplacement struct {
+	Callee        *ast.Node
+	TypeArguments *ast.NodeList
+	Arguments     *ast.NodeList
+}
+
+// ReplacePipingFlowPrefix replaces the subject and the requested leading
+// transformations with a complete replacement expression while retaining any
+// transformations that follow the prefix.
+func (t *Tracker) ReplacePipingFlowPrefix(
+	sourceFile *ast.SourceFile,
+	flow *typeparser.PipingFlow,
+	transformationCount int,
+	replacementSubject *ast.Node,
+) bool {
+	if t == nil || sourceFile == nil || flow == nil || replacementSubject == nil ||
+		transformationCount <= 0 || transformationCount > len(flow.Transformations) {
+		return false
+	}
+
+	last := &flow.Transformations[transformationCount-1]
+	transformationNode := pipingFlowTransformationNode(last)
+	var target *ast.Node
+	switch last.Kind {
+	case typeparser.TransformationKindCall,
+		typeparser.TransformationKindDataFirst,
+		typeparser.TransformationKindDataLast:
+		target = transformationNode
+	case typeparser.TransformationKindPipe:
+		return t.replaceFunctionPipePrefix(sourceFile, transformationNode, replacementSubject)
+	case typeparser.TransformationKindPipeable:
+		return t.replaceMethodPipePrefix(sourceFile, transformationNode, replacementSubject)
+	default:
+		return false
+	}
+	if target == nil {
+		return false
+	}
+
+	ast.SetParentInChildren(replacementSubject)
+	t.ReplaceNode(sourceFile, target, replacementSubject, nil)
+	return true
+}
+
+func (t *Tracker) replaceFunctionPipePrefix(sourceFile *ast.SourceFile, lastTransformation *ast.Node, replacementSubject *ast.Node) bool {
+	callNode, call, argumentIndex := containingCallArgument(lastTransformation)
+	if call == nil || argumentIndex < 1 {
+		return false
+	}
+
+	remainingArguments := cloneNodeListNodesFrom(t, call.Arguments, argumentIndex+1)
+	replacement := replacementSubject
+	if len(remainingArguments) > 0 {
+		arguments := append([]*ast.Node{replacementSubject}, remainingArguments...)
+		replacement = t.NewCallExpression(
+			t.DeepCloneNode(call.Expression),
+			t.DeepCloneNode(call.QuestionDotToken),
+			cloneNodeList(t, call.TypeArguments),
+			t.NewNodeList(arguments),
+			callNode.Flags,
+		)
+	}
+	ast.SetParentInChildren(replacement)
+	t.ReplaceNode(sourceFile, callNode, replacement, nil)
+	return true
+}
+
+func (t *Tracker) replaceMethodPipePrefix(sourceFile *ast.SourceFile, lastTransformation *ast.Node, replacementSubject *ast.Node) bool {
+	callNode, call, argumentIndex := containingCallArgument(lastTransformation)
+	if call == nil || argumentIndex < 0 {
+		return false
+	}
+	access := call.Expression.AsPropertyAccessExpression()
+	if access == nil || access.Name() == nil {
+		return false
+	}
+
+	remainingArguments := cloneNodeListNodesFrom(t, call.Arguments, argumentIndex+1)
+	replacement := replacementSubject
+	if len(remainingArguments) > 0 {
+		replacementAccess := t.NewPropertyAccessExpression(
+			replacementSubject,
+			t.DeepCloneNode(access.QuestionDotToken),
+			t.DeepCloneNode(access.Name()),
+			call.Expression.Flags,
+		)
+		replacement = t.NewCallExpression(
+			replacementAccess,
+			t.DeepCloneNode(call.QuestionDotToken),
+			cloneNodeList(t, call.TypeArguments),
+			t.NewNodeList(remainingArguments),
+			callNode.Flags,
+		)
+	}
+	ast.SetParentInChildren(replacement)
+	t.ReplaceNode(sourceFile, callNode, replacement, nil)
+	return true
+}
+
+func containingCallArgument(node *ast.Node) (*ast.Node, *ast.CallExpression, int) {
+	for child := node; child != nil && child.Parent != nil; child = child.Parent {
+		parent := child.Parent
+		if !ast.IsCallExpression(parent) {
+			continue
+		}
+		call := parent.AsCallExpression()
+		if call == nil || call.Arguments == nil {
+			continue
+		}
+		for index, argument := range call.Arguments.Nodes {
+			if argument == child {
+				return parent, call, index
+			}
+		}
+	}
+	return nil, nil, -1
+}
+
+func pipingFlowTransformationNode(transformation *typeparser.PipingFlowTransformation) *ast.Node {
+	if transformation == nil || transformation.Callee == nil {
+		return nil
+	}
+	if call := callExpressionForCallee(transformation.Callee); call != nil {
+		return call.AsNode()
+	}
+	return transformation.Callee
+}
+
+func callExpressionForCallee(callee *ast.Node) *ast.CallExpression {
+	if callee == nil || callee.Parent == nil || !ast.IsCallExpression(callee.Parent) {
+		return nil
+	}
+	call := callee.Parent.AsCallExpression()
+	if call == nil || call.Expression != callee {
+		return nil
+	}
+	return call
+}
+
+// ReplacePipingFlowTransformation replaces a transformation while preserving
+// how its input is applied in source: as a pipe argument, a data-first or
+// data-last argument, or a unary/curried application.
+func (t *Tracker) ReplacePipingFlowTransformation(
+	sourceFile *ast.SourceFile,
+	transformation *typeparser.PipingFlowTransformation,
+	replacement PipingFlowTransformationReplacement,
+) bool {
+	if t == nil || sourceFile == nil || transformation == nil || replacement.Callee == nil {
+		return false
+	}
+	transformationNode := pipingFlowTransformationNode(transformation)
+	if transformationNode == nil {
+		return false
+	}
+
+	switch transformation.Kind {
+	case typeparser.TransformationKindPipe,
+		typeparser.TransformationKindPipeable,
+		typeparser.TransformationKindEffectFn,
+		typeparser.TransformationKindEffectFnUntraced:
+		replacementNode := t.pipingFlowOperator(replacement)
+		ast.SetParentInChildren(replacementNode)
+		t.ReplaceNode(sourceFile, transformationNode, replacementNode, nil)
+		return true
+
+	case typeparser.TransformationKindDataFirst, typeparser.TransformationKindDataLast:
+		call := transformationNode.AsCallExpression()
+		if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+			return false
+		}
+		arguments := cloneNodeListNodes(t, replacement.Arguments)
+		subjectIndex := 0
+		if transformation.Kind == typeparser.TransformationKindDataLast {
+			subjectIndex = len(call.Arguments.Nodes) - 1
+		}
+		subject := t.DeepCloneNode(call.Arguments.Nodes[subjectIndex])
+		if transformation.Kind == typeparser.TransformationKindDataFirst {
+			arguments = append([]*ast.Node{subject}, arguments...)
+		} else {
+			arguments = append(arguments, subject)
+		}
+		replacementNode := t.NewCallExpression(
+			replacement.Callee,
+			nil,
+			replacement.TypeArguments,
+			t.NewNodeList(arguments),
+			ast.NodeFlagsNone,
+		)
+		ast.SetParentInChildren(replacementNode)
+		t.ReplaceNode(sourceFile, transformationNode, replacementNode, nil)
+		return true
+
+	case typeparser.TransformationKindCall:
+		call := transformationNode.AsCallExpression()
+		if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) != 1 {
+			return false
+		}
+		operator := t.pipingFlowOperator(replacement)
+		replacementNode := t.NewCallExpression(
+			operator,
+			nil,
+			nil,
+			t.NewNodeList([]*ast.Node{t.DeepCloneNode(call.Arguments.Nodes[0])}),
+			ast.NodeFlagsNone,
+		)
+		ast.SetParentInChildren(replacementNode)
+		t.ReplaceNode(sourceFile, transformationNode, replacementNode, nil)
+		return true
+	}
+
+	return false
+}
+
+func (t *Tracker) pipingFlowOperator(replacement PipingFlowTransformationReplacement) *ast.Node {
+	if replacement.Arguments == nil && replacement.TypeArguments == nil {
+		return replacement.Callee
+	}
+	return t.NewCallExpression(
+		replacement.Callee,
+		nil,
+		replacement.TypeArguments,
+		replacement.Arguments,
+		ast.NodeFlagsNone,
+	)
+}
+
+func cloneNodeListNodes(t *Tracker, list *ast.NodeList) []*ast.Node {
+	if list == nil {
+		return nil
+	}
+	nodes := make([]*ast.Node, len(list.Nodes))
+	for i, node := range list.Nodes {
+		nodes[i] = t.DeepCloneNode(node)
+	}
+	return nodes
+}
+
+func cloneNodeListNodesFrom(t *Tracker, list *ast.NodeList, start int) []*ast.Node {
+	if list == nil || start >= len(list.Nodes) {
+		return nil
+	}
+	nodes := make([]*ast.Node, len(list.Nodes)-start)
+	for i, node := range list.Nodes[start:] {
+		nodes[i] = t.DeepCloneNode(node)
+	}
+	return nodes
+}
+
+func cloneNodeList(t *Tracker, list *ast.NodeList) *ast.NodeList {
+	if list == nil {
+		return nil
+	}
+	return t.NewNodeList(cloneNodeListNodes(t, list))
+}

--- a/internal/rules/catch_conditional_refail_to_catch_if.go
+++ b/internal/rules/catch_conditional_refail_to_catch_if.go
@@ -67,7 +67,7 @@ func AnalyzeCatchConditionalRefailToCatchIf(tp *typeparser.TypeParser, c *checke
 	for _, flow := range tp.PipingFlows(sf, true) {
 		for index := range flow.Transformations {
 			transformation := &flow.Transformations[index]
-			if transformation.Node == nil || transformation.Callee == nil {
+			if transformation.Callee == nil {
 				continue
 			}
 			methods, ok := conditionalRefailMethods(tp, transformation.Callee)

--- a/internal/rules/catch_conditional_refail_to_catch_if.go
+++ b/internal/rules/catch_conditional_refail_to_catch_if.go
@@ -64,17 +64,12 @@ func AnalyzeCatchConditionalRefailToCatchIf(tp *typeparser.TypeParser, c *checke
 	}
 
 	var matches []CatchConditionalRefailToCatchIfMatch
-	seen := make(map[*ast.Node]struct{})
 	for _, flow := range tp.PipingFlows(sf, true) {
 		for index := range flow.Transformations {
 			transformation := &flow.Transformations[index]
 			if transformation.Node == nil || transformation.Callee == nil {
 				continue
 			}
-			if _, duplicate := seen[transformation.Node]; duplicate {
-				continue
-			}
-
 			methods, ok := conditionalRefailMethods(tp, transformation.Callee)
 			if !ok || len(transformation.Args) != 1 {
 				continue
@@ -93,7 +88,6 @@ func AnalyzeCatchConditionalRefailToCatchIf(tp *typeparser.TypeParser, c *checke
 				continue
 			}
 
-			seen[transformation.Node] = struct{}{}
 			matches = append(matches, CatchConditionalRefailToCatchIfMatch{
 				SourceFile:          sf,
 				Location:            scanner.GetErrorRangeForNode(sf, transformation.Callee),

--- a/internal/rules/catch_die_to_or_die.go
+++ b/internal/rules/catch_die_to_or_die.go
@@ -40,14 +40,12 @@ var CatchDieToOrDie = rule.Rule{
 
 // CatchDieToOrDieMatch holds the nodes needed by the diagnostic and fix.
 type CatchDieToOrDieMatch struct {
-	SourceFile        *ast.SourceFile
-	Location          core.TextRange
-	Transformation    *ast.Node
-	EffectModule      *ast.Node
-	Input             *ast.Node
-	CatchMethodName   string
-	IsDataApplication bool
-	HasTypeArguments  bool
+	SourceFile       *ast.SourceFile
+	Location         core.TextRange
+	Transformation   *typeparser.PipingFlowTransformation
+	EffectModule     *ast.Node
+	CatchMethodName  string
+	HasTypeArguments bool
 }
 
 // AnalyzeCatchDieToOrDie finds Effect.catch/catchAll transformations whose
@@ -59,34 +57,28 @@ func AnalyzeCatchDieToOrDie(tp *typeparser.TypeParser, _ *checker.Checker, sf *a
 
 	var matches []CatchDieToOrDieMatch
 	for _, flow := range tp.PipingFlows(sf, true) {
-		inputNode := flow.Subject.Node
 		inputType := flow.Subject.OutType
 		for i := range flow.Transformations {
 			transformation := &flow.Transformations[i]
-			callee, args, isCurriedApplication := catchDieTransformationCall(transformation)
+			callee, args := catchDieTransformationCall(transformation)
 			methodName, effectModule, ok := catchDieMethod(tp, callee)
 			if ok && len(args) == 1 {
 				handler, _, _ := tp.UnwrapIdentityForwarder(args[0])
 				if tp.IsNodeReferenceToEffectModuleApi(handler, "die") {
 					inputEffect := tp.StrictEffectType(inputType)
 					if inputEffect != nil && inputEffect.E != nil && inputEffect.E.Flags()&checker.TypeFlagsNever == 0 {
-						isDataApplication := transformation.Kind == typeparser.TransformationKindDataFirst ||
-							transformation.Kind == typeparser.TransformationKindDataLast || isCurriedApplication
 						matches = append(matches, CatchDieToOrDieMatch{
-							SourceFile:        sf,
-							Location:          scanner.GetErrorRangeForNode(sf, callee),
-							Transformation:    transformation.Node,
-							EffectModule:      effectModule,
-							Input:             inputNode,
-							CatchMethodName:   methodName,
-							IsDataApplication: isDataApplication,
-							HasTypeArguments:  catchDieHasTypeArguments(transformation),
+							SourceFile:       sf,
+							Location:         scanner.GetErrorRangeForNode(sf, callee),
+							Transformation:   transformation,
+							EffectModule:     effectModule,
+							CatchMethodName:  methodName,
+							HasTypeArguments: catchDieHasTypeArguments(transformation),
 						})
 					}
 				}
 			}
 
-			inputNode = transformation.Node
 			inputType = transformation.OutType
 		}
 	}
@@ -94,20 +86,20 @@ func AnalyzeCatchDieToOrDie(tp *typeparser.TypeParser, _ *checker.Checker, sf *a
 	return matches
 }
 
-func catchDieTransformationCall(transformation *typeparser.PipingFlowTransformation) (callee *ast.Node, args []*ast.Node, isCurriedApplication bool) {
+func catchDieTransformationCall(transformation *typeparser.PipingFlowTransformation) (callee *ast.Node, args []*ast.Node) {
 	if transformation == nil {
-		return nil, nil, false
+		return nil, nil
 	}
 	callee = transformation.Callee
 	args = transformation.Args
 	if len(args) != 0 || callee == nil || callee.Kind != ast.KindCallExpression {
-		return callee, args, false
+		return callee, args
 	}
 	call := callee.AsCallExpression()
 	if call == nil || call.Expression == nil || call.Arguments == nil {
-		return callee, args, false
+		return callee, args
 	}
-	return call.Expression, call.Arguments.Nodes, true
+	return call.Expression, call.Arguments.Nodes
 }
 
 func catchDieMethod(tp *typeparser.TypeParser, callee *ast.Node) (name string, effectModule *ast.Node, ok bool) {

--- a/internal/rules/catch_die_to_or_die.go
+++ b/internal/rules/catch_die_to_or_die.go
@@ -58,7 +58,6 @@ func AnalyzeCatchDieToOrDie(tp *typeparser.TypeParser, _ *checker.Checker, sf *a
 	}
 
 	var matches []CatchDieToOrDieMatch
-	seen := make(map[*ast.Node]struct{})
 	for _, flow := range tp.PipingFlows(sf, true) {
 		inputNode := flow.Subject.Node
 		inputType := flow.Subject.OutType
@@ -71,21 +70,18 @@ func AnalyzeCatchDieToOrDie(tp *typeparser.TypeParser, _ *checker.Checker, sf *a
 				if tp.IsNodeReferenceToEffectModuleApi(handler, "die") {
 					inputEffect := tp.StrictEffectType(inputType)
 					if inputEffect != nil && inputEffect.E != nil && inputEffect.E.Flags()&checker.TypeFlagsNever == 0 {
-						if _, duplicate := seen[transformation.Node]; !duplicate {
-							seen[transformation.Node] = struct{}{}
-							isDataApplication := transformation.Kind == typeparser.TransformationKindDataFirst ||
-								transformation.Kind == typeparser.TransformationKindDataLast || isCurriedApplication
-							matches = append(matches, CatchDieToOrDieMatch{
-								SourceFile:        sf,
-								Location:          scanner.GetErrorRangeForNode(sf, callee),
-								Transformation:    transformation.Node,
-								EffectModule:      effectModule,
-								Input:             inputNode,
-								CatchMethodName:   methodName,
-								IsDataApplication: isDataApplication,
-								HasTypeArguments:  catchDieHasTypeArguments(transformation),
-							})
-						}
+						isDataApplication := transformation.Kind == typeparser.TransformationKindDataFirst ||
+							transformation.Kind == typeparser.TransformationKindDataLast || isCurriedApplication
+						matches = append(matches, CatchDieToOrDieMatch{
+							SourceFile:        sf,
+							Location:          scanner.GetErrorRangeForNode(sf, callee),
+							Transformation:    transformation.Node,
+							EffectModule:      effectModule,
+							Input:             inputNode,
+							CatchMethodName:   methodName,
+							IsDataApplication: isDataApplication,
+							HasTypeArguments:  catchDieHasTypeArguments(transformation),
+						})
 					}
 				}
 			}

--- a/internal/rules/catch_die_to_or_die.go
+++ b/internal/rules/catch_die_to_or_die.go
@@ -137,17 +137,5 @@ func catchDieMethod(tp *typeparser.TypeParser, callee *ast.Node) (name string, e
 }
 
 func catchDieHasTypeArguments(transformation *typeparser.PipingFlowTransformation) bool {
-	if transformation == nil {
-		return false
-	}
-	for _, node := range []*ast.Node{transformation.Node, transformation.Callee} {
-		if node == nil || node.Kind != ast.KindCallExpression {
-			continue
-		}
-		call := node.AsCallExpression()
-		if call != nil && call.TypeArguments != nil && len(call.TypeArguments.Nodes) > 0 {
-			return true
-		}
-	}
-	return false
+	return transformation != nil && transformation.TypeArguments != nil && len(transformation.TypeArguments.Nodes) > 0
 }

--- a/internal/rules/catch_tag_to_catch_reason.go
+++ b/internal/rules/catch_tag_to_catch_reason.go
@@ -65,28 +65,21 @@ func AnalyzeCatchTagToCatchReason(tp *typeparser.TypeParser, c *checker.Checker,
 	}
 
 	var matches []CatchTagToCatchReasonMatch
-	seen := make(map[*ast.Node]struct{})
 	for _, flow := range tp.PipingFlows(sf, true) {
 		for i := range flow.Transformations {
 			transformation := &flow.Transformations[i]
 			if transformation.Node == nil || transformation.Callee == nil {
 				continue
 			}
-			if _, ok := seen[transformation.Node]; ok {
-				continue
-			}
-
 			switch {
 			case tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "catchTag"):
 				match, ok := analyzeCatchTagTransformation(tp, c, sf, transformation)
 				if ok {
-					seen[transformation.Node] = struct{}{}
 					matches = append(matches, match)
 				}
 			case tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "catchTags"):
 				match, ok := analyzeCatchTagsTransformation(tp, c, sf, transformation)
 				if ok {
-					seen[transformation.Node] = struct{}{}
 					matches = append(matches, match)
 				}
 			}

--- a/internal/rules/catch_tag_to_catch_reason.go
+++ b/internal/rules/catch_tag_to_catch_reason.go
@@ -42,7 +42,7 @@ type CatchTagToCatchReasonBranch struct {
 type CatchTagToCatchReasonMatch struct {
 	SourceFile      *ast.SourceFile
 	Location        core.TextRange
-	CallNode        *ast.Node
+	Transformation  *typeparser.PipingFlowTransformation
 	Callee          *ast.Node
 	OuterTag        *ast.Node
 	ParameterName   string
@@ -68,7 +68,7 @@ func AnalyzeCatchTagToCatchReason(tp *typeparser.TypeParser, c *checker.Checker,
 	for _, flow := range tp.PipingFlows(sf, true) {
 		for i := range flow.Transformations {
 			transformation := &flow.Transformations[i]
-			if transformation.Node == nil || transformation.Callee == nil {
+			if transformation.Callee == nil {
 				continue
 			}
 			switch {
@@ -109,17 +109,16 @@ func analyzeCatchTagTransformation(
 		return CatchTagToCatchReasonMatch{}, false
 	}
 
-	canFix := handler.canFix && transformationCallHasExactArgs(transformation)
 	return CatchTagToCatchReasonMatch{
 		SourceFile:      sf,
-		Location:        scanner.GetErrorRangeForNode(sf, transformation.Node),
-		CallNode:        transformation.Node,
+		Location:        scanner.GetErrorRangeForNode(sf, transformation.Callee),
+		Transformation:  transformation,
 		Callee:          transformation.Callee,
 		OuterTag:        outerTag,
 		ParameterName:   handler.parameterName,
 		CatchMethodName: "catchTag",
 		Branches:        handler.branches,
-		CanFix:          canFix,
+		CanFix:          handler.canFix,
 	}, true
 }
 
@@ -168,8 +167,8 @@ func analyzeCatchTagsTransformation(
 
 	return CatchTagToCatchReasonMatch{
 		SourceFile:      sf,
-		Location:        scanner.GetErrorRangeForNode(sf, transformation.Node),
-		CallNode:        transformation.Node,
+		Location:        scanner.GetErrorRangeForNode(sf, transformation.Callee),
+		Transformation:  transformation,
 		Callee:          transformation.Callee,
 		ParameterName:   candidate.parameterName,
 		CatchMethodName: "catchTags",
@@ -407,22 +406,6 @@ func hasCatchReasonApi(tp *typeparser.TypeParser, c *checker.Checker, callee *as
 		apiName = "catchReasons"
 	}
 	return c.GetPropertyOfType(receiverType, apiName) != nil
-}
-
-func transformationCallHasExactArgs(transformation *typeparser.PipingFlowTransformation) bool {
-	if transformation == nil || transformation.Node == nil || transformation.Node.Kind != ast.KindCallExpression {
-		return false
-	}
-	call := transformation.Node.AsCallExpression()
-	if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) != len(transformation.Args) {
-		return false
-	}
-	for i, argument := range call.Arguments.Nodes {
-		if argument != transformation.Args[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func catchTagsPropertyName(name *ast.Node) (string, bool) {

--- a/internal/rules/catch_to_ignore.go
+++ b/internal/rules/catch_to_ignore.go
@@ -33,13 +33,12 @@ var CatchToIgnore = rule.Rule{
 // CatchToIgnoreMatch holds the AST nodes needed by both the diagnostic rule
 // and the quick-fix for the catchToIgnore pattern.
 type CatchToIgnoreMatch struct {
-	SourceFile         *ast.SourceFile
-	Location           core.TextRange
-	TransformationNode *ast.Node
-	EffectModuleNode   *ast.Node
-	CatchMethodName    string
-	IgnoreMethodName   string
-	DataCallSubject    *ast.Node
+	SourceFile       *ast.SourceFile
+	Location         core.TextRange
+	Transformation   *typeparser.PipingFlowTransformation
+	EffectModuleNode *ast.Node
+	CatchMethodName  string
+	IgnoreMethodName string
 }
 
 // AnalyzeCatchToIgnore finds Effect.catch/catchCause callbacks that return Effect.void
@@ -53,7 +52,8 @@ func AnalyzeCatchToIgnore(tp *typeparser.TypeParser, _ *checker.Checker, sf *ast
 
 	flows := tp.PipingFlows(sf, true)
 	for _, flow := range flows {
-		for _, transformation := range flow.Transformations {
+		for index := range flow.Transformations {
+			transformation := &flow.Transformations[index]
 			catchMethodName, ignoreMethodName, effectModuleNode, ok := catchToIgnoreMethods(tp, transformation.Callee)
 			if !ok {
 				continue
@@ -74,13 +74,12 @@ func AnalyzeCatchToIgnore(tp *typeparser.TypeParser, _ *checker.Checker, sf *ast
 			}
 
 			matches = append(matches, CatchToIgnoreMatch{
-				SourceFile:         sf,
-				Location:           scanner.GetErrorRangeForNode(sf, transformation.Callee),
-				TransformationNode: transformation.Node,
-				EffectModuleNode:   effectModuleNode,
-				CatchMethodName:    catchMethodName,
-				IgnoreMethodName:   ignoreMethodName,
-				DataCallSubject:    catchToIgnoreDataCallSubject(transformation.Node, transformation.Args[0]),
+				SourceFile:       sf,
+				Location:         scanner.GetErrorRangeForNode(sf, transformation.Callee),
+				Transformation:   transformation,
+				EffectModuleNode: effectModuleNode,
+				CatchMethodName:  catchMethodName,
+				IgnoreMethodName: ignoreMethodName,
 			})
 		}
 	}
@@ -142,21 +141,4 @@ func isVoidLikeEffectSuccess(t *checker.Type) bool {
 		}
 	}
 	return true
-}
-
-func catchToIgnoreDataCallSubject(node *ast.Node, callback *ast.Node) *ast.Node {
-	if node == nil || callback == nil || node.Kind != ast.KindCallExpression {
-		return nil
-	}
-	call := node.AsCallExpression()
-	if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) != 2 {
-		return nil
-	}
-	if call.Arguments.Nodes[0] == callback {
-		return call.Arguments.Nodes[1]
-	}
-	if call.Arguments.Nodes[1] == callback {
-		return call.Arguments.Nodes[0]
-	}
-	return nil
 }

--- a/internal/rules/effect_map_void.go
+++ b/internal/rules/effect_map_void.go
@@ -35,9 +35,8 @@ var EffectMapVoid = rule.Rule{
 type EffectMapVoidMatch struct {
 	SourceFile       *ast.SourceFile // The source file where the diagnostic should be reported
 	Location         core.TextRange  // The pre-computed error range for this match
-	CallNode         *ast.Node       // The Effect.map(...) call expression (replacement target)
-	EffectModuleNode *ast.Node       // The Effect module identifier (e.g., "Effect" in Effect.map)
-	SubjectNode      *ast.Node       // The data-first subject (e.g. self in Effect.map(self, () => {})); nil for data-last/pipeable forms
+	Transformation   *typeparser.PipingFlowTransformation
+	EffectModuleNode *ast.Node // The Effect module identifier (e.g., "Effect" in Effect.map)
 }
 
 // isVoidCallback checks if a callback argument is a "void callback":
@@ -93,8 +92,9 @@ func AnalyzeEffectMapVoid(tp *typeparser.TypeParser, _ *checker.Checker, sf *ast
 	var matches []EffectMapVoidMatch
 
 	for _, flow := range tp.PipingFlows(sf, true) {
-		for _, transformation := range flow.Transformations {
-			if len(transformation.Args) != 1 || transformation.Node == nil || transformation.Node.Kind != ast.KindCallExpression ||
+		for index := range flow.Transformations {
+			transformation := &flow.Transformations[index]
+			if len(transformation.Args) != 1 ||
 				transformation.Callee == nil || transformation.Callee.Kind != ast.KindPropertyAccessExpression ||
 				!tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "map") {
 				continue
@@ -102,25 +102,12 @@ func AnalyzeEffectMapVoid(tp *typeparser.TypeParser, _ *checker.Checker, sf *ast
 			if !isVoidCallback(transformation.Args[0]) {
 				continue
 			}
-			// For the data-first form the subject is a real argument that the
-			// quick-fix must preserve as Effect.asVoid(self); data-last/pipeable
-			// forms carry no subject argument.
-			var subject *ast.Node
-			if transformation.Kind == typeparser.TransformationKindDataFirst || transformation.Kind == typeparser.TransformationKindDataLast {
-				parsed := tp.DataFirstOrLastCall(transformation.Node)
-				if parsed == nil {
-					continue
-				}
-				subject = parsed.Subject
-			}
-
 			propAccess := transformation.Callee.AsPropertyAccessExpression()
 			matches = append(matches, EffectMapVoidMatch{
 				SourceFile:       sf,
 				Location:         scanner.GetErrorRangeForNode(sf, transformation.Callee),
-				CallNode:         transformation.Node,
+				Transformation:   transformation,
 				EffectModuleNode: propAccess.Expression,
-				SubjectNode:      subject,
 			})
 		}
 	}

--- a/internal/rules/effect_map_void.go
+++ b/internal/rules/effect_map_void.go
@@ -91,7 +91,6 @@ func isVoidCallback(node *ast.Node) bool {
 // data-first Effect.map(self, cb) are matched uniformly.
 func AnalyzeEffectMapVoid(tp *typeparser.TypeParser, _ *checker.Checker, sf *ast.SourceFile) []EffectMapVoidMatch {
 	var matches []EffectMapVoidMatch
-	seen := make(map[*ast.Node]struct{})
 
 	for _, flow := range tp.PipingFlows(sf, true) {
 		for _, transformation := range flow.Transformations {
@@ -103,10 +102,6 @@ func AnalyzeEffectMapVoid(tp *typeparser.TypeParser, _ *checker.Checker, sf *ast
 			if !isVoidCallback(transformation.Args[0]) {
 				continue
 			}
-			if _, ok := seen[transformation.Node]; ok {
-				continue
-			}
-
 			// For the data-first form the subject is a real argument that the
 			// quick-fix must preserve as Effect.asVoid(self); data-last/pipeable
 			// forms carry no subject argument.
@@ -120,7 +115,6 @@ func AnalyzeEffectMapVoid(tp *typeparser.TypeParser, _ *checker.Checker, sf *ast
 			}
 
 			propAccess := transformation.Callee.AsPropertyAccessExpression()
-			seen[transformation.Node] = struct{}{}
 			matches = append(matches, EffectMapVoidMatch{
 				SourceFile:       sf,
 				Location:         scanner.GetErrorRangeForNode(sf, transformation.Callee),

--- a/internal/rules/flat_map_conditional_to_filter_or_fail.go
+++ b/internal/rules/flat_map_conditional_to_filter_or_fail.go
@@ -63,7 +63,6 @@ func AnalyzeFlatMapConditionalToFilterOrFail(tp *typeparser.TypeParser, c *check
 	}
 
 	var matches []FlatMapConditionalToFilterOrFailMatch
-	seen := make(map[*ast.Node]struct{})
 	for _, flow := range tp.PipingFlows(sf, true) {
 		for index := range flow.Transformations {
 			transformation := &flow.Transformations[index]
@@ -71,10 +70,6 @@ func AnalyzeFlatMapConditionalToFilterOrFail(tp *typeparser.TypeParser, c *check
 			if callee == nil || replacementNode == nil || len(args) != 1 || !tp.IsNodeReferenceToEffectModuleApi(callee, "flatMap") {
 				continue
 			}
-			if _, duplicate := seen[replacementNode]; duplicate {
-				continue
-			}
-
 			parsed := typeparser.ParseReturningDispatch(args[0])
 			if parsed == nil || parsed.Dispatch == nil || len(parsed.Params) != 1 ||
 				len(parsed.Dispatch.Branches) != 1 || parsed.Dispatch.Fallback == nil ||
@@ -145,7 +140,6 @@ func AnalyzeFlatMapConditionalToFilterOrFail(tp *typeparser.TypeParser, c *check
 				match.SubjectNode = nil
 			}
 
-			seen[replacementNode] = struct{}{}
 			matches = append(matches, match)
 		}
 	}

--- a/internal/rules/flat_map_conditional_to_filter_or_fail.go
+++ b/internal/rules/flat_map_conditional_to_filter_or_fail.go
@@ -44,9 +44,8 @@ var FlatMapConditionalToFilterOrFail = rule.Rule{
 type FlatMapConditionalToFilterOrFailMatch struct {
 	SourceFile          *ast.SourceFile
 	Location            core.TextRange
-	ReplacementNode     *ast.Node
+	Transformation      *typeparser.PipingFlowTransformation
 	EffectModuleNode    *ast.Node
-	SubjectNode         *ast.Node
 	ParameterNode       *ast.Node
 	PredicateNode       *ast.Node
 	FallbackNode        *ast.Node
@@ -66,8 +65,8 @@ func AnalyzeFlatMapConditionalToFilterOrFail(tp *typeparser.TypeParser, c *check
 	for _, flow := range tp.PipingFlows(sf, true) {
 		for index := range flow.Transformations {
 			transformation := &flow.Transformations[index]
-			callee, args, replacementNode, curried := flatMapConditionalTransformation(transformation)
-			if callee == nil || replacementNode == nil || len(args) != 1 || !tp.IsNodeReferenceToEffectModuleApi(callee, "flatMap") {
+			callee, args := flatMapConditionalTransformation(transformation)
+			if callee == nil || len(args) != 1 || !tp.IsNodeReferenceToEffectModuleApi(callee, "flatMap") {
 				continue
 			}
 			parsed := typeparser.ParseReturningDispatch(args[0])
@@ -118,7 +117,7 @@ func AnalyzeFlatMapConditionalToFilterOrFail(tp *typeparser.TypeParser, c *check
 			match := FlatMapConditionalToFilterOrFailMatch{
 				SourceFile:          sf,
 				Location:            scanner.GetErrorRangeForNode(sf, callee),
-				ReplacementNode:     replacementNode,
+				Transformation:      transformation,
 				EffectModuleNode:    effectModule,
 				ParameterNode:       parameter,
 				PredicateNode:       branch.Condition.Subject,
@@ -128,42 +127,27 @@ func AnalyzeFlatMapConditionalToFilterOrFail(tp *typeparser.TypeParser, c *check
 				CanFix:              effectModule != nil,
 			}
 
-			if transformation.Kind == typeparser.TransformationKindDataFirst || transformation.Kind == typeparser.TransformationKindDataLast {
-				dataCall := tp.DataFirstOrLastCall(transformation.Node)
-				if dataCall == nil {
-					continue
-				}
-				match.SubjectNode = dataCall.Subject
-			} else if curried {
-				// The replacement is the inner operator call, so the outer subject
-				// application remains untouched.
-				match.SubjectNode = nil
-			}
-
 			matches = append(matches, match)
 		}
 	}
 	return matches
 }
 
-func flatMapConditionalTransformation(transformation *typeparser.PipingFlowTransformation) (callee *ast.Node, args []*ast.Node, replacement *ast.Node, curried bool) {
-	if transformation == nil || transformation.Node == nil || transformation.Callee == nil {
-		return nil, nil, nil, false
+func flatMapConditionalTransformation(transformation *typeparser.PipingFlowTransformation) (callee *ast.Node, args []*ast.Node) {
+	if transformation == nil || transformation.Callee == nil {
+		return nil, nil
 	}
 	callee = transformation.Callee
 	args = transformation.Args
-	replacement = transformation.Node
 	if len(args) == 0 && callee.Kind == ast.KindCallExpression {
 		call := callee.AsCallExpression()
 		if call == nil || call.Expression == nil || call.Arguments == nil {
-			return nil, nil, nil, false
+			return nil, nil
 		}
 		callee = call.Expression
 		args = call.Arguments.Nodes
-		replacement = call.AsNode()
-		curried = true
 	}
-	return callee, args, replacement, curried
+	return callee, args
 }
 
 func isIdentitySucceed(tp *typeparser.TypeParser, c *checker.Checker, expression *ast.Node, parameterSymbol *ast.Symbol) bool {

--- a/internal/rules/map_some_to_as_some.go
+++ b/internal/rules/map_some_to_as_some.go
@@ -59,8 +59,7 @@ func AnalyzeMapSomeToAsSome(tp *typeparser.TypeParser, _ *checker.Checker, sf *a
 				continue
 			}
 
-			call := transformation.Node.AsCallExpression()
-			if call == nil || call.TypeArguments != nil && len(call.TypeArguments.Nodes) > 0 ||
+			if transformation.TypeArguments != nil && len(transformation.TypeArguments.Nodes) > 0 ||
 				!isOptionSomeMapper(tp, transformation.Args[0]) {
 				continue
 			}

--- a/internal/rules/map_some_to_as_some.go
+++ b/internal/rules/map_some_to_as_some.go
@@ -50,7 +50,6 @@ type MapSomeToAsSomeMatch struct {
 // mapper is Option.some or an identity forwarder such as value => Option.some(value).
 func AnalyzeMapSomeToAsSome(tp *typeparser.TypeParser, _ *checker.Checker, sf *ast.SourceFile) []MapSomeToAsSomeMatch {
 	var matches []MapSomeToAsSomeMatch
-	seen := make(map[*ast.Node]struct{})
 	for _, flow := range tp.PipingFlows(sf, true) {
 		for _, transformation := range flow.Transformations {
 			if len(transformation.Args) != 1 || transformation.Node == nil || transformation.Node.Kind != ast.KindCallExpression ||
@@ -63,10 +62,6 @@ func AnalyzeMapSomeToAsSome(tp *typeparser.TypeParser, _ *checker.Checker, sf *a
 				!isOptionSomeMapper(tp, transformation.Args[0]) {
 				continue
 			}
-			if _, ok := seen[transformation.Node]; ok {
-				continue
-			}
-
 			var subject *ast.Node
 			if transformation.Kind == typeparser.TransformationKindDataFirst || transformation.Kind == typeparser.TransformationKindDataLast {
 				parsed := tp.DataFirstOrLastCall(transformation.Node)
@@ -77,7 +72,6 @@ func AnalyzeMapSomeToAsSome(tp *typeparser.TypeParser, _ *checker.Checker, sf *a
 			}
 
 			propertyAccess := transformation.Callee.AsPropertyAccessExpression()
-			seen[transformation.Node] = struct{}{}
 			matches = append(matches, MapSomeToAsSomeMatch{
 				SourceFile:       sf,
 				Location:         scanner.GetErrorRangeForNode(sf, transformation.Callee),

--- a/internal/rules/map_some_to_as_some.go
+++ b/internal/rules/map_some_to_as_some.go
@@ -41,9 +41,8 @@ var MapSomeToAsSome = rule.Rule{
 type MapSomeToAsSomeMatch struct {
 	SourceFile       *ast.SourceFile
 	Location         core.TextRange
-	CallNode         *ast.Node
+	Transformation   *typeparser.PipingFlowTransformation
 	EffectModuleNode *ast.Node
-	SubjectNode      *ast.Node
 }
 
 // AnalyzeMapSomeToAsSome finds data-last and data-first Effect.map calls whose
@@ -51,8 +50,9 @@ type MapSomeToAsSomeMatch struct {
 func AnalyzeMapSomeToAsSome(tp *typeparser.TypeParser, _ *checker.Checker, sf *ast.SourceFile) []MapSomeToAsSomeMatch {
 	var matches []MapSomeToAsSomeMatch
 	for _, flow := range tp.PipingFlows(sf, true) {
-		for _, transformation := range flow.Transformations {
-			if len(transformation.Args) != 1 || transformation.Node == nil || transformation.Node.Kind != ast.KindCallExpression ||
+		for index := range flow.Transformations {
+			transformation := &flow.Transformations[index]
+			if len(transformation.Args) != 1 ||
 				transformation.Callee == nil || transformation.Callee.Kind != ast.KindPropertyAccessExpression ||
 				!tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "map") {
 				continue
@@ -62,22 +62,12 @@ func AnalyzeMapSomeToAsSome(tp *typeparser.TypeParser, _ *checker.Checker, sf *a
 				!isOptionSomeMapper(tp, transformation.Args[0]) {
 				continue
 			}
-			var subject *ast.Node
-			if transformation.Kind == typeparser.TransformationKindDataFirst || transformation.Kind == typeparser.TransformationKindDataLast {
-				parsed := tp.DataFirstOrLastCall(transformation.Node)
-				if parsed == nil {
-					continue
-				}
-				subject = parsed.Subject
-			}
-
 			propertyAccess := transformation.Callee.AsPropertyAccessExpression()
 			matches = append(matches, MapSomeToAsSomeMatch{
 				SourceFile:       sf,
 				Location:         scanner.GetErrorRangeForNode(sf, transformation.Callee),
-				CallNode:         transformation.Node,
+				Transformation:   transformation,
 				EffectModuleNode: propertyAccess.Expression,
-				SubjectNode:      subject,
 			})
 		}
 	}

--- a/internal/rules/missing_effect_context.go
+++ b/internal/rules/missing_effect_context.go
@@ -93,7 +93,7 @@ func formatContextTypes(c *checker.Checker, types []*checker.Type) string {
 
 func missingEffectContextRelatedInformation(c *checker.Checker, ctx *rule.Context, errorNode *ast.Node, missingTypes []*checker.Type) []*ast.Diagnostic {
 	provideLocation := findRelatedProvideLocation(ctx.TypeParser, c, ctx.SourceFile, errorNode)
-	if provideLocation.Node == nil || provideLocation.LayerNode == nil {
+	if provideLocation.LayerNode == nil {
 		return nil
 	}
 	layerDiagnostics := findRelatedLayerProviderDiagnostics(c, ctx, provideLocation.LayerNode, missingTypes)
@@ -113,7 +113,6 @@ func missingEffectContextRelatedInformation(c *checker.Checker, ctx *rule.Contex
 }
 
 type provideLocation struct {
-	Node      *ast.Node
 	LayerNode *ast.Node
 	Location  core.TextRange
 }
@@ -139,14 +138,9 @@ func findRelatedProvideLocation(tp *typeparser.TypeParser, c *checker.Checker, s
 			if !tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "provide") {
 				continue
 			}
-			callNode := transformation.Node
-			if callNode == nil {
-				callNode = transformation.Callee
-			}
 			return provideLocation{
-				Node:      callNode,
 				LayerNode: firstNode(transformation.Args),
-				Location:  scanner.GetErrorRangeForNode(sf, callNode),
+				Location:  scanner.GetErrorRangeForNode(sf, transformation.Callee),
 			}
 		}
 	}
@@ -256,9 +250,11 @@ func findTransformationIndexContainingNode(flow *typeparser.PipingFlow, target *
 	if flow == nil || target == nil {
 		return -1
 	}
+	target = ast.SkipParentheses(target)
 	for i := range flow.Transformations {
 		transformation := flow.Transformations[i]
-		if transformation.Node == target || transformation.Callee == target {
+		callee := ast.SkipParentheses(transformation.Callee)
+		if callee == target || callee != nil && callee.Pos() == target.Pos() && target.End() >= callee.End() {
 			return i
 		}
 	}

--- a/internal/rules/option_match_to_from_option.go
+++ b/internal/rules/option_match_to_from_option.go
@@ -43,11 +43,11 @@ var OptionMatchToFromOption = rule.Rule{
 type OptionMatchToFromOptionMatch struct {
 	SourceFile       *ast.SourceFile
 	Location         core.TextRange
+	Transformation   *typeparser.PipingFlowTransformation
 	ReplacementNode  *ast.Node
 	EffectModuleNode *ast.Node
 	OptionNode       *ast.Node
 	FailureNode      *ast.Node
-	Pipeable         bool
 	DefaultFailure   bool
 	CanFix           bool
 }
@@ -70,7 +70,7 @@ func analyzeOptionMatchCalls(tp *typeparser.TypeParser, sf *ast.SourceFile) []Op
 	for _, flow := range tp.PipingFlows(sf, true) {
 		for index := range flow.Transformations {
 			transformation := &flow.Transformations[index]
-			if transformation.Node == nil || transformation.Callee == nil {
+			if transformation.Callee == nil {
 				continue
 			}
 
@@ -96,7 +96,7 @@ func analyzeOptionMatchCalls(tp *typeparser.TypeParser, sf *ast.SourceFile) []Op
 			match := OptionMatchToFromOptionMatch{
 				SourceFile:       sf,
 				Location:         scanner.GetErrorRangeForNode(sf, callee),
-				ReplacementNode:  transformation.Node,
+				Transformation:   transformation,
 				EffectModuleNode: effectModule,
 				FailureNode:      failure,
 				DefaultFailure:   isDefaultNoSuchElementError(tp, failure),
@@ -104,22 +104,11 @@ func analyzeOptionMatchCalls(tp *typeparser.TypeParser, sf *ast.SourceFile) []Op
 			}
 
 			switch transformation.Kind {
-			case typeparser.TransformationKindPipe, typeparser.TransformationKindPipeable:
-				match.Pipeable = true
-			case typeparser.TransformationKindDataFirst, typeparser.TransformationKindDataLast:
-				parsed := tp.DataFirstOrLastCall(transformation.Node)
-				if parsed == nil {
-					continue
-				}
-				match.OptionNode = parsed.Subject
-			case typeparser.TransformationKindCall:
-				// A direct data-last call has the shape Option.match(handlers)(option).
-				// It is only safe to rebuild from the flow subject when this is the
-				// first transformation in the flow.
-				if index != 0 || flow.Subject.Node == nil {
-					continue
-				}
-				match.OptionNode = flow.Subject.Node
+			case typeparser.TransformationKindPipe,
+				typeparser.TransformationKindPipeable,
+				typeparser.TransformationKindDataFirst,
+				typeparser.TransformationKindDataLast,
+				typeparser.TransformationKindCall:
 			default:
 				continue
 			}

--- a/internal/rules/option_match_to_from_option.go
+++ b/internal/rules/option_match_to_from_option.go
@@ -66,7 +66,6 @@ func AnalyzeOptionMatchToFromOption(tp *typeparser.TypeParser, c *checker.Checke
 
 func analyzeOptionMatchCalls(tp *typeparser.TypeParser, sf *ast.SourceFile) []OptionMatchToFromOptionMatch {
 	var matches []OptionMatchToFromOptionMatch
-	seen := make(map[*ast.Node]struct{})
 
 	for _, flow := range tp.PipingFlows(sf, true) {
 		for index := range flow.Transformations {
@@ -125,10 +124,6 @@ func analyzeOptionMatchCalls(tp *typeparser.TypeParser, sf *ast.SourceFile) []Op
 				continue
 			}
 
-			if _, duplicate := seen[match.ReplacementNode]; duplicate {
-				continue
-			}
-			seen[match.ReplacementNode] = struct{}{}
 			matches = append(matches, match)
 		}
 	}

--- a/internal/rules/prefer_succeed_some_or_none.go
+++ b/internal/rules/prefer_succeed_some_or_none.go
@@ -64,7 +64,6 @@ func AnalyzePreferSucceedSomeOrNone(tp *typeparser.TypeParser, _ *checker.Checke
 	}
 
 	var matches []PreferSucceedSomeOrNoneMatch
-	seen := make(map[*ast.Node]struct{})
 	for _, flow := range tp.PipingFlows(sf, true) {
 		for index := range flow.Transformations {
 			transformation := &flow.Transformations[index]
@@ -73,10 +72,6 @@ func AnalyzePreferSucceedSomeOrNone(tp *typeparser.TypeParser, _ *checker.Checke
 				!tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "succeed") {
 				continue
 			}
-			if _, ok := seen[transformation.Node]; ok {
-				continue
-			}
-
 			if transformation.TypeArguments != nil && len(transformation.TypeArguments.Nodes) > 0 {
 				continue
 			}
@@ -106,7 +101,6 @@ func AnalyzePreferSucceedSomeOrNone(tp *typeparser.TypeParser, _ *checker.Checke
 				match.ReplacementTarget = flow.Node
 			}
 
-			seen[transformation.Node] = struct{}{}
 			matches = append(matches, match)
 		}
 	}

--- a/internal/rules/prefer_succeed_some_or_none.go
+++ b/internal/rules/prefer_succeed_some_or_none.go
@@ -40,13 +40,14 @@ var PreferSucceedSomeOrNone = rule.Rule{
 
 // PreferSucceedSomeOrNoneMatch holds the nodes needed by the diagnostic and quick fix.
 type PreferSucceedSomeOrNoneMatch struct {
-	SourceFile         *ast.SourceFile
-	Location           core.TextRange
-	ReplacementTarget  *ast.Node
-	EffectModuleNode   *ast.Node
-	ReplacementName    string
-	ValueNode          *ast.Node
-	ValueTypeArguments *ast.NodeList
+	SourceFile          *ast.SourceFile
+	Location            core.TextRange
+	Flow                *typeparser.PipingFlow
+	TransformationCount int
+	EffectModuleNode    *ast.Node
+	ReplacementName     string
+	ValueNode           *ast.Node
+	ValueTypeArguments  *ast.NodeList
 }
 
 type normalizedOptionInput struct {
@@ -90,15 +91,11 @@ func AnalyzePreferSucceedSomeOrNone(tp *typeparser.TypeParser, _ *checker.Checke
 				ValueTypeArguments: optionInput.ValueTypeArguments,
 			}
 
-			// A direct Effect.succeed(...) call can be replaced in place even when
-			// more transformations follow. A pipe spelling is safely auto-fixable
-			// when the matched Option -> succeed pair is the complete flow.
-			if transformation.Node != nil && transformation.Node.Kind == ast.KindCallExpression {
-				match.ReplacementTarget = transformation.Node
-			} else if index == len(flow.Transformations)-1 &&
-				(match.ReplacementName == "succeedNone" && index == 0 ||
-					match.ReplacementName == "succeedSome" && index == 1) {
-				match.ReplacementTarget = flow.Node
+			if transformation.Kind == typeparser.TransformationKindCall ||
+				transformation.Kind == typeparser.TransformationKindPipe ||
+				transformation.Kind == typeparser.TransformationKindPipeable {
+				match.Flow = flow
+				match.TransformationCount = index + 1
 			}
 
 			matches = append(matches, match)
@@ -128,16 +125,10 @@ func matchNormalizedOptionInput(tp *typeparser.TypeParser, flow *typeparser.Pipi
 		return nil
 	}
 
-	input := &normalizedOptionInput{ReplacementName: "succeedSome"}
-	if previous.Node != nil && previous.Node.Kind == ast.KindCallExpression {
-		call := previous.Node.AsCallExpression()
-		if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) != 1 {
-			return nil
-		}
-		input.ValueNode = call.Arguments.Nodes[0]
-		input.ValueTypeArguments = call.TypeArguments
-	} else if succeedIndex == 1 {
-		input.ValueNode = flow.Subject.Node
+	input := &normalizedOptionInput{
+		ReplacementName:    "succeedSome",
+		ValueNode:          flow.TransformationInputNode(succeedIndex - 1),
+		ValueTypeArguments: previous.TypeArguments,
 	}
 	return input
 }

--- a/internal/rules/prefer_succeed_some_or_none.go
+++ b/internal/rules/prefer_succeed_some_or_none.go
@@ -77,12 +77,8 @@ func AnalyzePreferSucceedSomeOrNone(tp *typeparser.TypeParser, _ *checker.Checke
 				continue
 			}
 
-			if transformation.Node != nil && transformation.Node.Kind == ast.KindCallExpression {
-				call := transformation.Node.AsCallExpression()
-				if call != nil &&
-					call.TypeArguments != nil && len(call.TypeArguments.Nodes) > 0 {
-					continue
-				}
+			if transformation.TypeArguments != nil && len(transformation.TypeArguments.Nodes) > 0 {
+				continue
 			}
 
 			optionInput := matchNormalizedOptionInput(tp, flow, index)

--- a/internal/rules/prefer_typed_schema_decoder.go
+++ b/internal/rules/prefer_typed_schema_decoder.go
@@ -66,17 +66,17 @@ func AnalyzePreferTypedSchemaDecoder(tp *typeparser.TypeParser, c *checker.Check
 	}
 
 	var matches []PreferTypedSchemaDecoderMatch
-	seen := make(map[*ast.Node]bool)
+	handledDecoderNames := make(map[*ast.Node]struct{})
 
 	for _, flow := range tp.PipingFlows(sf, false) {
 		inputNode := flow.Subject.Node
 		inputType := flow.Subject.OutType
 		for _, transformation := range flow.Transformations {
 			callee, schema := schemaDecoderTransformation(transformation)
-			if callee != nil && schema != nil && !seen[transformation.Node] {
+			if callee != nil && schema != nil {
 				if match := analyzeTypedSchemaDecoderApplication(tp, c, sf, callee, schema, inputNode, inputType); match != nil {
 					matches = append(matches, *match)
-					seen[transformation.Node] = true
+					handledDecoderNames[match.DecoderName] = struct{}{}
 				}
 			}
 			inputNode = nil
@@ -89,14 +89,16 @@ func AnalyzePreferTypedSchemaDecoder(tp *typeparser.TypeParser, c *checker.Check
 		if node == nil {
 			return false
 		}
-		if node.Kind == ast.KindCallExpression && !seen[node] {
+		if node.Kind == ast.KindCallExpression {
 			call := node.AsCallExpression()
 			if call.Arguments != nil && len(call.Arguments.Nodes) > 0 && call.Expression != nil && call.Expression.Kind == ast.KindCallExpression {
 				factory := call.Expression.AsCallExpression()
 				if factory.Arguments != nil && len(factory.Arguments.Nodes) > 0 {
 					if match := analyzeTypedSchemaDecoderApplication(tp, c, sf, factory.Expression, factory.Arguments.Nodes[0], call.Arguments.Nodes[0], nil); match != nil {
-						matches = append(matches, *match)
-						seen[node] = true
+						if _, handled := handledDecoderNames[match.DecoderName]; !handled {
+							matches = append(matches, *match)
+							handledDecoderNames[match.DecoderName] = struct{}{}
+						}
 					}
 				}
 			}

--- a/internal/rules/race_first_with_sleep_to_timeout.go
+++ b/internal/rules/race_first_with_sleep_to_timeout.go
@@ -53,7 +53,7 @@ func AnalyzeRaceFirstWithSleepToTimeout(tp *typeparser.TypeParser, c *checker.Ch
 	for _, flow := range tp.PipingFlows(sf, true) {
 		for i := range flow.Transformations {
 			transformation := &flow.Transformations[i]
-			if transformation.Callee == nil || transformation.Node == nil {
+			if transformation.Callee == nil {
 				continue
 			}
 
@@ -71,11 +71,11 @@ func AnalyzeRaceFirstWithSleepToTimeout(tp *typeparser.TypeParser, c *checker.Ch
 				}
 
 			case tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "raceAllFirst"):
-				call := transformation.Node.AsCallExpression()
-				if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) != 1 {
+				input := flow.CopyPrefix(i)
+				if input == nil || input.Subject.Node == nil {
 					continue
 				}
-				array := ast.SkipParentheses(call.Arguments.Nodes[0])
+				array := ast.SkipParentheses(input.Subject.Node)
 				if array == nil || array.Kind != ast.KindArrayLiteralExpression || len(array.AsArrayLiteralExpression().Elements.Nodes) != 2 {
 					continue
 				}

--- a/internal/rules/race_first_with_sleep_to_timeout.go
+++ b/internal/rules/race_first_with_sleep_to_timeout.go
@@ -50,7 +50,6 @@ func AnalyzeRaceFirstWithSleepToTimeout(tp *typeparser.TypeParser, c *checker.Ch
 	}
 
 	var matches []RaceFirstWithSleepToTimeoutMatch
-	seen := make(map[*ast.Node]struct{})
 	for _, flow := range tp.PipingFlows(sf, true) {
 		for i := range flow.Transformations {
 			transformation := &flow.Transformations[i]
@@ -94,10 +93,6 @@ func AnalyzeRaceFirstWithSleepToTimeout(tp *typeparser.TypeParser, c *checker.Ch
 			if isRaceFirstTimerFlow(tp, left) == isRaceFirstTimerFlow(tp, right) {
 				continue
 			}
-			if _, duplicate := seen[transformation.Node]; duplicate {
-				continue
-			}
-			seen[transformation.Node] = struct{}{}
 			matches = append(matches, RaceFirstWithSleepToTimeoutMatch{
 				SourceFile: sf,
 				Location:   scanner.GetErrorRangeForNode(sf, transformation.Callee),

--- a/internal/rules/redundant_map_error.go
+++ b/internal/rules/redundant_map_error.go
@@ -92,7 +92,7 @@ func analyzeRedundantMapErrorFlowCandidate(tp *typeparser.TypeParser, sf *ast.So
 	}
 
 	lastTransform := flow.Transformations[len(flow.Transformations)-1]
-	if lastTransform.Node == nil || lastTransform.Callee == nil || len(lastTransform.Args) == 0 {
+	if lastTransform.Callee == nil || len(lastTransform.Args) == 0 {
 		return redundantMapErrorCandidate{}, nil, nil, false
 	}
 	if !tp.IsNodeReferenceToEffectModuleApi(lastTransform.Callee, "mapError") {
@@ -125,7 +125,7 @@ func analyzeRedundantMapErrorFlowCandidate(tp *typeparser.TypeParser, sf *ast.So
 
 	return redundantMapErrorCandidate{
 		yieldExpression: yieldExpr.AsNode(),
-		mapErrorNode:    lastTransform.Node,
+		mapErrorNode:    lastTransform.Callee,
 		mapperNode:      mapperNode,
 		mapperText:      mapperText,
 	}, genFn, genCallNode, true

--- a/internal/rules/redundant_or_die.go
+++ b/internal/rules/redundant_or_die.go
@@ -89,7 +89,7 @@ func analyzeRedundantOrDieFlowCandidate(tp *typeparser.TypeParser, sf *ast.Sourc
 	}
 
 	lastTransform := flow.Transformations[len(flow.Transformations)-1]
-	if lastTransform.Node == nil || lastTransform.Callee == nil {
+	if lastTransform.Callee == nil {
 		return redundantOrDieCandidate{}, nil, nil, false
 	}
 	if !tp.IsNodeReferenceToEffectModuleApi(lastTransform.Callee, "orDie") {
@@ -116,7 +116,7 @@ func analyzeRedundantOrDieFlowCandidate(tp *typeparser.TypeParser, sf *ast.Sourc
 
 	return redundantOrDieCandidate{
 		yieldExpression: yieldExpr.AsNode(),
-		orDieNode:       lastTransform.Node,
+		orDieNode:       lastTransform.Callee,
 	}, genFn, genCallNode, true
 }
 

--- a/internal/typeparser/data_first_signature_test.go
+++ b/internal/typeparser/data_first_signature_test.go
@@ -163,6 +163,50 @@ export const called = identity<string>("value")
 	}
 }
 
+func TestPipingFlows_TransformationOccurrencesAreUnique(t *testing.T) {
+	t.Parallel()
+
+	source := `
+import { Effect, pipe } from "effect"
+
+declare const base: Effect.Effect<number, string>
+
+export const piped = pipe(
+  base,
+  Effect.map((value) => value + 1),
+  Effect.flatMap((value) => Effect.succeed(value * 2))
+)
+
+export const nested = Effect.map(Effect.succeed(1), (value) => value + 1)
+
+export const effectFn = Effect.fn(
+  function*() {
+    return 1
+  },
+  Effect.map((value) => value + 1),
+  Effect.catch(() => Effect.succeed(0))
+)
+`
+
+	_, tp, sf, done := compileAndGetCheckerAndSourceFileWithEffectV4Internal(t, source)
+	defer done()
+
+	seen := make(map[*ast.Node]int)
+	for flowIndex, flow := range tp.PipingFlows(sf, true) {
+		for _, transformation := range flow.Transformations {
+			if previousFlowIndex, duplicate := seen[transformation.Node]; duplicate {
+				t.Fatalf(
+					"transformation %q occurs in flows %d and %d",
+					nodeText(sf, transformation.Node),
+					previousFlowIndex,
+					flowIndex,
+				)
+			}
+			seen[transformation.Node] = flowIndex
+		}
+	}
+}
+
 func TestPipingFlows_SkipsParentheses(t *testing.T) {
 	t.Parallel()
 

--- a/internal/typeparser/data_first_signature_test.go
+++ b/internal/typeparser/data_first_signature_test.go
@@ -194,15 +194,15 @@ export const effectFn = Effect.fn(
 	seen := make(map[*ast.Node]int)
 	for flowIndex, flow := range tp.PipingFlows(sf, true) {
 		for _, transformation := range flow.Transformations {
-			if previousFlowIndex, duplicate := seen[transformation.Node]; duplicate {
+			if previousFlowIndex, duplicate := seen[transformation.Callee]; duplicate {
 				t.Fatalf(
 					"transformation %q occurs in flows %d and %d",
-					nodeText(sf, transformation.Node),
+					nodeText(sf, transformation.Callee),
 					previousFlowIndex,
 					flowIndex,
 				)
 			}
-			seen[transformation.Node] = flowIndex
+			seen[transformation.Callee] = flowIndex
 		}
 	}
 }

--- a/internal/typeparser/data_first_signature_test.go
+++ b/internal/typeparser/data_first_signature_test.go
@@ -116,6 +116,53 @@ export const live = Layer.succeed(MyService, make)
 	}
 }
 
+func TestPipingFlows_TypeArguments(t *testing.T) {
+	t.Parallel()
+
+	source := `
+import { pipe } from "effect"
+
+declare function transform<A, B>(self: A, f: (value: A) => B): B
+declare function transform<A, B>(f: (value: A) => B): (self: A) => B
+declare function identity<A>(value: A): A
+
+export const piped = pipe("value", transform<string, number>((value) => value.length))
+export const dataFirst = transform<string, number>("value", (value) => value.length)
+export const curried = transform<string, number>((value) => value.length)("value")
+export const called = identity<string>("value")
+`
+
+	_, tp, sf, done := compileAndGetCheckerAndSourceFileWithEffectV4Internal(t, source)
+	defer done()
+
+	for _, test := range []struct {
+		name string
+		want []string
+	}{
+		{name: "piped", want: []string{"string", "number"}},
+		{name: "dataFirst", want: []string{"string", "number"}},
+		{name: "curried", want: []string{"string", "number"}},
+		{name: "called", want: []string{"string"}},
+	} {
+		call := findVariableInitializerCallByName(t, sf, test.name)
+		flow := findFlowByNode(t, sf, tp.PipingFlows(sf, false), call.AsNode())
+		if len(flow.Transformations) == 0 {
+			t.Fatalf("%s transformation count = 0, want at least 1", test.name)
+		}
+		transformation := flow.Transformations[len(flow.Transformations)-1]
+		if transformation.TypeArguments == nil {
+			t.Fatalf("%s type arguments are nil", test.name)
+		}
+		got := make([]string, 0, len(transformation.TypeArguments.Nodes))
+		for _, typeArgument := range transformation.TypeArguments.Nodes {
+			got = append(got, strings.TrimSpace(nodeText(sf, typeArgument)))
+		}
+		if !slices.Equal(got, test.want) {
+			t.Fatalf("%s type arguments = %v, want %v", test.name, got, test.want)
+		}
+	}
+}
+
 func TestPipingFlows_SkipsParentheses(t *testing.T) {
 	t.Parallel()
 

--- a/internal/typeparser/piping_flow.go
+++ b/internal/typeparser/piping_flow.go
@@ -263,6 +263,7 @@ type workItem struct {
 }
 
 // PipingFlows returns all piping flows found in a source file, sorted by source position.
+// Each source transformation occurrence belongs to at most one returned flow.
 func (tp *TypeParser) PipingFlows(sf *ast.SourceFile, includeEffectFn bool) []*PipingFlow {
 	if tp == nil || tp.checker == nil || sf == nil {
 		return nil

--- a/internal/typeparser/piping_flow.go
+++ b/internal/typeparser/piping_flow.go
@@ -25,7 +25,6 @@ const (
 // PipingFlowTransformation represents a single transformation step in a piping flow.
 type PipingFlowTransformation struct {
 	Kind          TransformationKind // How the transformation was expressed
-	Node          *ast.Node          // The full transformation node (call expression or bare callee)
 	Callee        *ast.Node          // The function being applied (e.g., Effect.map)
 	TypeArguments *ast.NodeList      // Explicit type arguments to the transformation call, if any
 	Args          []*ast.Node        // Arguments to the transformation, or nil for constants/single-arg calls
@@ -59,6 +58,48 @@ func (flow *PartialPipingFlow) CopyPrefix(transformationCount int) *PartialPipin
 	}
 }
 
+// TransformationInputNode returns the standalone source expression that feeds
+// the transformation at index, when that expression is represented directly
+// in the syntax tree.
+func (flow *PartialPipingFlow) TransformationInputNode(index int) *ast.Node {
+	if flow == nil || index < 0 || index >= len(flow.Transformations) {
+		return nil
+	}
+	transformation := &flow.Transformations[index]
+	if call := pipingFlowTransformationCall(transformation); call != nil && call.Arguments != nil {
+		switch transformation.Kind {
+		case TransformationKindCall:
+			if len(call.Arguments.Nodes) == 1 {
+				return call.Arguments.Nodes[0]
+			}
+		case TransformationKindDataFirst:
+			if len(call.Arguments.Nodes) > 0 {
+				return call.Arguments.Nodes[0]
+			}
+		case TransformationKindDataLast:
+			if len(call.Arguments.Nodes) > 0 {
+				return call.Arguments.Nodes[len(call.Arguments.Nodes)-1]
+			}
+		}
+	}
+	if index == 0 {
+		return flow.Subject.Node
+	}
+	return nil
+}
+
+func pipingFlowTransformationCall(transformation *PipingFlowTransformation) *ast.CallExpression {
+	if transformation == nil || transformation.Callee == nil || transformation.Callee.Parent == nil ||
+		!ast.IsCallExpression(transformation.Callee.Parent) {
+		return nil
+	}
+	call := transformation.Callee.Parent.AsCallExpression()
+	if call == nil || call.Expression != transformation.Callee {
+		return nil
+	}
+	return call
+}
+
 // PipingFlow represents a complete piping flow rooted at a source expression.
 type PipingFlow struct {
 	Node *ast.Node // The outermost expression encompassing the entire flow
@@ -72,6 +113,15 @@ func (flow *PipingFlow) CopyPrefix(transformationCount int) *PartialPipingFlow {
 		return nil
 	}
 	return flow.PartialPipingFlow.CopyPrefix(transformationCount)
+}
+
+// TransformationInputNode returns the source expression that feeds the
+// transformation at index.
+func (flow *PipingFlow) TransformationInputNode(index int) *ast.Node {
+	if flow == nil {
+		return nil
+	}
+	return flow.PartialPipingFlow.TransformationInputNode(index)
 }
 
 // ParsedPipeCallResult is the result of parsing a pipe or pipeable call.
@@ -380,7 +430,6 @@ func (tp *TypeParser) PipingFlows(sf *ast.SourceFile, includeEffectFn bool) []*P
 					}
 					transformation := PipingFlowTransformation{
 						Kind:          kind,
-						Node:          node,
 						Callee:        dataFirstResult.Callee,
 						TypeArguments: pipingFlowTypeArguments(node, dataFirstResult.Callee),
 						Args:          dataFirstResult.Args,
@@ -420,7 +469,6 @@ func (tp *TypeParser) PipingFlows(sf *ast.SourceFile, includeEffectFn bool) []*P
 					}
 					transformation := PipingFlowTransformation{
 						Kind:          TransformationKindCall,
-						Node:          node,
 						Callee:        singleResult.callee,
 						TypeArguments: pipingFlowTypeArguments(node, singleResult.callee),
 						Args:          nil,
@@ -516,7 +564,6 @@ func (tp *TypeParser) LongestPipingFlowAt(node *ast.Node, includeEffectFn bool) 
 		flow.Node = node
 		flow.Transformations = append(flow.Transformations, PipingFlowTransformation{
 			Kind:          kind,
-			Node:          node,
 			Callee:        result.Callee,
 			TypeArguments: pipingFlowTypeArguments(node, result.Callee),
 			Args:          result.Args,
@@ -534,7 +581,6 @@ func (tp *TypeParser) LongestPipingFlowAt(node *ast.Node, includeEffectFn bool) 
 		flow.Node = node
 		flow.Transformations = append(flow.Transformations, PipingFlowTransformation{
 			Kind:          TransformationKindCall,
-			Node:          node,
 			Callee:        result.callee,
 			TypeArguments: pipingFlowTypeArguments(node, result.callee),
 			OutType:       outType,
@@ -582,7 +628,6 @@ func (tp *TypeParser) buildPipeTransformations(result *ParsedPipeCallResult) []P
 		}
 
 		var callee *ast.Node
-		transformationNode := arg
 		var args []*ast.Node
 
 		if arg.Kind == ast.KindCallExpression {
@@ -598,7 +643,6 @@ func (tp *TypeParser) buildPipeTransformations(result *ParsedPipeCallResult) []P
 
 		transformations = append(transformations, PipingFlowTransformation{
 			Kind:          result.Kind,
-			Node:          transformationNode,
 			Callee:        callee,
 			TypeArguments: pipingFlowTypeArguments(arg, callee),
 			Args:          args,
@@ -645,7 +689,6 @@ func (tp *TypeParser) buildEffectFnTransformations(result *parsedEffectFnCallRes
 		}
 
 		var callee *ast.Node
-		transformationNode := arg
 		var args []*ast.Node
 
 		if arg.Kind == ast.KindCallExpression {
@@ -660,7 +703,6 @@ func (tp *TypeParser) buildEffectFnTransformations(result *parsedEffectFnCallRes
 
 		transformations = append(transformations, PipingFlowTransformation{
 			Kind:          result.kind,
-			Node:          transformationNode,
 			Callee:        callee,
 			TypeArguments: pipingFlowTypeArguments(arg, callee),
 			Args:          args,

--- a/internal/typeparser/piping_flow.go
+++ b/internal/typeparser/piping_flow.go
@@ -24,11 +24,12 @@ const (
 
 // PipingFlowTransformation represents a single transformation step in a piping flow.
 type PipingFlowTransformation struct {
-	Kind    TransformationKind // How the transformation was expressed
-	Node    *ast.Node          // The full transformation node (call expression or bare callee)
-	Callee  *ast.Node          // The function being applied (e.g., Effect.map)
-	Args    []*ast.Node        // Arguments to the transformation, or nil for constants/single-arg calls
-	OutType *checker.Type      // The resulting type after this transformation (may be nil)
+	Kind          TransformationKind // How the transformation was expressed
+	Node          *ast.Node          // The full transformation node (call expression or bare callee)
+	Callee        *ast.Node          // The function being applied (e.g., Effect.map)
+	TypeArguments *ast.NodeList      // Explicit type arguments to the transformation call, if any
+	Args          []*ast.Node        // Arguments to the transformation, or nil for constants/single-arg calls
+	OutType       *checker.Type      // The resulting type after this transformation (may be nil)
 }
 
 // PipingFlowSubject is the starting expression of a piping flow.
@@ -377,11 +378,12 @@ func (tp *TypeParser) PipingFlows(sf *ast.SourceFile, includeEffectFn bool) []*P
 						kind = TransformationKindDataLast
 					}
 					transformation := PipingFlowTransformation{
-						Kind:    kind,
-						Node:    node,
-						Callee:  dataFirstResult.Callee,
-						Args:    dataFirstResult.Args,
-						OutType: callOutType,
+						Kind:          kind,
+						Node:          node,
+						Callee:        dataFirstResult.Callee,
+						TypeArguments: pipingFlowTypeArguments(node, dataFirstResult.Callee),
+						Args:          dataFirstResult.Args,
+						OutType:       callOutType,
 					}
 
 					if item.parentFlow != nil {
@@ -416,11 +418,12 @@ func (tp *TypeParser) PipingFlows(sf *ast.SourceFile, includeEffectFn bool) []*P
 						callOutType = c.GetReturnTypeOfSignature(callSig)
 					}
 					transformation := PipingFlowTransformation{
-						Kind:    TransformationKindCall,
-						Node:    node,
-						Callee:  singleResult.callee,
-						Args:    nil,
-						OutType: callOutType,
+						Kind:          TransformationKindCall,
+						Node:          node,
+						Callee:        singleResult.callee,
+						TypeArguments: pipingFlowTypeArguments(node, singleResult.callee),
+						Args:          nil,
+						OutType:       callOutType,
 					}
 
 					if item.parentFlow != nil {
@@ -511,11 +514,12 @@ func (tp *TypeParser) LongestPipingFlowAt(node *ast.Node, includeEffectFn bool) 
 		}
 		flow.Node = node
 		flow.Transformations = append(flow.Transformations, PipingFlowTransformation{
-			Kind:    kind,
-			Node:    node,
-			Callee:  result.Callee,
-			Args:    result.Args,
-			OutType: tp.GetTypeAtLocation(node),
+			Kind:          kind,
+			Node:          node,
+			Callee:        result.Callee,
+			TypeArguments: pipingFlowTypeArguments(node, result.Callee),
+			Args:          result.Args,
+			OutType:       tp.GetTypeAtLocation(node),
 		})
 		return flow
 	}
@@ -528,10 +532,11 @@ func (tp *TypeParser) LongestPipingFlowAt(node *ast.Node, includeEffectFn bool) 
 		}
 		flow.Node = node
 		flow.Transformations = append(flow.Transformations, PipingFlowTransformation{
-			Kind:    TransformationKindCall,
-			Node:    node,
-			Callee:  result.callee,
-			OutType: outType,
+			Kind:          TransformationKindCall,
+			Node:          node,
+			Callee:        result.callee,
+			TypeArguments: pipingFlowTypeArguments(node, result.callee),
+			OutType:       outType,
 		})
 		return flow
 	}
@@ -591,11 +596,12 @@ func (tp *TypeParser) buildPipeTransformations(result *ParsedPipeCallResult) []P
 		}
 
 		transformations = append(transformations, PipingFlowTransformation{
-			Kind:    result.Kind,
-			Node:    transformationNode,
-			Callee:  callee,
-			Args:    args,
-			OutType: outType,
+			Kind:          result.Kind,
+			Node:          transformationNode,
+			Callee:        callee,
+			TypeArguments: pipingFlowTypeArguments(arg, callee),
+			Args:          args,
+			OutType:       outType,
 		})
 	}
 
@@ -652,13 +658,28 @@ func (tp *TypeParser) buildEffectFnTransformations(result *parsedEffectFnCallRes
 		}
 
 		transformations = append(transformations, PipingFlowTransformation{
-			Kind:    result.kind,
-			Node:    transformationNode,
-			Callee:  callee,
-			Args:    args,
-			OutType: outType,
+			Kind:          result.kind,
+			Node:          transformationNode,
+			Callee:        callee,
+			TypeArguments: pipingFlowTypeArguments(arg, callee),
+			Args:          args,
+			OutType:       outType,
 		})
 	}
 
 	return transformations, subjectType
+}
+
+func callTypeArguments(node *ast.Node) *ast.NodeList {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return nil
+	}
+	return node.AsCallExpression().TypeArguments
+}
+
+func pipingFlowTypeArguments(node *ast.Node, callee *ast.Node) *ast.NodeList {
+	if typeArguments := callTypeArguments(node); typeArguments != nil {
+		return typeArguments
+	}
+	return callTypeArguments(callee)
 }

--- a/testdata/baselines/reference/effect-v3/preferSucceedSomeOrNone.errors.txt
+++ b/testdata/baselines/reference/effect-v3/preferSucceedSomeOrNone.errors.txt
@@ -13,9 +13,19 @@ Effect version: 3.19.19
 /.src/preferSucceedSomeOrNone.ts(28,66): suggestion TS377117: `Effect.succeedNone` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
 /.src/preferSucceedSomeOrNone.ts(29,67): suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
 /.src/preferSucceedSomeOrNone.ts(32,69): suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+/.src/preferSucceedSomeOrNone.ts(35,73): suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+/.src/preferSucceedSomeOrNone.ts(36,72): suggestion TS377117: `Effect.succeedNone` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+/.src/preferSucceedSomeOrNone.ts(37,70): suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+/.src/preferSucceedSomeOrNone.ts(38,69): suggestion TS377117: `Effect.succeedNone` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+/.src/preferSucceedSomeOrNone.ts(41,52): suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+/.src/preferSucceedSomeOrNone.ts(41,73): suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+/.src/preferSucceedSomeOrNone.ts(42,52): suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+/.src/preferSucceedSomeOrNone.ts(42,77): suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+/.src/preferSucceedSomeOrNone.ts(43,58): suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+/.src/preferSucceedSomeOrNone.ts(43,84): suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
 
 
-==== /.src/preferSucceedSomeOrNone.ts (12 errors) ====
+==== /.src/preferSucceedSomeOrNone.ts (22 errors) ====
     import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
     import { none as optionNone, some as optionSome } from "effect/Option"
     
@@ -71,6 +81,37 @@ Effect version: 3.19.19
     // Should trigger: adjacent transformations in an existing flow
     export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
                                                                         ~~~~~~~~~~~~~~
+!!! suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+    
+    // Should trigger: replacing pipe prefixes retains later transformations
+    export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+                                                                            ~~~~~~~~~~~~~~
+!!! suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+    export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+                                                                           ~~~~~~~~~~~~~~
+!!! suggestion TS377117: `Effect.succeedNone` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+    export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+                                                                         ~~~~~~~~~~~~~~
+!!! suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+    export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+                                                                        ~~~~~~~~~~~~~~
+!!! suggestion TS377117: `Effect.succeedNone` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+    
+    // Should trigger: nested pipe styles can be mixed around the replaced prefix
+    export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+                                                                            ~~~~~~~~~~~~~~
+!!! suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+    export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+                                                                                ~~~~~~~~~~~~~~
+!!! suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+    export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+                                                                                       ~~~~~~~~~~~~~~
 !!! suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
     
     // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone

--- a/testdata/baselines/reference/effect-v3/preferSucceedSomeOrNone.flows.preferSucceedSomeOrNone.mermaid
+++ b/testdata/baselines/reference/effect-v3/preferSucceedSomeOrNone.flows.preferSucceedSomeOrNone.mermaid
@@ -46,45 +46,74 @@ flowchart TB
   44[/"type: 1<br/>node: 1"/]
   45["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
   46["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  47[/"type: Option#lt;number#gt;<br/>node: Option.none#lt;number#gt;#40;#41;"/]
-  48["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  49[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  50[/"type: Option#lt;number#gt;<br/>node: Option.none#40;#41;"/]
-  51["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  52[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  53[/"type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>node: Effect.succeedNone"/]
+  47[/"type: 1<br/>node: 1"/]
+  48["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
+  49["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  50["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
+  51[/"type: Option#lt;never#gt;<br/>node: Option.none#40;#41;"/]
+  52["type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  53["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
   54[/"type: 1<br/>node: 1"/]
-  55["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeedSome<br/>args: #91;#93;"]
-  56[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;Option#lt;A#gt;, never, never#gt;<br/>node: Effect.succeedSome"/]
-  57[/"type: #lt;A = never#gt;#40;#41; =#gt; Option#lt;A#gt;<br/>node: Option.none"/]
-  58["type: Effect#lt;#lt;A = never#gt;#40;#41; =#gt; Option#lt;A#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  59[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  60[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
-  61["type: Effect#lt;#lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  62[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  63[/"type: #123; succeed: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;; #125;<br/>node: #123;#92;n  succeed: #lt;A#gt;#40;value: A#41; =#gt; Effect.succeed#40;value#41;#92;n#125;"/]
-  64[["type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: #lt;A#gt;#40;value: A#41; =#gt; Effect.succeed#40;value#41;"]]
-  65[/"type: A<br/>node: value"/]
-  66["type: Effect#lt;A, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  67[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  68[/"type: #123; none: #40;#41; =#gt; Option#lt;never#gt;; some: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;; #125;<br/>node: #123;#92;n  none: #40;#41; =#gt; Option.none#40;#41;,#92;n  some: #lt;A#gt;#40;value: A#41; =#gt; Option.some#40;value#41;#92;n#125;"/]
-  69[["type: #40;#41; =#gt; Option#lt;never#gt;<br/>node: #40;#41; =#gt; Option.none#40;#41;"]]
-  70[/"type: Option#lt;never#gt;<br/>node: Option.none#40;#41;"/]
-  71[["type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: #lt;A#gt;#40;value: A#41; =#gt; Option.some#40;value#41;"]]
-  72[/"type: A<br/>node: value"/]
-  73["type: Option#lt;A#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
-  74[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
-  75[/"type: Option#lt;never#gt;<br/>node: Option.none#40;#41;"/]
-  76["type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>callee: LocalEffect.succeed<br/>args: #91;#93;"]
-  77[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: LocalEffect.succeed"/]
-  78[/"type: Option#lt;never#gt;<br/>node: LocalOption.none#40;#41;"/]
-  79["type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  80[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  81[/"type: 1<br/>node: 1"/]
-  82["type: Option#lt;number#gt;<br/>callee: LocalOption.some<br/>args: #91;#93;"]
-  83[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: LocalOption.some"/]
-  84["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  85[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  55["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
+  56[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
+  57["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  58["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
+  59[/"type: Option#lt;never#gt;<br/>node: Option.none#40;#41;"/]
+  60["type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  61["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
+  62[/"type: 1<br/>node: 1"/]
+  63["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
+  64[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
+  65["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  66["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
+  67[/"type: 1<br/>node: 1"/]
+  68["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
+  69[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
+  70["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  71["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
+  72[/"type: 1<br/>node: 1"/]
+  73["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
+  74["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  75["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
+  76[/"type: Option#lt;number#gt;<br/>node: Option.none#lt;number#gt;#40;#41;"/]
+  77["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  78[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  79[/"type: Option#lt;number#gt;<br/>node: Option.none#40;#41;"/]
+  80["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  81[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  82[/"type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>node: Effect.succeedNone"/]
+  83[/"type: 1<br/>node: 1"/]
+  84["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeedSome<br/>args: #91;#93;"]
+  85[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;Option#lt;A#gt;, never, never#gt;<br/>node: Effect.succeedSome"/]
+  86[/"type: #lt;A = never#gt;#40;#41; =#gt; Option#lt;A#gt;<br/>node: Option.none"/]
+  87["type: Effect#lt;#lt;A = never#gt;#40;#41; =#gt; Option#lt;A#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  88[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  89[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
+  90["type: Effect#lt;#lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  91[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  92[/"type: #123; succeed: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;; #125;<br/>node: #123;#92;n  succeed: #lt;A#gt;#40;value: A#41; =#gt; Effect.succeed#40;value#41;#92;n#125;"/]
+  93[["type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: #lt;A#gt;#40;value: A#41; =#gt; Effect.succeed#40;value#41;"]]
+  94[/"type: A<br/>node: value"/]
+  95["type: Effect#lt;A, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  96[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  97[/"type: #123; none: #40;#41; =#gt; Option#lt;never#gt;; some: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;; #125;<br/>node: #123;#92;n  none: #40;#41; =#gt; Option.none#40;#41;,#92;n  some: #lt;A#gt;#40;value: A#41; =#gt; Option.some#40;value#41;#92;n#125;"/]
+  98[["type: #40;#41; =#gt; Option#lt;never#gt;<br/>node: #40;#41; =#gt; Option.none#40;#41;"]]
+  99[/"type: Option#lt;never#gt;<br/>node: Option.none#40;#41;"/]
+  100[["type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: #lt;A#gt;#40;value: A#41; =#gt; Option.some#40;value#41;"]]
+  101[/"type: A<br/>node: value"/]
+  102["type: Option#lt;A#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
+  103[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
+  104[/"type: Option#lt;never#gt;<br/>node: Option.none#40;#41;"/]
+  105["type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>callee: LocalEffect.succeed<br/>args: #91;#93;"]
+  106[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: LocalEffect.succeed"/]
+  107[/"type: Option#lt;never#gt;<br/>node: LocalOption.none#40;#41;"/]
+  108["type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  109[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  110[/"type: 1<br/>node: 1"/]
+  111["type: Option#lt;number#gt;<br/>callee: LocalOption.some<br/>args: #91;#93;"]
+  112[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: LocalOption.some"/]
+  113["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  114[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
   0 -->|"kind: pipe"| 1
   2 -->|"kind: transformCallee"| 1
   3 -->|"kind: pipe"| 4
@@ -121,30 +150,52 @@ flowchart TB
   44 -->|"kind: pipe"| 45
   45 -->|"kind: pipe"| 46
   47 -->|"kind: pipe"| 48
-  49 -->|"kind: transformCallee"| 48
-  50 -->|"kind: pipe"| 51
-  52 -->|"kind: transformCallee"| 51
+  48 -->|"kind: pipe"| 49
+  49 -->|"kind: pipe"| 50
+  51 -->|"kind: pipe"| 52
+  52 -->|"kind: pipe"| 53
   54 -->|"kind: pipe"| 55
   56 -->|"kind: transformCallee"| 55
+  55 -->|"kind: pipe"| 57
   57 -->|"kind: pipe"| 58
-  59 -->|"kind: transformCallee"| 58
+  59 -->|"kind: pipe"| 60
   60 -->|"kind: pipe"| 61
-  62 -->|"kind: transformCallee"| 61
+  62 -->|"kind: pipe"| 63
+  64 -->|"kind: transformCallee"| 63
+  63 -->|"kind: pipe"| 65
   65 -->|"kind: pipe"| 66
-  67 -->|"kind: transformCallee"| 66
-  66 -->|"kind: potentialReturn"| 64
-  64 -->|"kind: usedBy"| 63
-  70 -->|"kind: potentialReturn"| 69
-  69 -->|"kind: usedBy"| 68
+  67 -->|"kind: pipe"| 68
+  69 -->|"kind: transformCallee"| 68
+  68 -->|"kind: pipe"| 70
+  70 -->|"kind: pipe"| 71
   72 -->|"kind: pipe"| 73
-  74 -->|"kind: transformCallee"| 73
-  73 -->|"kind: potentialReturn"| 71
-  71 -->|"kind: usedBy"| 68
-  75 -->|"kind: pipe"| 76
-  77 -->|"kind: transformCallee"| 76
-  78 -->|"kind: pipe"| 79
-  80 -->|"kind: transformCallee"| 79
-  81 -->|"kind: pipe"| 82
-  83 -->|"kind: transformCallee"| 82
-  82 -->|"kind: pipe"| 84
+  73 -->|"kind: pipe"| 74
+  74 -->|"kind: pipe"| 75
+  76 -->|"kind: pipe"| 77
+  78 -->|"kind: transformCallee"| 77
+  79 -->|"kind: pipe"| 80
+  81 -->|"kind: transformCallee"| 80
+  83 -->|"kind: pipe"| 84
   85 -->|"kind: transformCallee"| 84
+  86 -->|"kind: pipe"| 87
+  88 -->|"kind: transformCallee"| 87
+  89 -->|"kind: pipe"| 90
+  91 -->|"kind: transformCallee"| 90
+  94 -->|"kind: pipe"| 95
+  96 -->|"kind: transformCallee"| 95
+  95 -->|"kind: potentialReturn"| 93
+  93 -->|"kind: usedBy"| 92
+  99 -->|"kind: potentialReturn"| 98
+  98 -->|"kind: usedBy"| 97
+  101 -->|"kind: pipe"| 102
+  103 -->|"kind: transformCallee"| 102
+  102 -->|"kind: potentialReturn"| 100
+  100 -->|"kind: usedBy"| 97
+  104 -->|"kind: pipe"| 105
+  106 -->|"kind: transformCallee"| 105
+  107 -->|"kind: pipe"| 108
+  109 -->|"kind: transformCallee"| 108
+  110 -->|"kind: pipe"| 111
+  112 -->|"kind: transformCallee"| 111
+  111 -->|"kind: pipe"| 113
+  114 -->|"kind: transformCallee"| 113

--- a/testdata/baselines/reference/effect-v3/preferSucceedSomeOrNone.pipings.txt
+++ b/testdata/baselines/reference/effect-v3/preferSucceedSomeOrNone.pipings.txt
@@ -1,4 +1,4 @@
-==== /.src/preferSucceedSomeOrNone.ts (22 flows) ====
+==== /.src/preferSucceedSomeOrNone.ts (29 flows) ====
 
 === Piping Flow ===
 Location: 5:33 - 5:63
@@ -201,7 +201,153 @@ Transformations (2):
       outType: Effect<Option<number>, never, never>
 
 === Piping Flow ===
-Location: 35:48 - 35:86
+Location: 35:51 - 35:103
+Node: pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (3):
+  [0] kind: pipe
+      callee: Option.some
+      args: (constant)
+      outType: Option<number>
+  [1] kind: pipe
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<Option<number>, never, never>
+  [2] kind: pipe
+      callee: Effect.asVoid
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 36:51 - 36:102
+Node: pipe(Option.none(), Effect.succeed, Effect.asVoid)
+Node Kind: KindCallExpression
+
+Subject: Option.none()
+Subject Type: Option<never>
+
+Transformations (2):
+  [0] kind: pipe
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<Option<never>, never, never>
+  [1] kind: pipe
+      callee: Effect.asVoid
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 37:49 - 37:100
+Node: Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (3):
+  [0] kind: call
+      callee: Option.some
+      args: (constant)
+      outType: Option<number>
+  [1] kind: pipeable
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<Option<number>, never, never>
+  [2] kind: pipeable
+      callee: Effect.asVoid
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 38:49 - 38:99
+Node: Option.none().pipe(Effect.succeed, Effect.asVoid)
+Node Kind: KindCallExpression
+
+Subject: Option.none()
+Subject Type: Option<never>
+
+Transformations (2):
+  [0] kind: pipeable
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<Option<never>, never, never>
+  [1] kind: pipeable
+      callee: Effect.asVoid
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 41:51 - 41:108
+Node: pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (3):
+  [0] kind: call
+      callee: Option.some
+      args: (constant)
+      outType: Option<number>
+  [1] kind: pipe
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<Option<number>, never, never>
+  [2] kind: pipeable
+      callee: Effect.asVoid
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 42:51 - 42:108
+Node: pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (3):
+  [0] kind: call
+      callee: Option.some
+      args: (constant)
+      outType: Option<number>
+  [1] kind: pipeable
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<Option<number>, never, never>
+  [2] kind: pipe
+      callee: Effect.asVoid
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 43:57 - 43:114
+Node: pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (3):
+  [0] kind: pipe
+      callee: Option.some
+      args: (constant)
+      outType: Option<number>
+  [1] kind: pipeable
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<Option<number>, never, never>
+  [2] kind: pipeable
+      callee: Effect.asVoid
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 46:48 - 46:86
 Node: Effect.succeed(Option.none<number>())
 Node Kind: KindCallExpression
 
@@ -215,7 +361,7 @@ Transformations (1):
       outType: Effect<Option<number>, never, never>
 
 === Piping Flow ===
-Location: 38:49 - 38:102
+Location: 49:49 - 49:102
 Node: Effect.succeed<Option.Option<number>>(Option.none())
 Node Kind: KindCallExpression
 
@@ -229,7 +375,7 @@ Transformations (1):
       outType: Effect<Option<number>, never, never>
 
 === Piping Flow ===
-Location: 42:43 - 42:65
+Location: 53:43 - 53:65
 Node: Effect.succeedSome(1)
 Node Kind: KindCallExpression
 
@@ -243,7 +389,7 @@ Transformations (1):
       outType: Effect<Option<number>, never, never>
 
 === Piping Flow ===
-Location: 45:44 - 45:72
+Location: 56:44 - 56:72
 Node: Effect.succeed(Option.none)
 Node Kind: KindCallExpression
 
@@ -257,7 +403,7 @@ Transformations (1):
       outType: Effect<<A = never>() => Option<A>, never, never>
 
 === Piping Flow ===
-Location: 46:44 - 46:72
+Location: 57:44 - 57:72
 Node: Effect.succeed(Option.some)
 Node Kind: KindCallExpression
 
@@ -271,7 +417,7 @@ Transformations (1):
       outType: Effect<<A>(value: A) => Option<A>, never, never>
 
 === Piping Flow ===
-Location: 49:28 - 49:50
+Location: 60:28 - 60:50
 Node: Effect.succeed(value)
 Node Kind: KindCallExpression
 
@@ -285,7 +431,7 @@ Transformations (1):
       outType: Effect<A, never, never>
 
 === Piping Flow ===
-Location: 53:25 - 53:44
+Location: 64:25 - 64:44
 Node: Option.some(value)
 Node Kind: KindCallExpression
 
@@ -299,7 +445,7 @@ Transformations (1):
       outType: Option<A>
 
 === Piping Flow ===
-Location: 57:43 - 57:78
+Location: 68:43 - 68:78
 Node: LocalEffect.succeed(Option.none())
 Node Kind: KindCallExpression
 
@@ -313,7 +459,7 @@ Transformations (1):
       outType: Effect<Option<never>, never, never>
 
 === Piping Flow ===
-Location: 58:47 - 58:82
+Location: 69:47 - 69:82
 Node: Effect.succeed(LocalOption.none())
 Node Kind: KindCallExpression
 
@@ -327,7 +473,7 @@ Transformations (1):
       outType: Effect<Option<never>, never, never>
 
 === Piping Flow ===
-Location: 59:47 - 59:83
+Location: 70:47 - 70:83
 Node: Effect.succeed(LocalOption.some(1))
 Node Kind: KindCallExpression
 

--- a/testdata/baselines/reference/effect-v3/preferSucceedSomeOrNone.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v3/preferSucceedSomeOrNone.quickfixes.txt
@@ -60,6 +60,56 @@
   Fix 1: "Disable preferSucceedSomeOrNone for entire file"
   Fix 2: "Replace with Effect.succeedSome"
 
+[D13] (35:73-35:87) TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+  Fix 0: "Disable preferSucceedSomeOrNone for this line"
+  Fix 1: "Disable preferSucceedSomeOrNone for entire file"
+  Fix 2: "Replace with Effect.succeedSome"
+
+[D14] (36:72-36:86) TS377117: `Effect.succeedNone` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+  Fix 0: "Disable preferSucceedSomeOrNone for this line"
+  Fix 1: "Disable preferSucceedSomeOrNone for entire file"
+  Fix 2: "Replace with Effect.succeedNone"
+
+[D15] (37:70-37:84) TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+  Fix 0: "Disable preferSucceedSomeOrNone for this line"
+  Fix 1: "Disable preferSucceedSomeOrNone for entire file"
+  Fix 2: "Replace with Effect.succeedSome"
+
+[D16] (38:69-38:83) TS377117: `Effect.succeedNone` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+  Fix 0: "Disable preferSucceedSomeOrNone for this line"
+  Fix 1: "Disable preferSucceedSomeOrNone for entire file"
+  Fix 2: "Replace with Effect.succeedNone"
+
+[D17] (41:52-41:108) TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+  Fix 0: "Disable unnecessaryPipeChain for this line"
+  Fix 1: "Disable unnecessaryPipeChain for entire file"
+  Fix 2: "Rewrite as single pipe call"
+
+[D18] (41:73-41:87) TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+  Fix 0: "Disable preferSucceedSomeOrNone for this line"
+  Fix 1: "Disable preferSucceedSomeOrNone for entire file"
+  Fix 2: "Replace with Effect.succeedSome"
+
+[D19] (42:52-42:108) TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+  Fix 0: "Disable unnecessaryPipeChain for this line"
+  Fix 1: "Disable unnecessaryPipeChain for entire file"
+  Fix 2: "Rewrite as single pipe call"
+
+[D20] (42:77-42:91) TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+  Fix 0: "Disable preferSucceedSomeOrNone for this line"
+  Fix 1: "Disable preferSucceedSomeOrNone for entire file"
+  Fix 2: "Replace with Effect.succeedSome"
+
+[D21] (43:58-43:114) TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+  Fix 0: "Disable unnecessaryPipeChain for this line"
+  Fix 1: "Disable unnecessaryPipeChain for entire file"
+  Fix 2: "Rewrite as single pipe call"
+
+[D22] (43:84-43:98) TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+  Fix 0: "Disable preferSucceedSomeOrNone for this line"
+  Fix 1: "Disable preferSucceedSomeOrNone for entire file"
+  Fix 2: "Replace with Effect.succeedSome"
+
 === Quick Fix Application Results ===
 
 === [D1] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
@@ -103,6 +153,17 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
 
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
@@ -174,6 +235,17 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
 
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
 
@@ -243,6 +315,17 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
 
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
@@ -314,6 +397,17 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
 
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
 
@@ -383,6 +477,17 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
 
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
@@ -454,6 +559,17 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
 
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
 
@@ -523,6 +639,17 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
 
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
@@ -594,6 +721,17 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
 
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
 
@@ -663,6 +801,17 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
 
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
@@ -734,6 +883,17 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
 
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
 
@@ -804,6 +964,17 @@ export const shouldTriggerSomeFunctionPipe = Effect.succeedSome(1)
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
 
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
 
@@ -873,6 +1044,827 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = Effect.succeedSome(1)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D13] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
+skipped by default
+
+=== [D13] Fix 1: "Disable preferSucceedSomeOrNone for entire file" ===
+skipped by default
+
+=== [D13] Fix 2: "Replace with Effect.succeedSome" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(Effect.succeedSome(1), Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D14] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
+skipped by default
+
+=== [D14] Fix 1: "Disable preferSucceedSomeOrNone for entire file" ===
+skipped by default
+
+=== [D14] Fix 2: "Replace with Effect.succeedNone" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Effect.succeedNone, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D15] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
+skipped by default
+
+=== [D15] Fix 1: "Disable preferSucceedSomeOrNone for entire file" ===
+skipped by default
+
+=== [D15] Fix 2: "Replace with Effect.succeedSome" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Effect.succeedSome(1).pipe(Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D16] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
+skipped by default
+
+=== [D16] Fix 1: "Disable preferSucceedSomeOrNone for entire file" ===
+skipped by default
+
+=== [D16] Fix 2: "Replace with Effect.succeedNone" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Effect.succeedNone.pipe(Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D17] Fix 0: "Disable unnecessaryPipeChain for this line" ===
+skipped by default
+
+=== [D17] Fix 1: "Disable unnecessaryPipeChain for entire file" ===
+skipped by default
+
+=== [D17] Fix 2: "Rewrite as single pipe call" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed, Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D18] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
+skipped by default
+
+=== [D18] Fix 1: "Disable preferSucceedSomeOrNone for entire file" ===
+skipped by default
+
+=== [D18] Fix 2: "Replace with Effect.succeedSome" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = Effect.succeedSome(1).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D19] Fix 0: "Disable unnecessaryPipeChain for this line" ===
+skipped by default
+
+=== [D19] Fix 1: "Disable unnecessaryPipeChain for entire file" ===
+skipped by default
+
+=== [D19] Fix 2: "Rewrite as single pipe call" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D20] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
+skipped by default
+
+=== [D20] Fix 1: "Disable preferSucceedSomeOrNone for entire file" ===
+skipped by default
+
+=== [D20] Fix 2: "Replace with Effect.succeedSome" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Effect.succeedSome(1), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D21] Fix 0: "Disable unnecessaryPipeChain for this line" ===
+skipped by default
+
+=== [D21] Fix 1: "Disable unnecessaryPipeChain for entire file" ===
+skipped by default
+
+=== [D21] Fix 2: "Rewrite as single pipe call" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D22] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
+skipped by default
+
+=== [D22] Fix 1: "Disable preferSucceedSomeOrNone for entire file" ===
+skipped by default
+
+=== [D22] Fix 2: "Replace with Effect.succeedSome" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = Effect.succeedSome(1).pipe(Effect.asVoid)
 
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())

--- a/testdata/baselines/reference/effect-v4/catchTagToCatchReason.errors.txt
+++ b/testdata/baselines/reference/effect-v4/catchTagToCatchReason.errors.txt
@@ -48,169 +48,117 @@ Effect version: 4.0.0
     // Should trigger and offer catchReason: canonical switch with explicit re-fail.
     export const switchSingle = program.pipe(
       Fx.catchTag("OuterError", (error) => {
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        switch (error.reason._tag) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          case "ReasonA":
-    ~~~~~~~~~~~~~~~~~~~~~
-            return Fx.succeed(1)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          default:
-    ~~~~~~~~~~~~~~
-            return Fx.fail(error)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-      })
-    ~~~~
+      ~~~~~~~~~~~
 !!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+        switch (error.reason._tag) {
+          case "ReasonA":
+            return Fx.succeed(1)
+          default:
+            return Fx.fail(error)
+        }
+      })
     )
     
     // Should trigger and offer catchReasons: sequential ifs in pipe(...) style.
     export const ifMultiple = pipe(
       program,
       Fx.catchTag("OuterError", (error) => {
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        if (error.reason._tag === "ReasonA") return Fx.succeed(1)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        if ("ReasonB" === error.reason._tag) return Fx.succeed(2)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        return Fx.fail(error)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
-      })
-    ~~~~
+      ~~~~~~~~~~~
 !!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+        if (error.reason._tag === "ReasonA") return Fx.succeed(1)
+        if ("ReasonB" === error.reason._tag) return Fx.succeed(2)
+        return Fx.fail(error)
+      })
     )
     
     // Should trigger and offer catchReasons: an if/else-if chain.
     export const ifElseMultiple = program.pipe(
       Fx.catchTag("OuterError", (error) => {
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        if (error.reason._tag === "ReasonA") {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          return Fx.succeed(1)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-        } else if (error.reason._tag === "ReasonB") {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          return Fx.succeed(2)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-        } else {
-    ~~~~~~~~~~~~
-          return Fx.fail(error)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-      })
-    ~~~~
+      ~~~~~~~~~~~
 !!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+        if (error.reason._tag === "ReasonA") {
+          return Fx.succeed(1)
+        } else if (error.reason._tag === "ReasonB") {
+          return Fx.succeed(2)
+        } else {
+          return Fx.fail(error)
+        }
+      })
     )
     
     // Should trigger and offer catchReason: conditional-expression dispatch.
     export const ternarySingle = program.pipe(
       Fx.catchTag("OuterError", (error) =>
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        error.reason._tag === "ReasonA" ? Fx.succeed(1) : Fx.fail(error)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      )
-    ~~~
+      ~~~~~~~~~~~
 !!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+        error.reason._tag === "ReasonA" ? Fx.succeed(1) : Fx.fail(error)
+      )
     )
     
     // Should trigger and offer catchReasons under conditional-expression narrowing.
     export const ternaryMultiple = program.pipe(
       Fx.catchTag("OuterError", (error) =>
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        error.reason._tag === "ReasonA"
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          ? Fx.succeed(1)
-    ~~~~~~~~~~~~~~~~~~~~~
-          : error.reason._tag === "ReasonB"
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            ? Fx.succeed(2)
-    ~~~~~~~~~~~~~~~~~~~~~~~
-            : Fx.fail(error)
-    ~~~~~~~~~~~~~~~~~~~~~~~~
-      )
-    ~~~
+      ~~~~~~~~~~~
 !!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+        error.reason._tag === "ReasonA"
+          ? Fx.succeed(1)
+          : error.reason._tag === "ReasonB"
+            ? Fx.succeed(2)
+            : Fx.fail(error)
+      )
     )
     
     // Should trigger without a fix: extracting a function body could change arguments.
     export const functionArguments = program.pipe(
       Fx.catchTag("OuterError", function(error) {
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        if (error.reason._tag === "ReasonA") return Fx.succeed(arguments.length)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        return Fx.fail(error)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
-      })
-    ~~~~
+      ~~~~~~~~~~~
 !!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+        if (error.reason._tag === "ReasonA") return Fx.succeed(arguments.length)
+        return Fx.fail(error)
+      })
     )
     
     // Should trigger and preserve wrapper uses through catchReason's second parameter.
     export const reasonUsePreservesWrapper = program.pipe(
       Fx.catchTag("OuterError", (error) => {
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        switch (error.reason._tag) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          case "ReasonB":
-    ~~~~~~~~~~~~~~~~~~~~~
-            return Fx.succeed(error.reason.detail.length)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          default:
-    ~~~~~~~~~~~~~~
-            return Fx.fail(error)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-      })
-    ~~~~
+      ~~~~~~~~~~~
 !!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+        switch (error.reason._tag) {
+          case "ReasonB":
+            return Fx.succeed(error.reason.detail.length)
+          default:
+            return Fx.fail(error)
+        }
+      })
     )
     
     // Should trigger on the containing catchTags transformation, without a fix.
     export const catchTagsCase = program.pipe(
       Fx.catchTags({
-      ~~~~~~~~~~~~~~
-        OuterError: (error) => {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          switch (error.reason._tag) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            case "ReasonA":
-    ~~~~~~~~~~~~~~~~~~~~~~~
-              return Fx.succeed(1)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            default:
-    ~~~~~~~~~~~~~~~~
-              return Fx.fail(error)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          }
-    ~~~~~~~
-        },
-    ~~~~~~
-        OtherError: () => Fx.succeed(2)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      })
-    ~~~~
+      ~~~~~~~~~~~~
 !!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTags` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+        OuterError: (error) => {
+          switch (error.reason._tag) {
+            case "ReasonA":
+              return Fx.succeed(1)
+            default:
+              return Fx.fail(error)
+          }
+        },
+        OtherError: () => Fx.succeed(2)
+      })
     )
     
     // Should trigger without a fix: catchTags cases that need the narrowed reason.
     export const catchTagsReasonUse = program.pipe(
       Fx.catchTags({
-      ~~~~~~~~~~~~~~
-        OuterError: (error) => {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          if (error.reason._tag === "ReasonB") return Fx.succeed(error.reason.detail.length)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          return Fx.fail(error)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-      })
-    ~~~~
+      ~~~~~~~~~~~~
 !!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTags` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+        OuterError: (error) => {
+          if (error.reason._tag === "ReasonB") return Fx.succeed(error.reason.detail.length)
+          return Fx.fail(error)
+        }
+      })
     )
     
     // Should NOT trigger: the wrapper parameter is used outside reason dispatch.

--- a/testdata/baselines/reference/effect-v4/catchTagToCatchReason.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/catchTagToCatchReason.quickfixes.txt
@@ -1,44 +1,44 @@
 === Quick Fix Inventory ===
 
-[D1] (35:3-42:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+[D1] (35:3-35:14) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
   Fix 1: "Disable catchTagToCatchReason for entire file"
   Fix 2: "Replace with Effect.catchReason or Effect.catchReasons"
 
-[D2] (48:3-52:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+[D2] (48:3-48:14) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
   Fix 1: "Disable catchTagToCatchReason for entire file"
   Fix 2: "Replace with Effect.catchReason or Effect.catchReasons"
 
-[D3] (57:3-65:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+[D3] (57:3-57:14) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
   Fix 1: "Disable catchTagToCatchReason for entire file"
   Fix 2: "Replace with Effect.catchReason or Effect.catchReasons"
 
-[D4] (70:3-72:4) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+[D4] (70:3-70:14) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
   Fix 1: "Disable catchTagToCatchReason for entire file"
   Fix 2: "Replace with Effect.catchReason or Effect.catchReasons"
 
-[D5] (77:3-83:4) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+[D5] (77:3-77:14) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
   Fix 1: "Disable catchTagToCatchReason for entire file"
   Fix 2: "Replace with Effect.catchReason or Effect.catchReasons"
 
-[D6] (88:3-91:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+[D6] (88:3-88:14) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
   Fix 1: "Disable catchTagToCatchReason for entire file"
 
-[D7] (96:3-103:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+[D7] (96:3-96:14) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
   Fix 1: "Disable catchTagToCatchReason for entire file"
   Fix 2: "Replace with Effect.catchReason or Effect.catchReasons"
 
-[D8] (108:3-118:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTags` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+[D8] (108:3-108:15) TS377110: Branching on `error.reason._tag` inside `Effect.catchTags` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
   Fix 1: "Disable catchTagToCatchReason for entire file"
 
-[D9] (123:3-128:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTags` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+[D9] (123:3-123:15) TS377110: Branching on `error.reason._tag` inside `Effect.catchTags` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
   Fix 1: "Disable catchTagToCatchReason for entire file"
 

--- a/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.errors.txt
+++ b/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.errors.txt
@@ -34,65 +34,42 @@ Effect version: 4.0.0
     
     export const parameterUse = program.pipe(
       Effect.catchTag("OuterError", (error) => {
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        switch (error.reason._tag) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          case "ReasonA":
-    ~~~~~~~~~~~~~~~~~~~~~
-            return Effect.succeed(`${_}: ${error.context}: ${error.reason.detail}`)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          default:
-    ~~~~~~~~~~~~~~
-            return Effect.fail(error)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-      })
-    ~~~~
+      ~~~~~~~~~~~~~~~
 !!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+        switch (error.reason._tag) {
+          case "ReasonA":
+            return Effect.succeed(`${_}: ${error.context}: ${error.reason.detail}`)
+          default:
+            return Effect.fail(error)
+        }
+      })
     )
     
     export const reassignedParameter = program.pipe(
       Effect.catchTag("OuterError", (error) => {
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        switch (error.reason._tag) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          case "ReasonA":
-    ~~~~~~~~~~~~~~~~~~~~~
-            return (error = otherError, Effect.succeed(1))
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          default:
-    ~~~~~~~~~~~~~~
-            return Effect.fail(error)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-      })
-    ~~~~
+      ~~~~~~~~~~~~~~~
 !!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+        switch (error.reason._tag) {
+          case "ReasonA":
+            return (error = otherError, Effect.succeed(1))
+          default:
+            return Effect.fail(error)
+        }
+      })
     )
     
     export const multipleBranches = program.pipe(
       Effect.catchTag("OuterError", (error) => {
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        switch (error.reason._tag) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          case "ReasonA":
-    ~~~~~~~~~~~~~~~~~~~~~
-            return Effect.succeed(error.reason.detail)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          case "ReasonB":
-    ~~~~~~~~~~~~~~~~~~~~~
-            return Effect.succeed("reason b")
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          default:
-    ~~~~~~~~~~~~~~
-            return Effect.fail(error)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-      })
-    ~~~~
+      ~~~~~~~~~~~~~~~
 !!! suggestion TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+        switch (error.reason._tag) {
+          case "ReasonA":
+            return Effect.succeed(error.reason.detail)
+          case "ReasonB":
+            return Effect.succeed("reason b")
+          default:
+            return Effect.fail(error)
+        }
+      })
     )
     

--- a/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/catchTagToCatchReasonParameterUse.quickfixes.txt
@@ -1,15 +1,15 @@
 === Quick Fix Inventory ===
 
-[D1] (27:3-34:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+[D1] (27:3-27:18) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
   Fix 1: "Disable catchTagToCatchReason for entire file"
   Fix 2: "Replace with Effect.catchReason or Effect.catchReasons"
 
-[D2] (38:3-45:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+[D2] (38:3-38:18) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
   Fix 1: "Disable catchTagToCatchReason for entire file"
 
-[D3] (49:3-58:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+[D3] (49:3-49:18) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
   Fix 1: "Disable catchTagToCatchReason for entire file"
   Fix 2: "Replace with Effect.catchReason or Effect.catchReasons"

--- a/testdata/baselines/reference/effect-v4/catchTagToCatchReason_preview.errors.txt
+++ b/testdata/baselines/reference/effect-v4/catchTagToCatchReason_preview.errors.txt
@@ -26,13 +26,10 @@ Effect version: 4.0.0
     
     export const fixable = program.pipe(
       Effect.catchTag("AppError", (error) => {
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        if (error.reason._tag === "RetryReason") return Effect.succeed("retry")
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        return Effect.fail(error)
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      })
-    ~~~~
+      ~~~~~~~~~~~~~~~
 !!! warning TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+        if (error.reason._tag === "RetryReason") return Effect.succeed("retry")
+        return Effect.fail(error)
+      })
     )
     

--- a/testdata/baselines/reference/effect-v4/catchTagToCatchReason_preview.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/catchTagToCatchReason_preview.quickfixes.txt
@@ -1,6 +1,6 @@
 === Quick Fix Inventory ===
 
-[D1] (21:3-24:5) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
+[D1] (21:3-21:18) TS377110: Branching on `error.reason._tag` inside `Effect.catchTag` hand-rolls reason dispatch; use `Effect.catchReason` or `Effect.catchReasons`, which re-fail unmatched reasons automatically. effect(catchTagToCatchReason)
   Fix 0: "Disable catchTagToCatchReason for this line"
   Fix 1: "Disable catchTagToCatchReason for entire file"
   Fix 2: "Replace with Effect.catchReason or Effect.catchReasons"

--- a/testdata/baselines/reference/effect-v4/debugDocumentSymbolFlows.symbols.txt
+++ b/testdata/baselines/reference/effect-v4/debugDocumentSymbolFlows.symbols.txt
@@ -5,12 +5,12 @@
   (Package) Flows range=1:1-1:1 selection=1:1-1:1
     (Variable) Flow 0 range=5:21-8:2 selection=5:21-8:2
       (Variable) start detail="Effect.Effect<number, never, never>" range=5:21-5:26 selection=5:21-5:26
-      (Function) 0: Effect.map detail="Effect.Effect<number, never, never>" range=6:3-6:27 selection=6:3-6:27
-      (Function) 1: Effect.flatMap detail="Effect.Effect<string, never, never>" range=7:3-7:51 selection=7:3-7:51
+      (Function) 0: Effect.map detail="Effect.Effect<number, never, never>" range=6:3-6:13 selection=6:3-6:13
+      (Function) 1: Effect.flatMap detail="Effect.Effect<string, never, never>" range=7:3-7:17 selection=7:3-7:17
     (Variable) Flow 1 range=7:25-7:50 selection=7:25-7:50
       (Variable) n detail="number" range=7:47-7:48 selection=7:47-7:48
-      (Function) 0: String detail="string" range=7:40-7:49 selection=7:40-7:49
-      (Function) 1: Effect.succeed detail="Effect.Effect<string, never, never>" range=7:25-7:50 selection=7:25-7:50
+      (Function) 0: String detail="string" range=7:40-7:46 selection=7:40-7:46
+      (Function) 1: Effect.succeed detail="Effect.Effect<string, never, never>" range=7:25-7:39 selection=7:25-7:39
 (Variable) Effect range=1:10-1:16 selection=1:10-1:16
 (Variable) start range=3:15-3:43 selection=3:15-3:20
 (Variable) flow range=5:14-8:2 selection=5:14-5:18
@@ -22,12 +22,12 @@
 (Package) Flows container="Effect" range=1:1-1:1
 (Variable) Flow 0 container="Flows" range=5:21-8:2
 (Variable) start container="Flow 0" range=5:21-5:26
-(Function) 0: Effect.map container="Flow 0" range=6:3-6:27
-(Function) 1: Effect.flatMap container="Flow 0" range=7:3-7:51
+(Function) 0: Effect.map container="Flow 0" range=6:3-6:13
+(Function) 1: Effect.flatMap container="Flow 0" range=7:3-7:17
 (Variable) Flow 1 container="Flows" range=7:25-7:50
 (Variable) n container="Flow 1" range=7:47-7:48
-(Function) 0: String container="Flow 1" range=7:40-7:49
-(Function) 1: Effect.succeed container="Flow 1" range=7:25-7:50
+(Function) 0: String container="Flow 1" range=7:40-7:46
+(Function) 1: Effect.succeed container="Flow 1" range=7:25-7:39
 (Variable) Effect container="" range=1:10-1:16
 (Variable) start container="" range=3:15-3:43
 (Variable) flow container="" range=5:14-8:2

--- a/testdata/baselines/reference/effect-v4/optionMatchToFromOption.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/optionMatchToFromOption.quickfixes.txt
@@ -588,7 +588,7 @@ export const functionPipe = pipe(
 )
 
 // Should trigger: direct data-last application is also supported.
-export const dataLast = Effect.fromOption(option, () => new MissingValue("data-last"))
+export const dataLast = Effect.fromOption(() => new MissingValue("data-last"))(option)
 
 // Should trigger and use the one-argument Effect.fromOption form.
 export const defaultFailure = Option.match(option, {

--- a/testdata/baselines/reference/effect-v4/preferSucceedSomeOrNone.errors.txt
+++ b/testdata/baselines/reference/effect-v4/preferSucceedSomeOrNone.errors.txt
@@ -13,9 +13,19 @@ Effect version: 4.0.0
 /.src/preferSucceedSomeOrNone.ts(28,66): suggestion TS377117: `Effect.succeedNone` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
 /.src/preferSucceedSomeOrNone.ts(29,67): suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
 /.src/preferSucceedSomeOrNone.ts(32,69): suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+/.src/preferSucceedSomeOrNone.ts(35,69): suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+/.src/preferSucceedSomeOrNone.ts(38,72): suggestion TS377117: `Effect.succeedNone` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+/.src/preferSucceedSomeOrNone.ts(39,70): suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+/.src/preferSucceedSomeOrNone.ts(40,69): suggestion TS377117: `Effect.succeedNone` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+/.src/preferSucceedSomeOrNone.ts(43,52): suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+/.src/preferSucceedSomeOrNone.ts(43,73): suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+/.src/preferSucceedSomeOrNone.ts(44,52): suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+/.src/preferSucceedSomeOrNone.ts(44,77): suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+/.src/preferSucceedSomeOrNone.ts(45,58): suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+/.src/preferSucceedSomeOrNone.ts(45,84): suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
 
 
-==== /.src/preferSucceedSomeOrNone.ts (12 errors) ====
+==== /.src/preferSucceedSomeOrNone.ts (22 errors) ====
     import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
     import { none as optionNone, some as optionSome } from "effect/Option"
     
@@ -71,6 +81,39 @@ Effect version: 4.0.0
     // Should trigger: adjacent transformations in an existing flow
     export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
                                                                         ~~~~~~~~~~~~~~
+!!! suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+    
+    // Should trigger: replacing a Function.pipe prefix retains later transformations
+    export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+                                                                        ~~~~~~~~~~~~~~
+!!! suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+    
+    // Should trigger: replacing pipe prefixes retains later transformations
+    export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+                                                                           ~~~~~~~~~~~~~~
+!!! suggestion TS377117: `Effect.succeedNone` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+    export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+                                                                         ~~~~~~~~~~~~~~
+!!! suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+    export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+                                                                        ~~~~~~~~~~~~~~
+!!! suggestion TS377117: `Effect.succeedNone` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+    
+    // Should trigger: nested pipe styles can be mixed around the replaced prefix
+    export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+                                                                            ~~~~~~~~~~~~~~
+!!! suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+    export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+                                                                                ~~~~~~~~~~~~~~
+!!! suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+    export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! suggestion TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+                                                                                       ~~~~~~~~~~~~~~
 !!! suggestion TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
     
     // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone

--- a/testdata/baselines/reference/effect-v4/preferSucceedSomeOrNone.flows.preferSucceedSomeOrNone.mermaid
+++ b/testdata/baselines/reference/effect-v4/preferSucceedSomeOrNone.flows.preferSucceedSomeOrNone.mermaid
@@ -46,45 +46,74 @@ flowchart TB
   44[/"type: 1<br/>node: 1"/]
   45["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
   46["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  47[/"type: Option#lt;number#gt;<br/>node: Option.none#lt;number#gt;#40;#41;"/]
-  48["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  49[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  50[/"type: Option#lt;number#gt;<br/>node: Option.none#40;#41;"/]
-  51["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  52[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  53[/"type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>node: Effect.succeedNone"/]
+  47[/"type: 1<br/>node: 1"/]
+  48["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
+  49["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  50["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
+  51[/"type: Option#lt;never#gt;<br/>node: Option.none#40;#41;"/]
+  52["type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  53["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
   54[/"type: 1<br/>node: 1"/]
-  55["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeedSome<br/>args: #91;#93;"]
-  56[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;Option#lt;A#gt;, never, never#gt;<br/>node: Effect.succeedSome"/]
-  57[/"type: #lt;A = never#gt;#40;#41; =#gt; Option#lt;A#gt;<br/>node: Option.none"/]
-  58["type: Effect#lt;#lt;A = never#gt;#40;#41; =#gt; Option#lt;A#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  59[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  60[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
-  61["type: Effect#lt;#lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  62[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  63[/"type: #123; succeed: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;; #125;<br/>node: #123;#92;n  succeed: #lt;A#gt;#40;value: A#41; =#gt; Effect.succeed#40;value#41;#92;n#125;"/]
-  64[["type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: #lt;A#gt;#40;value: A#41; =#gt; Effect.succeed#40;value#41;"]]
-  65[/"type: A<br/>node: value"/]
-  66["type: Effect#lt;A, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  67[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  68[/"type: #123; none: #40;#41; =#gt; Option#lt;never#gt;; some: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;; #125;<br/>node: #123;#92;n  none: #40;#41; =#gt; Option.none#40;#41;,#92;n  some: #lt;A#gt;#40;value: A#41; =#gt; Option.some#40;value#41;#92;n#125;"/]
-  69[["type: #40;#41; =#gt; Option#lt;never#gt;<br/>node: #40;#41; =#gt; Option.none#40;#41;"]]
-  70[/"type: Option#lt;never#gt;<br/>node: Option.none#40;#41;"/]
-  71[["type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: #lt;A#gt;#40;value: A#41; =#gt; Option.some#40;value#41;"]]
-  72[/"type: A<br/>node: value"/]
-  73["type: Option#lt;A#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
-  74[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
-  75[/"type: Option#lt;never#gt;<br/>node: Option.none#40;#41;"/]
-  76["type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>callee: LocalEffect.succeed<br/>args: #91;#93;"]
-  77[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: LocalEffect.succeed"/]
-  78[/"type: Option#lt;never#gt;<br/>node: LocalOption.none#40;#41;"/]
-  79["type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  80[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
-  81[/"type: 1<br/>node: 1"/]
-  82["type: Option#lt;number#gt;<br/>callee: LocalOption.some<br/>args: #91;#93;"]
-  83[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: LocalOption.some"/]
-  84["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
-  85[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  55["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
+  56[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
+  57["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  58["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
+  59[/"type: Option#lt;never#gt;<br/>node: Option.none#40;#41;"/]
+  60["type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  61["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
+  62[/"type: 1<br/>node: 1"/]
+  63["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
+  64[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
+  65["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  66["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
+  67[/"type: 1<br/>node: 1"/]
+  68["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
+  69[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
+  70["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  71["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
+  72[/"type: 1<br/>node: 1"/]
+  73["type: Option#lt;number#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
+  74["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  75["type: Effect#lt;void, never, never#gt;<br/>callee: Effect.asVoid<br/>args: #91;#93;"]
+  76[/"type: Option#lt;number#gt;<br/>node: Option.none#lt;number#gt;#40;#41;"/]
+  77["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  78[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  79[/"type: Option#lt;number#gt;<br/>node: Option.none#40;#41;"/]
+  80["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  81[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  82[/"type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>node: Effect.succeedNone"/]
+  83[/"type: 1<br/>node: 1"/]
+  84["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeedSome<br/>args: #91;#93;"]
+  85[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;Option#lt;A#gt;, never, never#gt;<br/>node: Effect.succeedSome"/]
+  86[/"type: #lt;A = never#gt;#40;#41; =#gt; Option#lt;A#gt;<br/>node: Option.none"/]
+  87["type: Effect#lt;#lt;A = never#gt;#40;#41; =#gt; Option#lt;A#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  88[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  89[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
+  90["type: Effect#lt;#lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  91[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  92[/"type: #123; succeed: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;; #125;<br/>node: #123;#92;n  succeed: #lt;A#gt;#40;value: A#41; =#gt; Effect.succeed#40;value#41;#92;n#125;"/]
+  93[["type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: #lt;A#gt;#40;value: A#41; =#gt; Effect.succeed#40;value#41;"]]
+  94[/"type: A<br/>node: value"/]
+  95["type: Effect#lt;A, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  96[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  97[/"type: #123; none: #40;#41; =#gt; Option#lt;never#gt;; some: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;; #125;<br/>node: #123;#92;n  none: #40;#41; =#gt; Option.none#40;#41;,#92;n  some: #lt;A#gt;#40;value: A#41; =#gt; Option.some#40;value#41;#92;n#125;"/]
+  98[["type: #40;#41; =#gt; Option#lt;never#gt;<br/>node: #40;#41; =#gt; Option.none#40;#41;"]]
+  99[/"type: Option#lt;never#gt;<br/>node: Option.none#40;#41;"/]
+  100[["type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: #lt;A#gt;#40;value: A#41; =#gt; Option.some#40;value#41;"]]
+  101[/"type: A<br/>node: value"/]
+  102["type: Option#lt;A#gt;<br/>callee: Option.some<br/>args: #91;#93;"]
+  103[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: Option.some"/]
+  104[/"type: Option#lt;never#gt;<br/>node: Option.none#40;#41;"/]
+  105["type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>callee: LocalEffect.succeed<br/>args: #91;#93;"]
+  106[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: LocalEffect.succeed"/]
+  107[/"type: Option#lt;never#gt;<br/>node: LocalOption.none#40;#41;"/]
+  108["type: Effect#lt;Option#lt;never#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  109[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
+  110[/"type: 1<br/>node: 1"/]
+  111["type: Option#lt;number#gt;<br/>callee: LocalOption.some<br/>args: #91;#93;"]
+  112[/"type: #lt;A#gt;#40;value: A#41; =#gt; Option#lt;A#gt;<br/>node: LocalOption.some"/]
+  113["type: Effect#lt;Option#lt;number#gt;, never, never#gt;<br/>callee: Effect.succeed<br/>args: #91;#93;"]
+  114[/"type: #lt;A#gt;#40;value: A#41; =#gt; Effect#lt;A, never, never#gt;<br/>node: Effect.succeed"/]
   0 -->|"kind: pipe"| 1
   2 -->|"kind: transformCallee"| 1
   3 -->|"kind: pipe"| 4
@@ -121,30 +150,52 @@ flowchart TB
   44 -->|"kind: pipe"| 45
   45 -->|"kind: pipe"| 46
   47 -->|"kind: pipe"| 48
-  49 -->|"kind: transformCallee"| 48
-  50 -->|"kind: pipe"| 51
-  52 -->|"kind: transformCallee"| 51
+  48 -->|"kind: pipe"| 49
+  49 -->|"kind: pipe"| 50
+  51 -->|"kind: pipe"| 52
+  52 -->|"kind: pipe"| 53
   54 -->|"kind: pipe"| 55
   56 -->|"kind: transformCallee"| 55
+  55 -->|"kind: pipe"| 57
   57 -->|"kind: pipe"| 58
-  59 -->|"kind: transformCallee"| 58
+  59 -->|"kind: pipe"| 60
   60 -->|"kind: pipe"| 61
-  62 -->|"kind: transformCallee"| 61
+  62 -->|"kind: pipe"| 63
+  64 -->|"kind: transformCallee"| 63
+  63 -->|"kind: pipe"| 65
   65 -->|"kind: pipe"| 66
-  67 -->|"kind: transformCallee"| 66
-  66 -->|"kind: potentialReturn"| 64
-  64 -->|"kind: usedBy"| 63
-  70 -->|"kind: potentialReturn"| 69
-  69 -->|"kind: usedBy"| 68
+  67 -->|"kind: pipe"| 68
+  69 -->|"kind: transformCallee"| 68
+  68 -->|"kind: pipe"| 70
+  70 -->|"kind: pipe"| 71
   72 -->|"kind: pipe"| 73
-  74 -->|"kind: transformCallee"| 73
-  73 -->|"kind: potentialReturn"| 71
-  71 -->|"kind: usedBy"| 68
-  75 -->|"kind: pipe"| 76
-  77 -->|"kind: transformCallee"| 76
-  78 -->|"kind: pipe"| 79
-  80 -->|"kind: transformCallee"| 79
-  81 -->|"kind: pipe"| 82
-  83 -->|"kind: transformCallee"| 82
-  82 -->|"kind: pipe"| 84
+  73 -->|"kind: pipe"| 74
+  74 -->|"kind: pipe"| 75
+  76 -->|"kind: pipe"| 77
+  78 -->|"kind: transformCallee"| 77
+  79 -->|"kind: pipe"| 80
+  81 -->|"kind: transformCallee"| 80
+  83 -->|"kind: pipe"| 84
   85 -->|"kind: transformCallee"| 84
+  86 -->|"kind: pipe"| 87
+  88 -->|"kind: transformCallee"| 87
+  89 -->|"kind: pipe"| 90
+  91 -->|"kind: transformCallee"| 90
+  94 -->|"kind: pipe"| 95
+  96 -->|"kind: transformCallee"| 95
+  95 -->|"kind: potentialReturn"| 93
+  93 -->|"kind: usedBy"| 92
+  99 -->|"kind: potentialReturn"| 98
+  98 -->|"kind: usedBy"| 97
+  101 -->|"kind: pipe"| 102
+  103 -->|"kind: transformCallee"| 102
+  102 -->|"kind: potentialReturn"| 100
+  100 -->|"kind: usedBy"| 97
+  104 -->|"kind: pipe"| 105
+  106 -->|"kind: transformCallee"| 105
+  107 -->|"kind: pipe"| 108
+  109 -->|"kind: transformCallee"| 108
+  110 -->|"kind: pipe"| 111
+  112 -->|"kind: transformCallee"| 111
+  111 -->|"kind: pipe"| 113
+  114 -->|"kind: transformCallee"| 113

--- a/testdata/baselines/reference/effect-v4/preferSucceedSomeOrNone.pipings.txt
+++ b/testdata/baselines/reference/effect-v4/preferSucceedSomeOrNone.pipings.txt
@@ -1,4 +1,4 @@
-==== /.src/preferSucceedSomeOrNone.ts (22 flows) ====
+==== /.src/preferSucceedSomeOrNone.ts (29 flows) ====
 
 === Piping Flow ===
 Location: 5:33 - 5:63
@@ -201,7 +201,153 @@ Transformations (2):
       outType: Effect<Option<number>, never, never>
 
 === Piping Flow ===
-Location: 35:48 - 35:86
+Location: 35:47 - 35:99
+Node: pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (3):
+  [0] kind: pipe
+      callee: Option.some
+      args: (constant)
+      outType: Option<number>
+  [1] kind: pipe
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<Option<number>, never, never>
+  [2] kind: pipe
+      callee: Effect.asVoid
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 38:51 - 38:102
+Node: pipe(Option.none(), Effect.succeed, Effect.asVoid)
+Node Kind: KindCallExpression
+
+Subject: Option.none()
+Subject Type: Option<never>
+
+Transformations (2):
+  [0] kind: pipe
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<Option<never>, never, never>
+  [1] kind: pipe
+      callee: Effect.asVoid
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 39:49 - 39:100
+Node: Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (3):
+  [0] kind: call
+      callee: Option.some
+      args: (constant)
+      outType: Option<number>
+  [1] kind: pipeable
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<Option<number>, never, never>
+  [2] kind: pipeable
+      callee: Effect.asVoid
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 40:49 - 40:99
+Node: Option.none().pipe(Effect.succeed, Effect.asVoid)
+Node Kind: KindCallExpression
+
+Subject: Option.none()
+Subject Type: Option<never>
+
+Transformations (2):
+  [0] kind: pipeable
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<Option<never>, never, never>
+  [1] kind: pipeable
+      callee: Effect.asVoid
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 43:51 - 43:108
+Node: pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (3):
+  [0] kind: call
+      callee: Option.some
+      args: (constant)
+      outType: Option<number>
+  [1] kind: pipe
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<Option<number>, never, never>
+  [2] kind: pipeable
+      callee: Effect.asVoid
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 44:51 - 44:108
+Node: pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (3):
+  [0] kind: call
+      callee: Option.some
+      args: (constant)
+      outType: Option<number>
+  [1] kind: pipeable
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<Option<number>, never, never>
+  [2] kind: pipe
+      callee: Effect.asVoid
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 45:57 - 45:114
+Node: pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+Node Kind: KindCallExpression
+
+Subject: 1
+Subject Type: 1
+
+Transformations (3):
+  [0] kind: pipe
+      callee: Option.some
+      args: (constant)
+      outType: Option<number>
+  [1] kind: pipeable
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<Option<number>, never, never>
+  [2] kind: pipeable
+      callee: Effect.asVoid
+      args: (constant)
+      outType: Effect<void, never, never>
+
+=== Piping Flow ===
+Location: 48:48 - 48:86
 Node: Effect.succeed(Option.none<number>())
 Node Kind: KindCallExpression
 
@@ -215,7 +361,7 @@ Transformations (1):
       outType: Effect<Option<number>, never, never>
 
 === Piping Flow ===
-Location: 38:49 - 38:102
+Location: 51:49 - 51:102
 Node: Effect.succeed<Option.Option<number>>(Option.none())
 Node Kind: KindCallExpression
 
@@ -229,7 +375,7 @@ Transformations (1):
       outType: Effect<Option<number>, never, never>
 
 === Piping Flow ===
-Location: 42:43 - 42:65
+Location: 55:43 - 55:65
 Node: Effect.succeedSome(1)
 Node Kind: KindCallExpression
 
@@ -243,7 +389,7 @@ Transformations (1):
       outType: Effect<Option<number>, never, never>
 
 === Piping Flow ===
-Location: 45:44 - 45:72
+Location: 58:44 - 58:72
 Node: Effect.succeed(Option.none)
 Node Kind: KindCallExpression
 
@@ -257,7 +403,7 @@ Transformations (1):
       outType: Effect<<A = never>() => Option<A>, never, never>
 
 === Piping Flow ===
-Location: 46:44 - 46:72
+Location: 59:44 - 59:72
 Node: Effect.succeed(Option.some)
 Node Kind: KindCallExpression
 
@@ -271,7 +417,7 @@ Transformations (1):
       outType: Effect<<A>(value: A) => Option<A>, never, never>
 
 === Piping Flow ===
-Location: 49:28 - 49:50
+Location: 62:28 - 62:50
 Node: Effect.succeed(value)
 Node Kind: KindCallExpression
 
@@ -285,7 +431,7 @@ Transformations (1):
       outType: Effect<A, never, never>
 
 === Piping Flow ===
-Location: 53:25 - 53:44
+Location: 66:25 - 66:44
 Node: Option.some(value)
 Node Kind: KindCallExpression
 
@@ -299,7 +445,7 @@ Transformations (1):
       outType: Option<A>
 
 === Piping Flow ===
-Location: 57:43 - 57:78
+Location: 70:43 - 70:78
 Node: LocalEffect.succeed(Option.none())
 Node Kind: KindCallExpression
 
@@ -313,7 +459,7 @@ Transformations (1):
       outType: Effect<Option<never>, never, never>
 
 === Piping Flow ===
-Location: 58:47 - 58:82
+Location: 71:47 - 71:82
 Node: Effect.succeed(LocalOption.none())
 Node Kind: KindCallExpression
 
@@ -327,7 +473,7 @@ Transformations (1):
       outType: Effect<Option<never>, never, never>
 
 === Piping Flow ===
-Location: 59:47 - 59:83
+Location: 72:47 - 72:83
 Node: Effect.succeed(LocalOption.some(1))
 Node Kind: KindCallExpression
 

--- a/testdata/baselines/reference/effect-v4/preferSucceedSomeOrNone.quickfixes.txt
+++ b/testdata/baselines/reference/effect-v4/preferSucceedSomeOrNone.quickfixes.txt
@@ -60,6 +60,56 @@
   Fix 1: "Disable preferSucceedSomeOrNone for entire file"
   Fix 2: "Replace with Effect.succeedSome"
 
+[D13] (35:69-35:83) TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+  Fix 0: "Disable preferSucceedSomeOrNone for this line"
+  Fix 1: "Disable preferSucceedSomeOrNone for entire file"
+  Fix 2: "Replace with Effect.succeedSome"
+
+[D14] (38:72-38:86) TS377117: `Effect.succeedNone` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+  Fix 0: "Disable preferSucceedSomeOrNone for this line"
+  Fix 1: "Disable preferSucceedSomeOrNone for entire file"
+  Fix 2: "Replace with Effect.succeedNone"
+
+[D15] (39:70-39:84) TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+  Fix 0: "Disable preferSucceedSomeOrNone for this line"
+  Fix 1: "Disable preferSucceedSomeOrNone for entire file"
+  Fix 2: "Replace with Effect.succeedSome"
+
+[D16] (40:69-40:83) TS377117: `Effect.succeedNone` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+  Fix 0: "Disable preferSucceedSomeOrNone for this line"
+  Fix 1: "Disable preferSucceedSomeOrNone for entire file"
+  Fix 2: "Replace with Effect.succeedNone"
+
+[D17] (43:52-43:108) TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+  Fix 0: "Disable unnecessaryPipeChain for this line"
+  Fix 1: "Disable unnecessaryPipeChain for entire file"
+  Fix 2: "Rewrite as single pipe call"
+
+[D18] (43:73-43:87) TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+  Fix 0: "Disable preferSucceedSomeOrNone for this line"
+  Fix 1: "Disable preferSucceedSomeOrNone for entire file"
+  Fix 2: "Replace with Effect.succeedSome"
+
+[D19] (44:52-44:108) TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+  Fix 0: "Disable unnecessaryPipeChain for this line"
+  Fix 1: "Disable unnecessaryPipeChain for entire file"
+  Fix 2: "Rewrite as single pipe call"
+
+[D20] (44:77-44:91) TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+  Fix 0: "Disable preferSucceedSomeOrNone for this line"
+  Fix 1: "Disable preferSucceedSomeOrNone for entire file"
+  Fix 2: "Replace with Effect.succeedSome"
+
+[D21] (45:58-45:114) TS377015: This expression contains chained `pipe` calls that can be simplified to a single `pipe` call. effect(unnecessaryPipeChain)
+  Fix 0: "Disable unnecessaryPipeChain for this line"
+  Fix 1: "Disable unnecessaryPipeChain for entire file"
+  Fix 2: "Rewrite as single pipe call"
+
+[D22] (45:84-45:98) TS377117: `Effect.succeedSome` expresses this Option success value directly. effect(preferSucceedSomeOrNone)
+  Fix 0: "Disable preferSucceedSomeOrNone for this line"
+  Fix 1: "Disable preferSucceedSomeOrNone for entire file"
+  Fix 2: "Replace with Effect.succeedSome"
+
 === Quick Fix Application Results ===
 
 === [D1] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
@@ -103,6 +153,19 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
 
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
@@ -174,6 +237,19 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
 
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
 
@@ -243,6 +319,19 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
 
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
@@ -314,6 +403,19 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
 
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
 
@@ -383,6 +485,19 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
 
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
@@ -454,6 +569,19 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
 
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
 
@@ -523,6 +651,19 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
 
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
@@ -594,6 +735,19 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
 
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
 
@@ -663,6 +817,19 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
 
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
@@ -734,6 +901,19 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
 
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
 
@@ -804,6 +984,19 @@ export const shouldTriggerSomeFunctionPipe = Effect.succeedSome(1)
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
 
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
 
@@ -873,6 +1066,849 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = Effect.succeedSome(1)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D13] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
+skipped by default
+
+=== [D13] Fix 1: "Disable preferSucceedSomeOrNone for entire file" ===
+skipped by default
+
+=== [D13] Fix 2: "Replace with Effect.succeedSome" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(Effect.succeedSome(1), Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D14] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
+skipped by default
+
+=== [D14] Fix 1: "Disable preferSucceedSomeOrNone for entire file" ===
+skipped by default
+
+=== [D14] Fix 2: "Replace with Effect.succeedNone" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Effect.succeedNone, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D15] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
+skipped by default
+
+=== [D15] Fix 1: "Disable preferSucceedSomeOrNone for entire file" ===
+skipped by default
+
+=== [D15] Fix 2: "Replace with Effect.succeedSome" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Effect.succeedSome(1).pipe(Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D16] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
+skipped by default
+
+=== [D16] Fix 1: "Disable preferSucceedSomeOrNone for entire file" ===
+skipped by default
+
+=== [D16] Fix 2: "Replace with Effect.succeedNone" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Effect.succeedNone.pipe(Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D17] Fix 0: "Disable unnecessaryPipeChain for this line" ===
+skipped by default
+
+=== [D17] Fix 1: "Disable unnecessaryPipeChain for entire file" ===
+skipped by default
+
+=== [D17] Fix 2: "Rewrite as single pipe call" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed, Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D18] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
+skipped by default
+
+=== [D18] Fix 1: "Disable preferSucceedSomeOrNone for entire file" ===
+skipped by default
+
+=== [D18] Fix 2: "Replace with Effect.succeedSome" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = Effect.succeedSome(1).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D19] Fix 0: "Disable unnecessaryPipeChain for this line" ===
+skipped by default
+
+=== [D19] Fix 1: "Disable unnecessaryPipeChain for entire file" ===
+skipped by default
+
+=== [D19] Fix 2: "Rewrite as single pipe call" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D20] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
+skipped by default
+
+=== [D20] Fix 1: "Disable preferSucceedSomeOrNone for entire file" ===
+skipped by default
+
+=== [D20] Fix 2: "Replace with Effect.succeedSome" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Effect.succeedSome(1), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D21] Fix 0: "Disable unnecessaryPipeChain for this line" ===
+skipped by default
+
+=== [D21] Fix 1: "Disable unnecessaryPipeChain for entire file" ===
+skipped by default
+
+=== [D21] Fix 2: "Rewrite as single pipe call" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
+export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
+
+// Should NOT trigger: an explicit outer type argument can intentionally widen the success type
+export const shouldNotTriggerOuterTypeArgument = Effect.succeed<Option.Option<number>>(Option.none())
+
+// Should NOT trigger: already using the direct constructors
+export const shouldNotTriggerSucceedNone = Effect.succeedNone
+export const shouldNotTriggerSucceedSome = Effect.succeedSome(1)
+
+// Should NOT trigger: the Option functions are values rather than calls
+export const shouldNotTriggerNoneFunction = Effect.succeed(Option.none)
+export const shouldNotTriggerSomeFunction = Effect.succeed(Option.some)
+
+const LocalEffect = {
+  succeed: <A>(value: A) => Effect.succeed(value)
+}
+const LocalOption = {
+  none: () => Option.none(),
+  some: <A>(value: A) => Option.some(value)
+}
+
+// Should NOT trigger: look-alike APIs do not resolve to Effect's exports
+export const shouldNotTriggerLocalEffect = LocalEffect.succeed(Option.none())
+export const shouldNotTriggerLocalOptionNone = Effect.succeed(LocalOption.none())
+export const shouldNotTriggerLocalOptionSome = Effect.succeed(LocalOption.some(1))
+
+
+=== [D22] Fix 0: "Disable preferSucceedSomeOrNone for this line" ===
+skipped by default
+
+=== [D22] Fix 1: "Disable preferSucceedSomeOrNone for entire file" ===
+skipped by default
+
+=== [D22] Fix 2: "Replace with Effect.succeedSome" ===
+
+--- file:///.src/preferSucceedSomeOrNone.ts ---
+import { Effect, Effect as Fx, Option, Option as O, pipe } from "effect"
+import { none as optionNone, some as optionSome } from "effect/Option"
+
+// Should trigger: direct None constructor
+export const shouldTriggerNone = Effect.succeed(Option.none())
+
+// Should trigger: direct Some constructor
+export const shouldTriggerSome = Effect.succeed(Option.some(1))
+
+// Should trigger: aliased modules
+export const shouldTriggerAliases = Fx.succeed(O.some("value"))
+
+// Should trigger: named Option exports
+export const shouldTriggerNamedNone = Effect.succeed(optionNone())
+export const shouldTriggerNamedSome = Effect.succeed(optionSome(1))
+
+// Should trigger: parenthesized Option call
+export const shouldTriggerParenthesized = Effect.succeed((Option.some(1)))
+
+// Should trigger: preserve an explicit Some type argument in the fix
+export const shouldTriggerSomeTypeArgument = Effect.succeed(Option.some<number>(1))
+
+// Should trigger: method-pipe forms
+export const shouldTriggerNonePipe = Option.none().pipe(Effect.succeed)
+export const shouldTriggerSomePipe = Option.some(1).pipe(Effect.succeed)
+
+// Should trigger: Function.pipe forms
+export const shouldTriggerNoneFunctionPipe = pipe(Option.none(), Effect.succeed)
+export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed)
+
+// Should trigger: adjacent transformations in an existing flow
+export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
+
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = Effect.succeedSome(1).pipe(Effect.asVoid)
 
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())

--- a/testdata/tests/effect-v3/preferSucceedSomeOrNone.ts
+++ b/testdata/tests/effect-v3/preferSucceedSomeOrNone.ts
@@ -31,6 +31,17 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
 
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerSomeFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
 

--- a/testdata/tests/effect-v4/preferSucceedSomeOrNone.ts
+++ b/testdata/tests/effect-v4/preferSucceedSomeOrNone.ts
@@ -31,6 +31,19 @@ export const shouldTriggerSomeFunctionPipe = pipe(Option.some(1), Effect.succeed
 // Should trigger: adjacent transformations in an existing flow
 export const shouldTriggerTransformationPair = pipe(1, Option.some, Effect.succeed)
 
+// Should trigger: replacing a Function.pipe prefix retains later transformations
+export const shouldTriggerFunctionPipePrefix = pipe(1, Option.some, Effect.succeed, Effect.asVoid)
+
+// Should trigger: replacing pipe prefixes retains later transformations
+export const shouldTriggerNoneFunctionPipePrefix = pipe(Option.none(), Effect.succeed, Effect.asVoid)
+export const shouldTriggerSomeMethodPipePrefix = Option.some(1).pipe(Effect.succeed, Effect.asVoid)
+export const shouldTriggerNoneMethodPipePrefix = Option.none().pipe(Effect.succeed, Effect.asVoid)
+
+// Should trigger: nested pipe styles can be mixed around the replaced prefix
+export const shouldTriggerFunctionThenMethodPipe = pipe(Option.some(1), Effect.succeed).pipe(Effect.asVoid)
+export const shouldTriggerMethodThenFunctionPipe = pipe(Option.some(1).pipe(Effect.succeed), Effect.asVoid)
+export const shouldTriggerNestedPrefixAcrossPipeStyles = pipe(1, Option.some).pipe(Effect.succeed, Effect.asVoid)
+
 // Should NOT trigger: an explicit None type argument cannot be preserved by Effect.succeedNone
 export const shouldNotTriggerNoneTypeArgument = Effect.succeed(Option.none<number>())
 


### PR DESCRIPTION
## Summary

- expose explicit type arguments directly on piping-flow transformations and remove the representation-dependent transformation `Node` from both internal and public structures
- centralize transformation and prefix replacement in the rewriter while preserving nested calls, data-first/data-last calls, `pipe(...)`, and `.pipe(...)` forms
- migrate affected diagnostics and quick fixes to the shared rewrite operations and remove redundant transformation deduplication
- cover mixed pipe styles and partial-prefix replacement in Effect v3 and v4 baselines

## Examples

A partial Function.pipe prefix keeps its remaining transformations:

```ts
pipe(1, Option.some, Effect.succeed, Effect.asVoid)
// becomes
pipe(Effect.succeedSome(1), Effect.asVoid)
```

A method-pipe prefix does the same:

```ts
Option.none().pipe(Effect.succeed, Effect.asVoid)
// becomes
Effect.succeedNone.pipe(Effect.asVoid)
```

The same replacement interface is now shared by rules including `flatMapConditionalToFilterOrFail`, `mapSomeToAsSome`, `effectMapVoid`, `catchToIgnore`, `catchDieToOrDie`, `catchTagToCatchReason`, and `optionMatchToFromOption`.

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
