### PR TITLE
Reuse piping flow match utilities

### DIFF
--- a/.changeset/clean-piping-flow-matches.md
+++ b/.changeset/clean-piping-flow-matches.md
@@ -1,0 +1,5 @@
+---
+"@effect/tsgo": patch
+---
+
+Reuse the normalized piping-flow shape and sequence matchers across existing diagnostics.

--- a/internal/rules/all_of_map_to_for_each.go
+++ b/internal/rules/all_of_map_to_for_each.go
@@ -82,18 +82,17 @@ func AnalyzeAllOfMapToForEach(tp *typeparser.TypeParser, c *checker.Checker, sf 
 	// Data-last Effect.all references inside piping flows. A bare reference is
 	// invisible to the call walk above because it never appears as a call.
 	for _, flow := range tp.PipingFlows(sf, true) {
-		for i := range flow.Transformations {
-			transformation := &flow.Transformations[i]
-			if len(transformation.Args) != 0 ||
-				(transformation.Kind != typeparser.TransformationKindPipe && transformation.Kind != typeparser.TransformationKindPipeable) ||
-				transformation.Callee == nil ||
-				!tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "all") {
-				continue
-			}
-			if i == 0 {
-				continue
-			}
-			mapNode := transformationApplicationNode(&flow.Transformations[i-1])
+		sequences := flow.FindTransformationSequences(
+			func(*typeparser.PipingFlowTransformation) bool { return true },
+			func(transformation *typeparser.PipingFlowTransformation) bool {
+				return len(transformation.Args) == 0 &&
+					(transformation.Kind == typeparser.TransformationKindPipe || transformation.Kind == typeparser.TransformationKindPipeable) &&
+					transformation.Callee != nil && tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "all")
+			},
+		)
+		for _, sequence := range sequences {
+			transformation := &flow.Transformations[sequence.Start+1]
+			mapNode := transformationApplicationNode(&flow.Transformations[sequence.Start])
 			if match, ok := analyzeAllOfMapToForEachReceiver(tp, c, sf, transformation.Callee, mapNode, nil, false); ok {
 				matches = append(matches, match)
 			}

--- a/internal/rules/effect_map_flatten.go
+++ b/internal/rules/effect_map_flatten.go
@@ -50,19 +50,18 @@ func AnalyzeEffectMapFlatten(tp *typeparser.TypeParser, _ *checker.Checker, sf *
 
 	flows := tp.PipingFlows(sf, false)
 	for _, flow := range flows {
-		for i := range len(flow.Transformations) - 1 {
-			mapTransformation := flow.Transformations[i]
-			flattenTransformation := flow.Transformations[i+1]
-
-			if len(mapTransformation.Args) == 0 || len(flattenTransformation.Args) != 0 {
-				continue
-			}
-
+		sequences := flow.FindTransformationSequences(
+			func(transformation *typeparser.PipingFlowTransformation) bool {
+				return len(transformation.Args) > 0 && tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "map")
+			},
+			func(transformation *typeparser.PipingFlowTransformation) bool {
+				return len(transformation.Args) == 0 && tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "flatten")
+			},
+		)
+		for _, sequence := range sequences {
+			mapTransformation := &flow.Transformations[sequence.Start]
+			flattenTransformation := &flow.Transformations[sequence.Start+1]
 			if (mapTransformation.Kind != typeparser.TransformationKindPipe && mapTransformation.Kind != typeparser.TransformationKindPipeable) || flattenTransformation.Kind != mapTransformation.Kind {
-				continue
-			}
-
-			if !tp.IsNodeReferenceToEffectModuleApi(mapTransformation.Callee, "map") || !tp.IsNodeReferenceToEffectModuleApi(flattenTransformation.Callee, "flatten") {
 				continue
 			}
 

--- a/internal/rules/prefer_succeed_some_or_none.go
+++ b/internal/rules/prefer_succeed_some_or_none.go
@@ -66,64 +66,55 @@ func AnalyzePreferSucceedSomeOrNone(tp *typeparser.TypeParser, _ *checker.Checke
 
 	var matches []PreferSucceedSomeOrNoneMatch
 	for _, flow := range tp.PipingFlows(sf, true) {
-		for index := range flow.Transformations {
-			transformation := &flow.Transformations[index]
-			if transformation.Callee == nil || transformation.Callee.Kind != ast.KindPropertyAccessExpression ||
-				len(transformation.Args) != 0 ||
-				!tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "succeed") {
-				continue
-			}
-			if transformation.TypeArguments != nil && len(transformation.TypeArguments.Nodes) > 0 {
-				continue
-			}
+		isSucceed := func(transformation *typeparser.PipingFlowTransformation) bool {
+			return transformation.Callee != nil && transformation.Callee.Kind == ast.KindPropertyAccessExpression &&
+				len(transformation.Args) == 0 &&
+				(transformation.TypeArguments == nil || len(transformation.TypeArguments.Nodes) == 0) &&
+				tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "succeed")
+		}
+		if flow.MatchesPrefix(
+			func(subject *typeparser.PipingFlowSubject) bool { return isOptionNoneCall(tp, subject.Node) },
+			isSucceed,
+		) {
+			matches = append(matches, preferSucceedSomeOrNoneMatch(sf, flow, 0, &normalizedOptionInput{ReplacementName: "succeedNone"}))
+		}
 
-			optionInput := matchNormalizedOptionInput(tp, flow, index)
-			if optionInput == nil {
-				continue
-			}
-
-			match := PreferSucceedSomeOrNoneMatch{
-				SourceFile:         sf,
-				Location:           scanner.GetErrorRangeForNode(sf, transformation.Callee),
-				EffectModuleNode:   transformation.Callee.AsPropertyAccessExpression().Expression,
-				ReplacementName:    optionInput.ReplacementName,
-				ValueNode:          optionInput.ValueNode,
-				ValueTypeArguments: optionInput.ValueTypeArguments,
-			}
-
-			if transformation.Kind == typeparser.TransformationKindCall ||
-				transformation.Kind == typeparser.TransformationKindPipe ||
-				transformation.Kind == typeparser.TransformationKindPipeable {
-				match.Flow = flow
-				match.TransformationCount = index + 1
-			}
-
-			matches = append(matches, match)
+		sequences := flow.FindTransformationSequences(
+			func(transformation *typeparser.PipingFlowTransformation) bool {
+				return transformation.Callee != nil && len(transformation.Args) == 0 &&
+					tp.IsNodeReferenceToEffectOptionModuleApi(transformation.Callee, "some")
+			},
+			isSucceed,
+		)
+		for _, sequence := range sequences {
+			optionIndex := sequence.Start
+			matches = append(matches, preferSucceedSomeOrNoneMatch(sf, flow, optionIndex+1, &normalizedOptionInput{
+				ReplacementName:    "succeedSome",
+				ValueNode:          flow.TransformationInputNode(optionIndex),
+				ValueTypeArguments: flow.Transformations[optionIndex].TypeArguments,
+			}))
 		}
 	}
 	return matches
 }
 
-func matchNormalizedOptionInput(tp *typeparser.TypeParser, flow *typeparser.PipingFlow, succeedIndex int) *normalizedOptionInput {
-	if succeedIndex == 0 {
-		if !isOptionNoneCall(tp, flow.Subject.Node) {
-			return nil
-		}
-		return &normalizedOptionInput{ReplacementName: "succeedNone"}
+func preferSucceedSomeOrNoneMatch(sf *ast.SourceFile, flow *typeparser.PipingFlow, succeedIndex int, optionInput *normalizedOptionInput) PreferSucceedSomeOrNoneMatch {
+	transformation := &flow.Transformations[succeedIndex]
+	match := PreferSucceedSomeOrNoneMatch{
+		SourceFile:         sf,
+		Location:           scanner.GetErrorRangeForNode(sf, transformation.Callee),
+		EffectModuleNode:   transformation.Callee.AsPropertyAccessExpression().Expression,
+		ReplacementName:    optionInput.ReplacementName,
+		ValueNode:          optionInput.ValueNode,
+		ValueTypeArguments: optionInput.ValueTypeArguments,
 	}
-
-	previous := &flow.Transformations[succeedIndex-1]
-	if previous.Callee == nil || len(previous.Args) != 0 ||
-		!tp.IsNodeReferenceToEffectOptionModuleApi(previous.Callee, "some") {
-		return nil
+	if transformation.Kind == typeparser.TransformationKindCall ||
+		transformation.Kind == typeparser.TransformationKindPipe ||
+		transformation.Kind == typeparser.TransformationKindPipeable {
+		match.Flow = flow
+		match.TransformationCount = succeedIndex + 1
 	}
-
-	input := &normalizedOptionInput{
-		ReplacementName:    "succeedSome",
-		ValueNode:          flow.TransformationInputNode(succeedIndex - 1),
-		ValueTypeArguments: previous.TypeArguments,
-	}
-	return input
+	return match
 }
 
 func isOptionNoneCall(tp *typeparser.TypeParser, node *ast.Node) bool {

--- a/internal/rules/provide_layer_succeed_to_provide_service.go
+++ b/internal/rules/provide_layer_succeed_to_provide_service.go
@@ -86,14 +86,16 @@ func AnalyzeProvideLayerSucceedToProvideService(tp *typeparser.TypeParser, _ *ch
 func inlineSingleServiceLayer(tp *typeparser.TypeParser, node *ast.Node) (*ast.Node, *ast.Node, string, bool) {
 	node = ast.SkipParentheses(node)
 	flow := tp.LongestPipingFlowAt(node, false)
-	if flow == nil || flow.Node != node || len(flow.Transformations) != 1 || flow.Subject.Node == nil {
+	if flow == nil || flow.Node != node || !flow.MatchesExactly(
+		func(subject *typeparser.PipingFlowSubject) bool { return subject.Node != nil },
+		func(transformation *typeparser.PipingFlowTransformation) bool {
+			return transformation.Callee != nil && len(transformation.Args) == 1 &&
+				(transformation.TypeArguments == nil || len(transformation.TypeArguments.Nodes) == 0)
+		},
+	) {
 		return nil, nil, "", false
 	}
 	transformation := &flow.Transformations[0]
-	if transformation.Callee == nil || len(transformation.Args) != 1 ||
-		transformation.TypeArguments != nil && len(transformation.TypeArguments.Nodes) > 0 {
-		return nil, nil, "", false
-	}
 	replacement := ""
 	switch {
 	case tp.IsNodeReferenceToEffectLayerModuleApi(transformation.Callee, "succeed"):

--- a/internal/rules/run_of_exit_to_run_exit.go
+++ b/internal/rules/run_of_exit_to_run_exit.go
@@ -62,18 +62,20 @@ func AnalyzeRunOfExitToRunExit(tp *typeparser.TypeParser, _ *checker.Checker, sf
 
 	var matches []RunOfExitToRunExitMatch
 	for _, flow := range tp.PipingFlows(sf, false) {
-		for index := 0; index+1 < len(flow.Transformations); index++ {
-			exitTransformation := &flow.Transformations[index]
-			if exitTransformation.Callee == nil || len(exitTransformation.Args) != 0 ||
-				!tp.IsNodeReferenceToEffectModuleApi(exitTransformation.Callee, "exit") {
-				continue
-			}
-
-			runnerTransformation := &flow.Transformations[index+1]
+		sequences := flow.FindTransformationSequences(
+			func(transformation *typeparser.PipingFlowTransformation) bool {
+				return transformation.Callee != nil && len(transformation.Args) == 0 &&
+					tp.IsNodeReferenceToEffectModuleApi(transformation.Callee, "exit")
+			},
+			func(transformation *typeparser.PipingFlowTransformation) bool {
+				_, runnerName, _ := runOfExitRunner(tp, transformation.Callee)
+				return runnerName != ""
+			},
+		)
+		for _, sequence := range sequences {
+			exitTransformation := &flow.Transformations[sequence.Start]
+			runnerTransformation := &flow.Transformations[sequence.Start+1]
 			runnerNameNode, runnerName, replacementName := runOfExitRunner(tp, runnerTransformation.Callee)
-			if runnerName == "" {
-				continue
-			}
 
 			matches = appendRunOfExitMatch(matches, RunOfExitToRunExitMatch{
 				SourceFile:         sf,


### PR DESCRIPTION
## Summary

- replace hand-rolled adjacent transformation scans with `FindTransformationSequences`
- use `MatchesPrefix` and `MatchesExactly` for normalized whole-flow shape checks
- preserve source ordering, transformation pointer identity, and relationship-dependent guards

For example, rules recognizing adjacent `Effect.map` / `Effect.flatten` and `Effect.exit` / runner transformations now use the shared piping-flow sequence matcher instead of indexing pairs manually.

## Performance

Five clean runs against the canonical `Effect-TS/effect` repository showed no measurable regression from this refactor: median total time changed by +0.53%, mean total time by -0.14%, median check time by -0.38%, and aggregate allocations by -0.012%. Memory readings overlapped substantially between before and after runs.

## Validation

- `pnpm setup-repo`
- `pnpm lint`
- `pnpm check`
- `pnpm test`