### PR TITLE
Expand Oxlint and Vite+ upstream coverage

### DIFF
--- a/.changeset/expand-oxlint-coverage.md
+++ b/.changeset/expand-oxlint-coverage.md
@@ -1,0 +1,7 @@
+---
+"@effect/tsgo": minor
+---
+
+Retain the latest three stable Oxlint releases and the Oxlint runtimes required by the latest three stable Vite+ releases, including their compiler dependencies. Add versioned compatibility profiles so CI tests every distinct retained runtime pair.
+
+The refreshed upstream metadata supports Oxlint 1.77.0, 1.79.0, 1.80.0, 1.81.0, and 1.82.0, covering Vite+ 0.2.9, 0.3.0, and 0.3.1, and advances TypeScript next to 7.1.0-dev.20260911.1.

--- a/_packages/tsgo/upstream.json
+++ b/_packages/tsgo/upstream.json
@@ -3,7 +3,7 @@
   "tags": {
     "typescript": {
       "latest": "7.0.2",
-      "next": "7.1.0-dev.20260910.1"
+      "next": "7.1.0-dev.20260911.1"
     },
     "oxlint": {
       "latest": "1.82.0"
@@ -18,8 +18,8 @@
         "gitHead": "2bd066d87f5bafd315be9f40889d0a60b9e58e0b",
         "provider": "typescript-go"
       },
-      "7.1.0-dev.20260910.1": {
-        "gitHead": "0b832e12235cc3db14a4be6501827c2f8a8a8569",
+      "7.1.0-dev.20260911.1": {
+        "gitHead": "8ab45047673086f086f91b100ccad84d14ae5571",
         "provider": "typescript"
       }
     },
@@ -32,6 +32,15 @@
       }
     },
     "oxlint": {
+      "1.77.0": {
+        "gitHead": "9a423f2f485b79c2353c49442c0c7f60f900261d"
+      },
+      "1.79.0": {
+        "gitHead": "0db127cc16d28b97d84bac4ebeb302caf1a78c7e"
+      },
+      "1.80.0": {
+        "gitHead": "97e99b85483776a72928d675cc05b1cfc1130ba0"
+      },
       "1.81.0": {
         "gitHead": "0b4e2e67f4193e7ebfcc64982275eb583ae82c83"
       },
@@ -46,6 +55,54 @@
       "description": "Vite+ 0.3.1 compatibility runtime",
       "dependencies": {
         "oxlint": "1.81.0",
+        "oxlint-tsgolint": "7.0.2001"
+      }
+    },
+    {
+      "name": "oxlint@1.82.0",
+      "description": "Oxlint 1.82.0 compatibility runtime",
+      "dependencies": {
+        "oxlint": "1.82.0",
+        "oxlint-tsgolint": "7.0.2001"
+      }
+    },
+    {
+      "name": "oxlint@1.81.0",
+      "description": "Oxlint 1.81.0 compatibility runtime",
+      "dependencies": {
+        "oxlint": "1.81.0",
+        "oxlint-tsgolint": "7.0.2001"
+      }
+    },
+    {
+      "name": "oxlint@1.80.0",
+      "description": "Oxlint 1.80.0 compatibility runtime",
+      "dependencies": {
+        "oxlint": "1.80.0",
+        "oxlint-tsgolint": "7.0.2001"
+      }
+    },
+    {
+      "name": "vite-plus@0.3.1",
+      "description": "Vite+ 0.3.1 compatibility runtime",
+      "dependencies": {
+        "oxlint": "1.81.0",
+        "oxlint-tsgolint": "7.0.2001"
+      }
+    },
+    {
+      "name": "vite-plus@0.3.0",
+      "description": "Vite+ 0.3.0 compatibility runtime",
+      "dependencies": {
+        "oxlint": "1.79.0",
+        "oxlint-tsgolint": "7.0.2001"
+      }
+    },
+    {
+      "name": "vite-plus@0.2.9",
+      "description": "Vite+ 0.2.9 compatibility runtime",
+      "dependencies": {
+        "oxlint": "1.77.0",
         "oxlint-tsgolint": "7.0.2001"
       }
     }

--- a/_tools/repoctl/src/upstream.ts
+++ b/_tools/repoctl/src/upstream.ts
@@ -6,7 +6,7 @@ import * as Schema from "effect/Schema"
 import { appendFile, mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { maxSatisfying } from "semver"
+import { maxSatisfying, rcompare, satisfies } from "semver"
 import { runCommand, runCommandString } from "./process.ts"
 
 export type ComponentName = "typescript" | "oxlint-tsgolint" | "oxlint"
@@ -345,6 +345,33 @@ export const decodeLatestNpmVersion = (output: string, packageSpec: string, vers
     }))
   )
 
+export const decodeRecentNpmVersions = (output: string, packageName: string) =>
+  Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Struct({
+    versions: Schema.Array(NonEmptyString),
+    "dist-tags.latest": NonEmptyString
+  })))(output).pipe(
+    Effect.flatMap((metadata) => {
+      const latest = metadata["dist-tags.latest"]
+      const versions = [...new Set(metadata.versions)]
+        .filter((version) => satisfies(version, `<=${latest}`))
+        .sort(rcompare)
+        .slice(0, 3)
+      return versions[0] === latest
+        ? Effect.succeed(versions)
+        : Effect.fail(new UpstreamManifestError({ reason: `No stable latest version found for ${packageName}` }))
+    }),
+    Effect.mapError((error) => new UpstreamManifestError({
+      reason: `Unable to resolve recent ${packageName} versions: ${error.message}`
+    }))
+  )
+
+const fetchRecentNpmVersions = Effect.fnUntraced(function*(repositoryRoot: string, packageName: string) {
+  const output = yield* runCommandString("npm", repositoryRoot, [
+    "view", packageName, "versions", "dist-tags.latest", "--json"
+  ])
+  return yield* decodeRecentNpmVersions(output, packageName)
+})
+
 const resolveLatestMatchingVersion = Effect.fnUntraced(function*(
   repositoryRoot: string,
   packageName: string,
@@ -364,6 +391,7 @@ interface ResolvedRuntime {
 interface BuildUpstreamOptions {
   readonly next: TypeScriptMetadata
   readonly latest: TypeScriptMetadata
+  readonly retainedRuntimes?: ReadonlyArray<ResolvedRuntime & { readonly name: string; readonly description: string }>
   readonly oxlint: ResolvedRuntime
   readonly vitePlus: ResolvedRuntime & { readonly vitePlusVersion: string }
 }
@@ -371,7 +399,9 @@ interface BuildUpstreamOptions {
 const sortedRecord = <A>(entries: ReadonlyArray<readonly [string, A]>): Record<string, A> =>
   Object.fromEntries([...entries].sort(([left], [right]) => Buffer.compare(Buffer.from(left), Buffer.from(right))))
 
-export const buildUpstream = ({ latest, next, oxlint, vitePlus }: BuildUpstreamOptions): typeof Upstream.Type => {
+export const buildUpstream = ({
+  latest, next, oxlint, vitePlus, retainedRuntimes = []
+}: BuildUpstreamOptions): typeof Upstream.Type => {
   const typescript = new Map<string, { readonly gitHead: string; readonly provider: TypeScriptProvider }>()
   const tsgolint = new Map<string, {
     readonly gitHead: string
@@ -379,10 +409,11 @@ export const buildUpstream = ({ latest, next, oxlint, vitePlus }: BuildUpstreamO
   }>()
   const oxlintComponents = new Map<string, { readonly gitHead: string }>()
 
-  for (const metadata of [latest, next, oxlint.ts, vitePlus.ts]) {
+  const runtimes = [...retainedRuntimes, oxlint, vitePlus]
+  for (const metadata of [latest, next, ...runtimes.map((runtime) => runtime.ts)]) {
     typescript.set(metadata.npmVersion, { gitHead: metadata.gitHead, provider: metadata.provider })
   }
-  for (const runtime of [oxlint, vitePlus]) {
+  for (const runtime of runtimes) {
     tsgolint.set(runtime.tsgolint.npmVersion, {
       gitHead: runtime.tsgolint.gitHead,
       dependencies: { typescript: runtime.ts.npmVersion }
@@ -413,7 +444,15 @@ export const buildUpstream = ({ latest, next, oxlint, vitePlus }: BuildUpstreamO
           oxlint: vitePlus.oxlint.npmVersion,
           "oxlint-tsgolint": vitePlus.tsgolint.npmVersion
         }
-      }
+      },
+      ...retainedRuntimes.map((runtime) => ({
+        name: runtime.name,
+        description: runtime.description,
+        dependencies: {
+          oxlint: runtime.oxlint.npmVersion,
+          "oxlint-tsgolint": runtime.tsgolint.npmVersion
+        }
+      }))
     ]
   }
 }
@@ -687,10 +726,10 @@ const readRemoteTypeScriptGitlink = Effect.fnUntraced(function*(repository: stri
   return preferred
 })
 
-const fetchLatestOxlintSelection = Effect.fnUntraced(function*(repositoryRoot: string) {
+const fetchOxlintSelection = Effect.fnUntraced(function*(repositoryRoot: string, version: string) {
   const oxlintOutput = yield* runCommandString("npm", repositoryRoot, [
     "view",
-    "oxlint@latest",
+    `oxlint@${version}`,
     "version",
     "peerDependencies",
     "--json"
@@ -699,7 +738,7 @@ const fetchLatestOxlintSelection = Effect.fnUntraced(function*(repositoryRoot: s
     version: NonEmptyString,
     peerDependencies: Schema.Struct({ "oxlint-tsgolint": NonEmptyString })
   })))(oxlintOutput).pipe(
-    Effect.mapError((error) => new UpstreamManifestError({ reason: `Unable to resolve oxlint@latest: ${error.message}` }))
+    Effect.mapError((error) => new UpstreamManifestError({ reason: `Unable to resolve oxlint@${version}: ${error.message}` }))
   )
   return {
     oxlintVersion: oxlintPackage.version,
@@ -711,10 +750,10 @@ const fetchLatestOxlintSelection = Effect.fnUntraced(function*(repositoryRoot: s
   }
 })
 
-const fetchVitePlusSelection = Effect.fnUntraced(function*(repositoryRoot: string) {
+const fetchVitePlusSelection = Effect.fnUntraced(function*(repositoryRoot: string, version: string) {
   const output = yield* runCommandString("npm", repositoryRoot, [
     "view",
-    "vite-plus@latest",
+    `vite-plus@${version}`,
     "version",
     "dependencies",
     "--json"
@@ -727,7 +766,7 @@ const fetchVitePlusSelection = Effect.fnUntraced(function*(repositoryRoot: strin
     })
   })))(output).pipe(
     Effect.mapError((error) => new UpstreamManifestError({
-      reason: `Unable to resolve vite-plus@latest: ${error.message}`
+      reason: `Unable to resolve vite-plus@${version}: ${error.message}`
     }))
   )
   const [oxlintVersion, tsgolintVersion] = yield* Effect.all([
@@ -805,11 +844,19 @@ export const updateUpstream = Effect.fnUntraced(function*(repositoryRoot: string
     npmVersion: upstream.tags.typescript.latest,
     ...upstream.components.typescript[upstream.tags.typescript.latest]!
   }
-  const [next, latest, oxlintSelection, vitePlusSelection, remoteSchema, packument] = yield* Effect.all([
+  const [next, latest, oxlintSelections, vitePlusSelections, remoteSchema, packument] = yield* Effect.all([
     fetchTypeScriptMetadata(repositoryRoot, "typescript@next"),
     fetchTypeScriptMetadata(repositoryRoot, "typescript@latest"),
-    fetchLatestOxlintSelection(repositoryRoot),
-    fetchVitePlusSelection(repositoryRoot),
+    fetchRecentNpmVersions(repositoryRoot, "oxlint").pipe(
+      Effect.flatMap((versions) => Effect.forEach(versions, (version) => fetchOxlintSelection(repositoryRoot, version), {
+        concurrency: "unbounded"
+      }))
+    ),
+    fetchRecentNpmVersions(repositoryRoot, "vite-plus").pipe(
+      Effect.flatMap((versions) => Effect.forEach(versions, (version) => fetchVitePlusSelection(repositoryRoot, version), {
+        concurrency: "unbounded"
+      }))
+    ),
     fetchJson("https://json.schemastore.org/tsconfig"),
     fetchJson("https://registry.npmjs.org/typescript")
   ], { concurrency: "unbounded" })
@@ -817,14 +864,22 @@ export const updateUpstream = Effect.fnUntraced(function*(repositoryRoot: string
     typeof packument.versions !== "object" || packument.versions === null) {
     return yield* new UpstreamManifestError({ reason: "TypeScript npm metadata does not contain versions" })
   }
-  const oxlintVersions = Array.from(new Set([
-    oxlintSelection.oxlintVersion,
-    vitePlusSelection.oxlintVersion
-  ])).sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right)))
-  const tsgolintVersions = Array.from(new Set([
-    oxlintSelection.tsgolintVersion,
-    vitePlusSelection.tsgolintVersion
-  ])).sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right)))
+  const selections = [
+    ...oxlintSelections.map((selection) => ({
+      ...selection,
+      name: `oxlint@${selection.oxlintVersion}`,
+      description: `Oxlint ${selection.oxlintVersion} compatibility runtime`
+    })),
+    ...vitePlusSelections.map((selection) => ({
+      ...selection,
+      name: `vite-plus@${selection.vitePlusVersion}`,
+      description: `Vite+ ${selection.vitePlusVersion} compatibility runtime`
+    }))
+  ]
+  const oxlintVersions = Array.from(new Set(selections.map((selection) => selection.oxlintVersion)))
+    .sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right)))
+  const tsgolintVersions = Array.from(new Set(selections.map((selection) => selection.tsgolintVersion)))
+    .sort((left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right)))
   const [resolvedOxlint, resolvedTsgolint] = yield* Effect.all([
     Effect.forEach(oxlintVersions, (version) => resolveOxlintComponent(repositoryRoot, version), {
       concurrency: "unbounded"
@@ -837,10 +892,14 @@ export const updateUpstream = Effect.fnUntraced(function*(repositoryRoot: string
   ], { concurrency: "unbounded" })
   const oxlintByVersion = new Map(resolvedOxlint.map((component) => [component.npmVersion, component]))
   const tsgolintByVersion = new Map(resolvedTsgolint.map((component) => [component.npmVersion, component]))
-  const oxlint = yield* resolveRuntime(oxlintSelection, oxlintByVersion, tsgolintByVersion)
+  const retainedRuntimes = yield* Effect.forEach(selections, (selection) =>
+    resolveRuntime(selection, oxlintByVersion, tsgolintByVersion).pipe(
+      Effect.map((runtime) => ({ ...runtime, name: selection.name, description: selection.description }))
+    ))
+  const oxlint = yield* resolveRuntime(oxlintSelections[0]!, oxlintByVersion, tsgolintByVersion)
   const vitePlus = {
-    ...(yield* resolveRuntime(vitePlusSelection, oxlintByVersion, tsgolintByVersion)),
-    vitePlusVersion: vitePlusSelection.vitePlusVersion
+    ...(yield* resolveRuntime(vitePlusSelections[0]!, oxlintByVersion, tsgolintByVersion)),
+    vitePlusVersion: vitePlusSelections[0]!.vitePlusVersion
   }
   const schema = formatTSConfigSchema(remoteSchema)
   if (schema === undefined) {
@@ -855,7 +914,7 @@ export const updateUpstream = Effect.fnUntraced(function*(repositoryRoot: string
       reason: `The oxlint@${oxlint.oxlint.npmVersion} configuration schema is invalid`
     })
   }
-  const updated = buildUpstream({ next, latest, oxlint, vitePlus })
+  const updated = buildUpstream({ next, latest, oxlint, vitePlus, retainedRuntimes })
   const metadataChanged = JSON.stringify(updated) !== JSON.stringify(upstream)
   const schemaPath = path.join(repositoryRoot, "_tools", "tsconfig-base-schema.json")
   const currentSchema = yield* fs.readFileString(schemaPath).pipe(

--- a/_tools/repoctl/test/upstream.test.ts
+++ b/_tools/repoctl/test/upstream.test.ts
@@ -5,9 +5,11 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import test from "node:test"
+import { buildOxlintTestMatrix } from "../src/matrix.ts"
 import {
   buildUpstream,
   decodeLatestNpmVersion,
+  decodeRecentNpmVersions,
   decodeUpstream,
   findTypeScriptVersion,
   formatGitHubOutputs,
@@ -254,6 +256,17 @@ test("selects the latest npm version matching a dependency spec regardless of re
   )
 })
 
+test("retains the three newest stable npm versions through the latest tag", async() => {
+  const decode = (versions: Array<string>, latest: string) => Effect.runPromise(decodeRecentNpmVersions(
+    JSON.stringify({ versions, "dist-tags.latest": latest }), "oxlint"
+  ))
+  assert.deepEqual(await decode([
+    "1.8.0", "1.10.0", "1.9.0", "1.7.0", "2.0.0-beta.1", "2.0.0", "1.10.0"
+  ], "1.10.0"), ["1.10.0", "1.9.0", "1.8.0"])
+  assert.deepEqual(await decode(["0.2.0", "0.1.0"], "0.2.0"), ["0.2.0", "0.1.0"])
+  await assert.rejects(decode([], "1.0.0"), /No stable latest version found/)
+})
+
 test("builds deterministic normalized metadata and deduplicates components", () => {
   const upstream = buildUpstream({
     next: { npmVersion: "7.1.0", gitHead: secondRevision, provider: "typescript" },
@@ -263,6 +276,13 @@ test("builds deterministic normalized metadata and deduplicates components", () 
       tsgolint: { npmVersion: "7.0.2001", gitHead: secondRevision },
       ts: { npmVersion: "7.0.0", gitHead: revision, provider: "typescript-go" }
     },
+    retainedRuntimes: ["1.72.0", "1.73.0", "1.74.0", "1.75.0", "1.76.0", "1.77.0"].map((npmVersion) => ({
+      name: `oxlint@${npmVersion}`,
+      description: `Oxlint ${npmVersion} compatibility runtime`,
+      oxlint: { npmVersion, gitHead: thirdRevision },
+      tsgolint: { npmVersion: npmVersion < "1.76.0" ? "7.0.2000" : "7.0.2001", gitHead: secondRevision },
+      ts: { npmVersion: npmVersion < "1.76.0" ? "6.0.0" : "7.0.0", gitHead: revision, provider: "typescript-go" }
+    })),
     vitePlus: {
       vitePlusVersion: "0.2.8",
       oxlint: { npmVersion: "1.76.0", gitHead: secondRevision },
@@ -271,15 +291,20 @@ test("builds deterministic normalized metadata and deduplicates components", () 
     }
   })
 
-  assert.deepEqual(Object.keys(upstream.components.typescript), ["7.0.0", "7.1.0"])
-  assert.deepEqual(Object.keys(upstream.components["oxlint-tsgolint"]), ["7.0.2001"])
-  assert.deepEqual(Object.keys(upstream.components.oxlint), ["1.76.0", "1.77.0"])
+  assert.deepEqual(Object.keys(upstream.components.typescript), ["6.0.0", "7.0.0", "7.1.0"])
+  assert.deepEqual(Object.keys(upstream.components["oxlint-tsgolint"]), ["7.0.2000", "7.0.2001"])
+  assert.deepEqual(Object.keys(upstream.components.oxlint), ["1.72.0", "1.73.0", "1.74.0", "1.75.0", "1.76.0", "1.77.0"])
+  assert.deepEqual(upstream.components["oxlint-tsgolint"]["7.0.2000"]!.dependencies, { typescript: "6.0.0" })
   assert.deepEqual(upstream.tags, {
     typescript: { latest: "7.0.0", next: "7.1.0" },
     oxlint: { latest: "1.77.0" },
     "oxlint-tsgolint": { latest: "7.0.2001" }
   })
-  assert.deepEqual(upstream.profiles, [
+  assert.equal(buildOxlintTestMatrix(upstream).include.length, 6)
+  assert.deepEqual(upstream.profiles.slice(1).map((profile) => profile.dependencies.oxlint), [
+    "1.72.0", "1.73.0", "1.74.0", "1.75.0", "1.76.0", "1.77.0"
+  ])
+  assert.deepEqual(upstream.profiles.slice(0, 1), [
     {
       name: "vite-plus",
       description: "Vite+ 0.2.8 compatibility runtime",

--- a/flake.lock
+++ b/flake.lock
@@ -42,17 +42,17 @@
     "typescript-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1788992199,
-        "narHash": "sha256-K+Z7tdDKRGlqFYlLzLd6Ik4MpjCZW8unKC9EyinQ4Ao=",
+        "lastModified": 1789079051,
+        "narHash": "sha256-e7h6SOD5J40YoriDM5DWgB1pYr+jRPMoA9rTeRmC14s=",
         "owner": "microsoft",
         "repo": "TypeScript",
-        "rev": "0b832e12235cc3db14a4be6501827c2f8a8a8569",
+        "rev": "8ab45047673086f086f91b100ccad84d14ae5571",
         "type": "github"
       },
       "original": {
         "owner": "microsoft",
         "repo": "TypeScript",
-        "rev": "0b832e12235cc3db14a4be6501827c2f8a8a8569",
+        "rev": "8ab45047673086f086f91b100ccad84d14ae5571",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nixpkgsUnstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     /* Source of truth: the next profile in `_packages/tsgo/upstream.json`. */
     typescript-src = {
-      url = "github:microsoft/TypeScript/0b832e12235cc3db14a4be6501827c2f8a8a8569";
+      url = "github:microsoft/TypeScript/8ab45047673086f086f91b100ccad84d14ae5571";
       flake = false;
     };
   };


### PR DESCRIPTION
Expand upstream retention from the latest Oxlint runtime and latest Vite+ runtime to the latest three stable releases of each package. Keep their distinct Oxlint, oxlint-tsgolint, and TypeScript components, and add versioned profiles so the Oxlint test matrix covers every compatible runtime pair without duplicate jobs. Existing latest tags and the unversioned Vite+ profile continue to select the latest release.

Running the updater retains Oxlint 1.80.0, 1.81.0, and 1.82.0, plus 1.77.0 and 1.79.0 required by Vite+ 0.2.9 and 0.3.0. Vite+ 0.3.1 shares Oxlint 1.81.0, so the test matrix expands from two jobs to five. Release selection uses descending semver order, excludes prereleases, and stops at each package's latest dist-tag.

Also refresh TypeScript next to 7.1.0-dev.20260911.1, synchronize the compiler submodule and Nix source pins, and add a minor changeset.

Validation: `pnpm setup-repo`, `pnpm lint`, `pnpm check`, `pnpm test` (Go and shim-generator suites plus 125 CLI tests), `pnpm check:repoctl`, and `pnpm test:repoctl` (50 tests) passed. Verified that `repoctl matrix test-oxlint` emits the five retained runtime pairs.

`pnpm exec repoctl flake update` also passed, including the Nix package build; the vendor hash remained unchanged.
